### PR TITLE
fix: runtime error on seal command when missing SealedSecret (nil)

### DIFF
--- a/pkg/deployment/commands/seal.go
+++ b/pkg/deployment/commands/seal.go
@@ -20,7 +20,7 @@ func NewSealCommand(c *deployment.DeploymentCollection) *SealCommand {
 }
 
 func (cmd *SealCommand) Run(sealer *seal.Sealer) error {
-	if cmd.c.Project.Config.SealedSecrets.OutputPattern == nil {
+	if cmd.c.Project.Config.SealedSecrets == nil || cmd.c.Project.Config.SealedSecrets.OutputPattern == nil {
 		return fmt.Errorf("sealedSecrets.outputPattern is not defined")
 	}
 


### PR DESCRIPTION
# Description

When creating a secrets project I have forgotten the configuration for `outputPattern and location of stored sealed secrets`.
When I try to seal against the cluster I get a nullpointer exception instead of the error message 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

All Submissions:

* [ ] A corresponding issue exists
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] I have performed a self-review of my code
* [x] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)

![image](https://user-images.githubusercontent.com/3482021/164948192-8c286684-97aa-49a5-befb-3c4b7489e46f.png)

```bash
➜  simple-with-secrets git:(main) kluctl seal -t simple
INFO[0001] Sealing for target simple                    
INFO[0002] Rendering templates and Helm charts          
WARN[0002] Failed to retrieve public certificate from sealed-secrets-controller, re-trying with bootstrap secret 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x183da22]

goroutine 1 [running]:
github.com/kluctl/kluctl/v2/pkg/deployment/commands.(*SealCommand).Run(0xc0004de300, 0x1c2d53c)
	/home/runner/work/kluctl/kluctl/pkg/deployment/commands/seal.go:23 +0x22
github.com/kluctl/kluctl/v2/cmd/kluctl/commands.(*sealCmd).runCmdSealForTarget.func1(0xc0009979c0)
	/home/runner/work/kluctl/kluctl/cmd/kluctl/commands/cmd_seal.go:111 +0x1e5
github.com/kluctl/kluctl/v2/cmd/kluctl/commands.withProjectTargetCommandContext({{{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, ...}, ...}, ...)
	/home/runner/work/kluctl/kluctl/cmd/kluctl/commands/utils.go:129 +0x363
github.com/kluctl/kluctl/v2/cmd/kluctl/commands.(*sealCmd).runCmdSealForTarget(0xc000656da0, 0xc000536f20, {0xc0002ad297, 0x6}, 0xc000861138)
	/home/runner/work/kluctl/kluctl/cmd/kluctl/commands/cmd_seal.go:74 +0x1c5
github.com/kluctl/kluctl/v2/cmd/kluctl/commands.(*sealCmd).Run.func1(0xc000536f20)
	/home/runner/work/kluctl/kluctl/cmd/kluctl/commands/cmd_seal.go:157 +0x3bd
github.com/kluctl/kluctl/v2/cmd/kluctl/commands.withKluctlProjectFromArgs({{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, ...}, ...)
	/home/runner/work/kluctl/kluctl/cmd/kluctl/commands/utils.go:52 +0x377
github.com/kluctl/kluctl/v2/cmd/kluctl/commands.(*sealCmd).Run(0x1)
	/home/runner/work/kluctl/kluctl/cmd/kluctl/commands/cmd_seal.go:121 +0xa5
reflect.Value.call({0x1a2d3e0, 0xc000656da0, 0x18716fb}, {0x1c1fbd6, 0x4}, {0xc00090fc28, 0x0, 0x486a48})
	/opt/hostedtoolcache/go/1.17.9/x64/src/reflect/value.go:556 +0x845
reflect.Value.Call({0x1a2d3e0, 0xc000656da0, 0x1a120e0}, {0xc00090fc28, 0x0, 0x0})
	/opt/hostedtoolcache/go/1.17.9/x64/src/reflect/value.go:339 +0xc5
github.com/alecthomas/kong.callMethod({0x1c1f3df, 0x3}, {0x1ae97e0, 0xc000656da0, 0x3}, {0x1a2d3e0, 0xc000656da0, 0x10}, 0xc0005f5a80)
	/home/runner/go/pkg/mod/github.com/alecthomas/kong@v0.5.0/callbacks.go:97 +0x4e7
github.com/alecthomas/kong.(*Context).RunNode(0xc0005f5a80, 0xc000538e10, {0x0, 0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/alecthomas/kong@v0.5.0/context.go:735 +0x40b
github.com/alecthomas/kong.(*Context).Run(0xc0005f5a80, {0x0, 0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/alecthomas/kong@v0.5.0/context.go:760 +0x115
github.com/kluctl/kluctl/v2/cmd/kluctl/commands.ExecuteWithArgs({0xc000136050, 0x6, 0x2}, {0xc00089ff40, 0x0, 0xc000068750})
	/home/runner/work/kluctl/kluctl/cmd/kluctl/commands/root.go:181 +0x4d
github.com/kluctl/kluctl/v2/cmd/kluctl/commands.Execute()
	/home/runner/work/kluctl/kluctl/cmd/kluctl/commands/root.go:172 +0x105
main.main()
	/home/runner/work/kluctl/kluctl/main.go:27 +0x4a
```

![image](https://user-images.githubusercontent.com/3482021/164948390-e889fb04-3c48-4f6f-8a6e-d8f6490e4f7f.png)

