### PR TITLE
fix: Treat strings as raw strings (no escape sequences handles) in version patterns

### DIFF
--- a/pkg/utils/python_scanner/README.md
+++ b/pkg/utils/python_scanner/README.md
@@ -1,2 +1,2 @@
-This package is a copy of golangs text/scanner package, with the difference that it interprets ' the same way as ", so
+This package is a copy of golangs text/scanner package, with the difference that it interprets ' and ` the same way as ", so
 that it's a little bit more like python.

--- a/pkg/utils/python_scanner/scanner.go
+++ b/pkg/utils/python_scanner/scanner.go
@@ -593,9 +593,9 @@ func (s *Scanner) scanString(quote rune) (n int) {
 	return
 }
 
-func (s *Scanner) scanRawString() {
+func (s *Scanner) scanRawString(quote rune) {
 	ch := s.next() // read character after '`'
-	for ch != '`' {
+	for ch != quote {
 		if ch < 0 {
 			s.error("literal not terminated")
 			return
@@ -697,14 +697,14 @@ redo:
 			break
 		case '"':
 			if s.Mode&ScanStrings != 0 {
-				s.scanString('"')
+				s.scanRawString('"')
 				tok = String
 			}
 			ch = s.next()
 		case '\'':
 			// This is the difference to golang's text/scanner package, we handle ' as a string and not as a char
 			if s.Mode&ScanStrings != 0 {
-				s.scanString('\'')
+				s.scanRawString('\'')
 				tok = String
 			}
 			ch = s.next()
@@ -726,7 +726,7 @@ redo:
 			}
 		case '`':
 			if s.Mode&ScanRawStrings != 0 {
-				s.scanRawString()
+				s.scanRawString('`')
 				tok = RawString
 			}
 			ch = s.next()


### PR DESCRIPTION
This avoids unnecessary warnings being printed in case of invalid escape sequences in regex strings. The parser should actually NOT try to parse these escape sequences as it would lead to invalid regex strings in case a valid escape sequence (e.g. \n) is provided.

Fixes #60 
