### PR TITLE
feat: add sorted output for list images

### DIFF
--- a/cmd/kluctl/commands/cmd_list_images.go
+++ b/cmd/kluctl/commands/cmd_list_images.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/types"
+	"sort"
 )
 
 type listImagesCmd struct {
@@ -14,6 +15,7 @@ type listImagesCmd struct {
 	args.OutputFlags
 	args.RenderOutputDirFlags
 
+	Sort   bool `group:"misc" help:"Sort Output of the image list"`
 	Simple bool `group:"misc" help:"Output a simplified version of the images list"`
 }
 
@@ -36,6 +38,12 @@ func (cmd *listImagesCmd) Run() error {
 	return withProjectCommandContext(ptArgs, func(ctx *commandCtx) error {
 		result := types.FixedImagesConfig{
 			Images: ctx.images.SeenImages(cmd.Simple),
+		}
+		if cmd.Sort {
+			sort.Slice(result.Images, func(i, j int) bool {
+				return result.Images[i].Image < result.Images[j].Image
+			})
+
 		}
 		return outputYamlResult(cmd.Output, result, false)
 	})

--- a/cmd/kluctl/commands/cmd_list_images.go
+++ b/cmd/kluctl/commands/cmd_list_images.go
@@ -15,7 +15,6 @@ type listImagesCmd struct {
 	args.OutputFlags
 	args.RenderOutputDirFlags
 
-	Sort   bool `group:"misc" help:"Sort Output of the image list"`
 	Simple bool `group:"misc" help:"Output a simplified version of the images list"`
 }
 
@@ -39,7 +38,7 @@ func (cmd *listImagesCmd) Run() error {
 		result := types.FixedImagesConfig{
 			Images: ctx.images.SeenImages(cmd.Simple),
 		}
-		if cmd.Sort {
+		if result.Images != nil && len(result.Images) > 1 {
 			sort.Slice(result.Images, func(i, j int) bool {
 				return result.Images[i].Image < result.Images[j].Image
 			})

--- a/cmd/kluctl/commands/cmd_list_images.go
+++ b/cmd/kluctl/commands/cmd_list_images.go
@@ -37,12 +37,10 @@ func (cmd *listImagesCmd) Run() error {
 	return withProjectCommandContext(ptArgs, func(ctx *commandCtx) error {
 		result := types.FixedImagesConfig{
 			Images: ctx.images.SeenImages(cmd.Simple),
-		}
-		if result.Images != nil && len(result.Images) > 1 {
-			sort.Slice(result.Images, func(i, j int) bool {
-				return result.Images[i].Image < result.Images[j].Image
-			})
-		}
+		}	
+		sort.Slice(result.Images, func(i, j int) bool {
+		   return result.Images[i].Image < result.Images[j].Image
+		})
 		return outputYamlResult(cmd.Output, result, false)
 	})
 }

--- a/cmd/kluctl/commands/cmd_list_images.go
+++ b/cmd/kluctl/commands/cmd_list_images.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/types"
-	"sort"
 )
 
 type listImagesCmd struct {
@@ -37,10 +36,7 @@ func (cmd *listImagesCmd) Run() error {
 	return withProjectCommandContext(ptArgs, func(ctx *commandCtx) error {
 		result := types.FixedImagesConfig{
 			Images: ctx.images.SeenImages(cmd.Simple),
-		}	
-		sort.Slice(result.Images, func(i, j int) bool {
-		   return result.Images[i].Image < result.Images[j].Image
-		})
+		}
 		return outputYamlResult(cmd.Output, result, false)
 	})
 }

--- a/cmd/kluctl/commands/cmd_list_images.go
+++ b/cmd/kluctl/commands/cmd_list_images.go
@@ -43,7 +43,6 @@ func (cmd *listImagesCmd) Run() error {
 			sort.Slice(result.Images, func(i, j int) bool {
 				return result.Images[i].Image < result.Images[j].Image
 			})
-
 		}
 		return outputYamlResult(cmd.Output, result, false)
 	})

--- a/pkg/deployment/images.go
+++ b/pkg/deployment/images.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/utils/versions"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -52,6 +53,9 @@ func (images *Images) SeenImages(simple bool) []types.FixedImage {
 			ret = append(ret, fi)
 		}
 	}
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Image < ret[j].Image
+	})
 	return ret
 }
 


### PR DESCRIPTION
# Description

In large deployment projects we use the `list-images` together with the `fixed-image` feature for our production environment to bring all images from UAT to a fixed version on the PROD environment. We then place the fixed-image.yml file in a git repository. Currently the result of `list-images` is unsorted, which makes it difficult to review during an update. Therefore kluctl should have the option to sort the output.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

All Submissions:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] New and existing unit tests pass locally with my changes
* [x] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)

![image](https://user-images.githubusercontent.com/3482021/167027442-ac22608e-1e05-4fdd-a760-b20ccad94e7a.png)
```bash
kluctl list-images --simple --sort -t simple
```
![image](https://user-images.githubusercontent.com/3482021/167027553-44dcebde-0423-4a78-89b8-0901f8143339.png)

