### PR TITLE
feat: Remove --output-metadata flag

### DIFF
--- a/cmd/kluctl/args/project.go
+++ b/cmd/kluctl/args/project.go
@@ -3,8 +3,7 @@ package args
 import "time"
 
 type ProjectFlags struct {
-	ProjectConfig  existingFileType `group:"project" short:"c" help:"Location of the .kluctl.yaml config file. Defaults to $PROJECT/.kluctl.yaml" exts:"yml,yaml"`
-	OutputMetadata string           `group:"project" help:"Specify the output path for the project metadata to be written to."`
+	ProjectConfig existingFileType `group:"project" short:"c" help:"Location of the .kluctl.yaml config file. Defaults to $PROJECT/.kluctl.yaml" exts:"yml,yaml"`
 
 	Timeout                time.Duration `group:"project" help:"Specify timeout for all operations, including loading of the project, all external api calls and waiting for readiness." default:"10m"`
 	GitCacheUpdateInterval time.Duration `group:"project" help:"Specify the time to wait between git cache updates. Defaults to not wait at all and always updating caches."`

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -15,7 +15,6 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
-	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -66,17 +65,6 @@ func withKluctlProjectFromArgs(projectFlags args.ProjectFlags, strictTemplates b
 		return err
 	}
 
-	if projectFlags.OutputMetadata != "" {
-		md := p.GetMetadata()
-		b, err := yaml.WriteYamlBytes(md)
-		if err != nil {
-			return err
-		}
-		err = os.WriteFile(projectFlags.OutputMetadata, b, 0o640)
-		if err != nil {
-			return err
-		}
-	}
 	return cb(ctx, p)
 }
 

--- a/pkg/kluctl_project/project.go
+++ b/pkg/kluctl_project/project.go
@@ -28,13 +28,6 @@ type LoadedKluctlProject struct {
 	RP *repocache.GitRepoCache
 }
 
-func (c *LoadedKluctlProject) GetMetadata() *types2.ProjectMetadata {
-	md := &types2.ProjectMetadata{
-		Targets: c.DynamicTargets,
-	}
-	return md
-}
-
 func (c *LoadedKluctlProject) FindBaseTarget(name string) (*types2.Target, error) {
 	for _, target := range c.Config.Targets {
 		if target.Name == name {

--- a/pkg/types/metadata.go
+++ b/pkg/types/metadata.go
@@ -1,5 +1,0 @@
-package types
-
-type ProjectMetadata struct {
-	Targets []*DynamicTarget `yaml:"targets"`
-}


### PR DESCRIPTION
This is unused and was originally used by the removed "archive" command.
