### PR TITLE
feat: Implement --kubernetes-version to be used with --offline-kubernetes

### DIFF
--- a/cmd/kluctl/args/misc.go
+++ b/cmd/kluctl/args/misc.go
@@ -8,6 +8,10 @@ type YesFlags struct {
 	Yes bool `group:"misc" short:"y" help:"Suppresses 'Are you sure?' questions and proceeds as if you would answer 'yes'."`
 }
 
+type OfflineKubernetesFlags struct {
+	OfflineKubernetes bool `group:"misc" help:"Run command in offline mode, meaning that it will not try to connect the target cluster"`
+}
+
 type DryRunFlags struct {
 	DryRun bool `group:"misc" help:"Performs all kubernetes API calls in dry-run mode."`
 }

--- a/cmd/kluctl/args/misc.go
+++ b/cmd/kluctl/args/misc.go
@@ -9,7 +9,8 @@ type YesFlags struct {
 }
 
 type OfflineKubernetesFlags struct {
-	OfflineKubernetes bool `group:"misc" help:"Run command in offline mode, meaning that it will not try to connect the target cluster"`
+	OfflineKubernetes bool   `group:"misc" help:"Run command in offline mode, meaning that it will not try to connect the target cluster"`
+	KubernetesVersion string `group:"misc" help:"Specify the Kubernetes version that will be assumed. This will also override the kubeVersion used when rendering Helm Charts."`
 }
 
 type DryRunFlags struct {

--- a/cmd/kluctl/commands/cmd_list_images.go
+++ b/cmd/kluctl/commands/cmd_list_images.go
@@ -36,6 +36,7 @@ func (cmd *listImagesCmd) Run() error {
 		helmCredentials:      cmd.HelmCredentials,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 		offlineKubernetes:    cmd.OfflineKubernetes,
+		kubernetesVersion:    cmd.KubernetesVersion,
 	}
 	return withProjectCommandContext(ptArgs, func(ctx *commandCtx) error {
 		result := types.FixedImagesConfig{

--- a/cmd/kluctl/commands/cmd_list_images.go
+++ b/cmd/kluctl/commands/cmd_list_images.go
@@ -14,9 +14,9 @@ type listImagesCmd struct {
 	args.HelmCredentials
 	args.OutputFlags
 	args.RenderOutputDirFlags
+	args.OfflineKubernetesFlags
 
-	OfflineKubernetes bool `group:"misc" help:"Run list-images in offline mode, meaning that it will not try to connect the target cluster"`
-	Simple            bool `group:"misc" help:"Output a simplified version of the images list"`
+	Simple bool `group:"misc" help:"Output a simplified version of the images list"`
 }
 
 func (cmd *listImagesCmd) Help() string {

--- a/cmd/kluctl/commands/cmd_render.go
+++ b/cmd/kluctl/commands/cmd_render.go
@@ -16,9 +16,9 @@ type renderCmd struct {
 	args.ImageFlags
 	args.HelmCredentials
 	args.RenderOutputDirFlags
+	args.OfflineKubernetesFlags
 
-	OfflineKubernetes bool `group:"misc" help:"Run render in offline mode, meaning that it will not try to connect the target cluster"`
-	PrintAll          bool `group:"misc" help:"Write all rendered manifests to stdout"`
+	PrintAll bool `group:"misc" help:"Write all rendered manifests to stdout"`
 }
 
 func (cmd *renderCmd) Help() string {

--- a/cmd/kluctl/commands/cmd_render.go
+++ b/cmd/kluctl/commands/cmd_render.go
@@ -45,6 +45,7 @@ func (cmd *renderCmd) Run() error {
 		helmCredentials:      cmd.HelmCredentials,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 		offlineKubernetes:    cmd.OfflineKubernetes,
+		kubernetesVersion:    cmd.KubernetesVersion,
 	}
 	return withProjectCommandContext(ptArgs, func(ctx *commandCtx) error {
 		if cmd.PrintAll {

--- a/cmd/kluctl/commands/cmd_seal.go
+++ b/cmd/kluctl/commands/cmd_seal.go
@@ -18,10 +18,10 @@ type sealCmd struct {
 	args.ProjectFlags
 	args.TargetFlags
 	args.HelmCredentials
+	args.OfflineKubernetesFlags
 
-	ForceReseal       bool   `group:"misc" help:"Lets kluctl ignore secret hashes found in already sealed secrets and thus forces resealing of those."`
-	CertFile          string `group:"misc" help:"Use the given certificate for sealing instead of requesting it from the sealed-secrets controller"`
-	OfflineKubernetes bool   `group:"misc" help:"Run seal in offline mode, meaning that it will not try to connect the target cluster"`
+	ForceReseal bool   `group:"misc" help:"Lets kluctl ignore secret hashes found in already sealed secrets and thus forces resealing of those."`
+	CertFile    string `group:"misc" help:"Use the given certificate for sealing instead of requesting it from the sealed-secrets controller"`
 }
 
 func (cmd *sealCmd) Help() string {

--- a/cmd/kluctl/commands/cmd_seal.go
+++ b/cmd/kluctl/commands/cmd_seal.go
@@ -48,6 +48,7 @@ func (cmd *sealCmd) runCmdSealForTarget(ctx context.Context, p *kluctl_project.L
 		helmCredentials:   cmd.HelmCredentials,
 		forSeal:           true,
 		offlineKubernetes: cmd.OfflineKubernetes,
+		kubernetesVersion: cmd.KubernetesVersion,
 	}
 	ptArgs.targetFlags.Target = targetName
 

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -101,6 +101,7 @@ type projectTargetCommandArgs struct {
 	forSeal           bool
 	forCompletion     bool
 	offlineKubernetes bool
+	kubernetesVersion string
 }
 
 type commandCtx struct {
@@ -167,6 +168,7 @@ func withProjectTargetCommandContext(ctx context.Context, args projectTargetComm
 		TargetNameOverride: args.targetFlags.TargetNameOverride,
 		ContextOverride:    args.targetFlags.Context,
 		OfflineK8s:         args.offlineKubernetes,
+		K8sVersion:         args.kubernetesVersion,
 		DryRun:             args.dryRunArgs == nil || args.dryRunArgs.DryRun || args.forCompletion,
 		ExternalArgs:       optionArgs2,
 		ForSeal:            args.forSeal,

--- a/docs/reference/commands/list-images.md
+++ b/docs/reference/commands/list-images.md
@@ -48,8 +48,10 @@ Misc arguments:
                                                     Must be in the form
                                                     --helm-username=<credentialsId>:<username>, where
                                                     <credentialsId> must match the id specified in the helm-chart.yaml.
-      --offline-kubernetes                          Run list-images in offline mode, meaning that it will not try
-                                                    to connect the target cluster
+      --kubernetes-version string                   Specify the Kubernetes version that will be assumed. This will
+                                                    also override the kubeVersion used when rendering Helm Charts.
+      --offline-kubernetes                          Run command in offline mode, meaning that it will not try to
+                                                    connect the target cluster
   -o, --output stringArray                          Specify output target file. Can be specified multiple times
       --render-output-dir string                    Specifies the target directory to render the project into. If
                                                     omitted, a temporary directory is used.

--- a/docs/reference/commands/render.md
+++ b/docs/reference/commands/render.md
@@ -45,7 +45,9 @@ Misc arguments:
                                                     Must be in the form
                                                     --helm-username=<credentialsId>:<username>, where
                                                     <credentialsId> must match the id specified in the helm-chart.yaml.
-      --offline-kubernetes                          Run render in offline mode, meaning that it will not try to
+      --kubernetes-version string                   Specify the Kubernetes version that will be assumed. This will
+                                                    also override the kubeVersion used when rendering Helm Charts.
+      --offline-kubernetes                          Run command in offline mode, meaning that it will not try to
                                                     connect the target cluster
       --print-all                                   Write all rendered manifests to stdout
       --render-output-dir string                    Specifies the target directory to render the project into. If

--- a/e2e/sops_test.go
+++ b/e2e/sops_test.go
@@ -109,8 +109,9 @@ func TestSopsHelmValues(t *testing.T) {
 	cm1 := assertConfigMapExists(t, k, p.TestSlug(), "test-helm1-test-chart1")
 
 	assert.Equal(t, map[string]any{
-		"a":       "secret1",
-		"b":       "secret2",
-		"version": "0.1.0",
+		"a":           "secret1",
+		"b":           "secret2",
+		"version":     "0.1.0",
+		"kubeVersion": k.ServerVersion.String(),
 	}, cm1.Object["data"])
 }

--- a/e2e/test-utils/envtest_cluster.go
+++ b/e2e/test-utils/envtest_cluster.go
@@ -7,6 +7,8 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
@@ -28,6 +30,7 @@ type EnvTestCluster struct {
 
 	HttpClient    *http.Client
 	DynamicClient dynamic.Interface
+	ServerVersion *version.Info
 
 	callbackServer     webhook.Server
 	callbackServerStop context.CancelFunc
@@ -84,6 +87,15 @@ func (k *EnvTestCluster) Start() error {
 		return err
 	}
 	k.DynamicClient = dynamicClient
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfigAndClient(k.config, client)
+	if err != nil {
+		return err
+	}
+	k.ServerVersion, err = discoveryClient.ServerVersion()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/e2e/test-utils/test-helm-chart/templates/configmap.yaml
+++ b/e2e/test-utils/test-helm-chart/templates/configmap.yaml
@@ -8,3 +8,4 @@ data:
   a: {{ .Values.data.a }}
   b: {{ .Values.data.b }}
   version: {{ .Chart.Version }}
+  kubeVersion: {{ .Capabilities.KubeVersion }}

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -214,7 +214,7 @@ func (di *DeploymentItem) renderHelmCharts() error {
 			}
 		}
 
-		return chart.Render(di.ctx.Ctx, di.ctx.K, di.ctx.SopsDecrypter)
+		return chart.Render(di.ctx.Ctx, di.ctx.K, di.ctx.K8sVersion, di.ctx.SopsDecrypter)
 	})
 	if err != nil {
 		return err

--- a/pkg/deployment/helm_chart.go
+++ b/pkg/deployment/helm_chart.go
@@ -386,15 +386,15 @@ func (c *HelmChart) findLatestVersion(inputVersions []string) (string, error) {
 	return latestVersion, nil
 }
 
-func (c *HelmChart) Render(ctx context.Context, k *k8s.K8sCluster, sopsDecrypter sops.SopsDecrypter) error {
-	err := c.doRender(ctx, k, sopsDecrypter)
+func (c *HelmChart) Render(ctx context.Context, k *k8s.K8sCluster, k8sVersion string, sopsDecrypter sops.SopsDecrypter) error {
+	err := c.doRender(ctx, k, k8sVersion, sopsDecrypter)
 	if err != nil {
 		return fmt.Errorf("rendering helm chart %s for release %s has failed: %w", c.chartName, c.Config.ReleaseName, err)
 	}
 	return nil
 }
 
-func (c *HelmChart) doRender(ctx context.Context, k *k8s.K8sCluster, sopsDecrypter sops.SopsDecrypter) error {
+func (c *HelmChart) doRender(ctx context.Context, k *k8s.K8sCluster, k8sVersion string, sopsDecrypter sops.SopsDecrypter) error {
 	chartDir := c.chartDir
 
 	needsPull, versionChanged, prePulledVersion, err := c.checkNeedsPull(chartDir, false)
@@ -453,6 +453,12 @@ func (c *HelmChart) doRender(ctx context.Context, k *k8s.K8sCluster, sopsDecrypt
 	var kubeVersion *chartutil.KubeVersion
 	if k != nil {
 		kubeVersion, err = chartutil.ParseKubeVersion(k.ServerVersion.String())
+		if err != nil {
+			return err
+		}
+	}
+	if k8sVersion != "" {
+		kubeVersion, err = chartutil.ParseKubeVersion(k8sVersion)
 		if err != nil {
 			return err
 		}

--- a/pkg/deployment/shared_context.go
+++ b/pkg/deployment/shared_context.go
@@ -11,6 +11,7 @@ import (
 type SharedContext struct {
 	Ctx             context.Context
 	K               *k8s.K8sCluster
+	K8sVersion      string
 	RP              *repocache.GitRepoCache
 	SopsDecrypter   sops.SopsDecrypter
 	VarsLoader      *vars.VarsLoader

--- a/pkg/kluctl_project/target_context.go
+++ b/pkg/kluctl_project/target_context.go
@@ -31,6 +31,7 @@ type TargetContextParams struct {
 	TargetNameOverride string
 	ContextOverride    string
 	OfflineK8s         bool
+	K8sVersion         string
 	DryRun             bool
 	ExternalArgs       *uo.UnstructuredObject
 	ForSeal            bool
@@ -103,6 +104,7 @@ func (p *LoadedKluctlProject) NewTargetContext(ctx context.Context, params Targe
 	dctx := deployment.SharedContext{
 		Ctx:                               ctx,
 		K:                                 k,
+		K8sVersion:                        params.K8sVersion,
 		RP:                                p.RP,
 		SopsDecrypter:                     p.SopsDecrypter,
 		VarsLoader:                        varsLoader,


### PR DESCRIPTION
# Description

This allows to specify the Kubernetes version that must be assumed while rendering in offline mode. 

Fixes: #128 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
