### PR TITLE
fix: Skip postprocessCRDs in case --offline-kubernetes was used

### DIFF
--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -439,6 +439,9 @@ func (di *DeploymentItem) postprocessCRDs() error {
 	if di.dir == nil {
 		return nil
 	}
+	if di.ctx.K == nil {
+		return nil
+	}
 
 	for _, o := range di.Objects {
 		gvk := o.GetK8sGVK()


### PR DESCRIPTION
Fixes #58
