### PR TITLE
Remove deprecated "sources" from "secretsSets" and "path" from "vars"

### DIFF
--- a/pkg/kluctl_project/target_context.go
+++ b/pkg/kluctl_project/target_context.go
@@ -186,12 +186,7 @@ func (p *LoadedKluctlProject) loadSecrets(target *types.Target, varsCtx *vars.Va
 		if err != nil {
 			return err
 		}
-		if len(secretEntry.Sources) != 0 {
-			status.Deprecation(p.ctx, "secrets-sets-sources", "'sources' in secretSets is deprecated, use 'vars' instead")
-			err = varsLoader.LoadVarsList(varsCtx, secretEntry.Sources, searchDirs, "secrets")
-		} else {
-			err = varsLoader.LoadVarsList(varsCtx, secretEntry.Vars, searchDirs, "secrets")
-		}
+		err = varsLoader.LoadVarsList(varsCtx, secretEntry.Vars, searchDirs, "secrets")
 		if err != nil {
 			return err
 		}

--- a/pkg/types/kluctl_project.go
+++ b/pkg/types/kluctl_project.go
@@ -1,9 +1,7 @@
 package types
 
 import (
-	"github.com/go-playground/validator/v10"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
-	"github.com/kluctl/kluctl/v2/pkg/yaml"
 )
 
 type DynamicArg struct {
@@ -44,18 +42,8 @@ type DynamicTarget struct {
 }
 
 type SecretSet struct {
-	Name string `yaml:"name" validate:"required"`
-	// TODO deprecated, use vars instead
-	Sources []*VarsSource `yaml:"sources,omitempty"`
-	Vars    []*VarsSource `yaml:"vars,omitempty"`
-}
-
-func ValidateSecretSet(sl validator.StructLevel) {
-	s := sl.Current().Interface().(SecretSet)
-
-	if len(s.Sources) != 0 && len(s.Vars) != 0 {
-		sl.ReportError(s, "vars", "vars", "sources and vars can't be set at the same time", "")
-	}
+	Name string        `yaml:"name" validate:"required"`
+	Vars []*VarsSource `yaml:"vars,omitempty"`
 }
 
 type GlobalSealedSecretsConfig struct {
@@ -72,8 +60,4 @@ type SecretsConfig struct {
 type KluctlProject struct {
 	Targets       []*Target      `yaml:"targets,omitempty"`
 	SecretsConfig *SecretsConfig `yaml:"secretsConfig,omitempty"`
-}
-
-func init() {
-	yaml.Validator.RegisterStructValidation(ValidateSecretSet, SecretSet{})
 }

--- a/pkg/types/vars_source.go
+++ b/pkg/types/vars_source.go
@@ -56,7 +56,6 @@ type VarsSourceVault struct {
 type VarsSource struct {
 	Values            *uo.UnstructuredObject              `yaml:"values,omitempty"`
 	File              *string                             `yaml:"file,omitempty"`
-	Path              *string                             `yaml:"path,omitempty"`
 	Git               *VarsSourceGit                      `yaml:"git,omitempty"`
 	ClusterConfigMap  *VarsSourceClusterConfigMapOrSecret `yaml:"clusterConfigMap,omitempty"`
 	ClusterSecret     *VarsSourceClusterConfigMapOrSecret `yaml:"clusterSecret,omitempty"`

--- a/pkg/vars/vars_loader.go
+++ b/pkg/vars/vars_loader.go
@@ -8,7 +8,6 @@ import (
 	"github.com/kluctl/go-jinja2"
 	"github.com/kluctl/kluctl/v2/pkg/git/repocache"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
-	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
@@ -74,9 +73,6 @@ func (v *VarsLoader) LoadVars(varsCtx *VarsCtx, sourceIn *types.VarsSource, sear
 	if source.Values != nil {
 		v.mergeVars(varsCtx, source.Values, rootKey)
 		return nil
-	} else if source.Path != nil {
-		status.Deprecation(v.ctx, "vars-path", "'path' is deprecated as vars source, use 'file' instead")
-		return v.loadFile(varsCtx, *source.Path, searchDirs, rootKey)
 	} else if source.File != nil {
 		return v.loadFile(varsCtx, *source.File, searchDirs, rootKey)
 	} else if source.Git != nil {


### PR DESCRIPTION
# Description

This removes deprecated "sources" from "secretsSets" and "path" from "vars".

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
