### PR TITLE
fix: Make check for overwritten fields managers more strict

### DIFF
--- a/pkg/diff/managed_fields.go
+++ b/pkg/diff/managed_fields.go
@@ -18,11 +18,11 @@ type LostOwnership struct {
 
 var forceApplyFieldAnnotationRegex = regexp.MustCompile(`^kluctl.io/force-apply-field(-\d*)?$`)
 var overwriteAllowedManagers = []*regexp.Regexp{
-	regexp.MustCompile("kluctl"),
-	regexp.MustCompile("kubectl"),
-	regexp.MustCompile("kubectl-.*"),
-	regexp.MustCompile("rancher"),
-	regexp.MustCompile("k9s"),
+	regexp.MustCompile("^kluctl$"),
+	regexp.MustCompile("^kubectl$"),
+	regexp.MustCompile("^kubectl-.*$"),
+	regexp.MustCompile("^rancher$"),
+	regexp.MustCompile("^k9s$"),
 }
 
 func checkListItemMatch(o interface{}, pathElement fieldpath.PathElement, index int) (bool, error) {


### PR DESCRIPTION
# Description

Otherwise field managers that for example contain "kluctl" somewhere in-between are overwritten as well. Noticed this while working on the flux-kluctl-controller.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
