### PR TITLE
chore: put label in front of options in feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE.yml
@@ -16,22 +16,22 @@ body:
       label: Command
       description: Which command will be affected by the feature request? (If you want to propose a new command, just leave all unchecked)
       options:
-        - "archive"
-        - "check-image-updates"
-        - "delete"
-        - "deploy"
-        - "diff"
-        - "downscale"
-        - "helm-pull"
-        - "helm-update"
-        - "list-images"
-        - "list-targets"
-        - "poke-images"
-        - "prune"
-        - "render"
-        - "seal"
-        - "validate"
-        - "version"
+        - label: "archive"
+        - label: "check-image-updates"
+        - label: "delete"
+        - label: "deploy"
+        - label: "diff"
+        - label: "downscale"
+        - label: "helm-pull"
+        - label: "helm-update"
+        - label: "list-images"
+        - label: "list-targets"
+        - label: "poke-images"
+        - label: "prune"
+        - label: "render"
+        - label: "seal"
+        - label: "validate"
+        - label: "version"
   - type: input
     id: persona
     attributes:


### PR DESCRIPTION
Signed-off-by: Aljoscha Pörtner <aljoscha.poertner@posteo.de>

# Description

This PR adds the `label` key in front of each options entry.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example
