### PR TITLE
tests: Refactor e2e test execution to not rely on processes and try to fix flakiness

### DIFF
--- a/cmd/kluctl/args/project.go
+++ b/cmd/kluctl/args/project.go
@@ -1,8 +1,28 @@
 package args
 
-import "time"
+import (
+	"os"
+	"time"
+)
+
+type ProjectDir struct {
+	ProjectDir existingDirType `group:"project" help:"Specify the project directory. Defaults to the current working directory."`
+}
+
+func (a ProjectDir) GetProjectDir() (string, error) {
+	if a.ProjectDir != "" {
+		return a.ProjectDir.String(), nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return cwd, nil
+}
 
 type ProjectFlags struct {
+	ProjectDir
+
 	ProjectConfig existingFileType `group:"project" short:"c" help:"Location of the .kluctl.yaml config file. Defaults to $PROJECT/.kluctl.yaml" exts:"yml,yaml"`
 
 	Timeout                time.Duration `group:"project" help:"Specify timeout for all operations, including loading of the project, all external api calls and waiting for readiness." default:"10m"`

--- a/cmd/kluctl/commands/cmd_check_image_updates.go
+++ b/cmd/kluctl/commands/cmd_check_image_updates.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/versions"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -130,6 +129,6 @@ func runCheckImageUpdates(cmdCtx *commandCtx) error {
 	}
 
 	table.SortRows(1)
-	_, _ = os.Stdout.WriteString(table.Render([]int{60}))
+	_, _ = getStdout(cmdCtx.ctx).WriteString(table.Render([]int{60}))
 	return nil
 }

--- a/cmd/kluctl/commands/cmd_check_image_updates.go
+++ b/cmd/kluctl/commands/cmd_check_image_updates.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/registries"
 	"github.com/kluctl/kluctl/v2/pkg/status"
@@ -22,20 +23,20 @@ func (cmd *checkImageUpdatesCmd) Help() string {
 	return `This is based on a best effort approach and might give many false-positives.`
 }
 
-func (cmd *checkImageUpdatesCmd) Run() error {
+func (cmd *checkImageUpdatesCmd) Run(ctx context.Context) error {
 	ptArgs := projectTargetCommandArgs{
 		projectFlags: cmd.ProjectFlags,
 		targetFlags:  cmd.TargetFlags,
 	}
-	return withProjectCommandContext(ptArgs, func(ctx *commandCtx) error {
-		return runCheckImageUpdates(ctx)
+	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
+		return runCheckImageUpdates(cmdCtx)
 	})
 }
 
-func runCheckImageUpdates(ctx *commandCtx) error {
-	renderedImages := ctx.targetCtx.DeploymentCollection.FindRenderedImages()
+func runCheckImageUpdates(cmdCtx *commandCtx) error {
+	renderedImages := cmdCtx.targetCtx.DeploymentCollection.FindRenderedImages()
 
-	rh := registries.NewRegistryHelper(ctx.ctx)
+	rh := registries.NewRegistryHelper(cmdCtx.ctx)
 
 	imageTags := make(map[string]interface{})
 	var mutex sync.Mutex
@@ -76,7 +77,7 @@ func runCheckImageUpdates(ctx *commandCtx) error {
 		for _, image := range images {
 			s := strings.SplitN(image, ":", 2)
 			if len(s) == 1 {
-				status.Warning(ctx.ctx, "%s: Ignoring image %s as it doesn't specify a tag", ref.String(), image)
+				status.Warning(cmdCtx.ctx, "%s: Ignoring image %s as it doesn't specify a tag", ref.String(), image)
 				continue
 			}
 			repo := s[0]
@@ -84,7 +85,7 @@ func runCheckImageUpdates(ctx *commandCtx) error {
 			repoTags, _ := imageTags[repo].([]string)
 			err, _ := imageTags[repo].(error)
 			if err != nil {
-				status.Warning(ctx.ctx, "%s: Failed to list tags for %s. %v", ref.String(), repo, err)
+				status.Warning(cmdCtx.ctx, "%s: Failed to list tags for %s. %v", ref.String(), repo, err)
 				continue
 			}
 

--- a/cmd/kluctl/commands/cmd_delete.go
+++ b/cmd/kluctl/commands/cmd_delete.go
@@ -37,7 +37,7 @@ project (anymore). It really only decides based on the 'deleteByLabel' labels an
 take the local target/state into account!`
 }
 
-func (cmd *deleteCmd) Run() error {
+func (cmd *deleteCmd) Run(ctx context.Context) error {
 	ptArgs := projectTargetCommandArgs{
 		projectFlags:         cmd.ProjectFlags,
 		targetFlags:          cmd.TargetFlags,
@@ -48,8 +48,8 @@ func (cmd *deleteCmd) Run() error {
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 	}
-	return withProjectCommandContext(ptArgs, func(ctx *commandCtx) error {
-		cmd2 := commands.NewDeleteCommand(ctx.targetCtx.DeploymentCollection)
+	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
+		cmd2 := commands.NewDeleteCommand(cmdCtx.targetCtx.DeploymentCollection)
 
 		deleteByLabels, err := deployment.ParseArgs(cmd.DeleteByLabel)
 		if err != nil {
@@ -58,15 +58,15 @@ func (cmd *deleteCmd) Run() error {
 
 		cmd2.OverrideDeleteByLabels = deleteByLabels
 
-		objects, err := cmd2.Run(ctx.ctx, ctx.targetCtx.SharedContext.K)
+		objects, err := cmd2.Run(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K)
 		if err != nil {
 			return err
 		}
-		result, err := confirmedDeleteObjects(ctx.ctx, ctx.targetCtx.SharedContext.K, objects, cmd.DryRun, cmd.Yes)
+		result, err := confirmedDeleteObjects(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K, objects, cmd.DryRun, cmd.Yes)
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(cmd.OutputFormat, result)
+		err = outputCommandResult(ctx, cmd.OutputFormat, result)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_delete.go
+++ b/cmd/kluctl/commands/cmd_delete.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
-	"os"
 )
 
 type deleteCmd struct {
@@ -79,9 +78,9 @@ func (cmd *deleteCmd) Run(ctx context.Context) error {
 
 func confirmedDeleteObjects(ctx context.Context, k *k8s.K8sCluster, refs []k8s2.ObjectRef, dryRun bool, forceYes bool) (*types.CommandResult, error) {
 	if len(refs) != 0 {
-		_, _ = os.Stderr.WriteString("The following objects will be deleted:\n")
+		_, _ = getStderr(ctx).WriteString("The following objects will be deleted:\n")
 		for _, ref := range refs {
-			_, _ = os.Stderr.WriteString(fmt.Sprintf("  %s\n", ref.String()))
+			_, _ = getStderr(ctx).WriteString(fmt.Sprintf("  %s\n", ref.String()))
 		}
 		if !forceYes && !dryRun {
 			if !status.AskForConfirmation(ctx, fmt.Sprintf("Do you really want to delete %d objects?", len(refs))) {

--- a/cmd/kluctl/commands/cmd_diff.go
+++ b/cmd/kluctl/commands/cmd_diff.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
@@ -27,7 +28,7 @@ is currently not documented and prone to changes.
 After the diff is performed, the command will also search for prunable objects and list them.`
 }
 
-func (cmd *diffCmd) Run() error {
+func (cmd *diffCmd) Run(ctx context.Context) error {
 	ptArgs := projectTargetCommandArgs{
 		projectFlags:         cmd.ProjectFlags,
 		targetFlags:          cmd.TargetFlags,
@@ -37,19 +38,19 @@ func (cmd *diffCmd) Run() error {
 		helmCredentials:      cmd.HelmCredentials,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 	}
-	return withProjectCommandContext(ptArgs, func(ctx *commandCtx) error {
-		cmd2 := commands.NewDiffCommand(ctx.targetCtx.DeploymentCollection)
+	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
+		cmd2 := commands.NewDiffCommand(cmdCtx.targetCtx.DeploymentCollection)
 		cmd2.ForceApply = cmd.ForceApply
 		cmd2.ReplaceOnError = cmd.ReplaceOnError
 		cmd2.ForceReplaceOnError = cmd.ForceReplaceOnError
 		cmd2.IgnoreTags = cmd.IgnoreTags
 		cmd2.IgnoreLabels = cmd.IgnoreLabels
 		cmd2.IgnoreAnnotations = cmd.IgnoreAnnotations
-		result, err := cmd2.Run(ctx.ctx, ctx.targetCtx.SharedContext.K)
+		result, err := cmd2.Run(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K)
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(cmd.OutputFormat, result)
+		err = outputCommandResult(ctx, cmd.OutputFormat, result)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_flux_reconcile.go
+++ b/cmd/kluctl/commands/cmd_flux_reconcile.go
@@ -27,7 +27,7 @@ func (cmd *fluxReconcileCmd) Run(ctx context.Context) error {
 	noWait := cmd.KluctlDeploymentFlags.NoWait
 	timestamp := time.Now().Format(time.RFC3339)
 
-	cf, err := k8s.NewClientFactoryFromDefaultConfig(nil)
+	cf, err := k8s.NewClientFactoryFromDefaultConfig(ctx, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/cmd_flux_reconcile.go
+++ b/cmd/kluctl/commands/cmd_flux_reconcile.go
@@ -16,7 +16,7 @@ type fluxReconcileCmd struct {
 	args.KluctlDeploymentFlags
 }
 
-func (cmd *fluxReconcileCmd) Run() error {
+func (cmd *fluxReconcileCmd) Run(ctx context.Context) error {
 	var (
 		sourceNamespace string
 		sourceName      string
@@ -61,7 +61,7 @@ func (cmd *fluxReconcileCmd) Run() error {
 		}
 		ref2 := k8s2.ObjectRef{GVK: args.GitRepositoryGVK, Name: sourceName, Namespace: sourceNamespace}
 
-		s := status.Start(cliCtx, "Annotating Source %s in %s namespace", sourceName, sourceNamespace)
+		s := status.Start(ctx, "Annotating Source %s in %s namespace", sourceName, sourceNamespace)
 		defer s.Failed()
 
 		_, _, err = k.PatchObjectWithJsonPatch(ref2, patch, k8s.PatchOptions{})
@@ -70,7 +70,7 @@ func (cmd *fluxReconcileCmd) Run() error {
 		}
 		s.Success()
 
-		s = status.Start(cliCtx, "Waiting for Source %s to finish reconciliation", sourceName)
+		s = status.Start(ctx, "Waiting for Source %s to finish reconciliation", sourceName)
 
 		if !noWait {
 			ready, err := WaitForReady(k, ref2)
@@ -83,7 +83,7 @@ func (cmd *fluxReconcileCmd) Run() error {
 		s.Success()
 	}
 
-	s := status.Start(cliCtx, "Annotating KluctlDeployment %s in %s namespace", kd, ns)
+	s := status.Start(ctx, "Annotating KluctlDeployment %s in %s namespace", kd, ns)
 	defer s.Failed()
 
 	_, _, err = k.PatchObjectWithJsonPatch(ref, patch, k8s.PatchOptions{})
@@ -92,7 +92,7 @@ func (cmd *fluxReconcileCmd) Run() error {
 	}
 	s.Success()
 
-	s = status.Start(cliCtx, "Waiting for KluctlDeployment %s in %s namespace to finish reconciliation", kd, ns)
+	s = status.Start(ctx, "Waiting for KluctlDeployment %s in %s namespace to finish reconciliation", kd, ns)
 
 	if !noWait {
 		ready, err := WaitForReady(k, ref)

--- a/cmd/kluctl/commands/cmd_flux_resume.go
+++ b/cmd/kluctl/commands/cmd_flux_resume.go
@@ -18,7 +18,7 @@ func (cmd *fluxResumeCmd) Run(ctx context.Context) error {
 	ns := cmd.KluctlDeploymentFlags.Namespace
 	kd := cmd.KluctlDeploymentFlags.KluctlDeployment
 
-	cf, err := k8s.NewClientFactoryFromDefaultConfig(nil)
+	cf, err := k8s.NewClientFactoryFromDefaultConfig(ctx, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/cmd_flux_resume.go
+++ b/cmd/kluctl/commands/cmd_flux_resume.go
@@ -14,7 +14,7 @@ type fluxResumeCmd struct {
 }
 
 // TODO add reconciliation after resume
-func (cmd *fluxResumeCmd) Run() error {
+func (cmd *fluxResumeCmd) Run(ctx context.Context) error {
 	ns := cmd.KluctlDeploymentFlags.Namespace
 	kd := cmd.KluctlDeploymentFlags.KluctlDeployment
 
@@ -35,7 +35,7 @@ func (cmd *fluxResumeCmd) Run() error {
 		Value: false,
 	}}
 
-	s := status.Start(cliCtx, "Resuming KluctlDeployment %s in %s namespace", kd, ns)
+	s := status.Start(ctx, "Resuming KluctlDeployment %s in %s namespace", kd, ns)
 	defer s.Failed()
 
 	_, _, err = k.PatchObjectWithJsonPatch(ref, patch, k8s.PatchOptions{})

--- a/cmd/kluctl/commands/cmd_flux_suspend.go
+++ b/cmd/kluctl/commands/cmd_flux_suspend.go
@@ -13,7 +13,7 @@ type fluxSuspendCmd struct {
 	args.KluctlDeploymentFlags
 }
 
-func (cmd *fluxSuspendCmd) Run() error {
+func (cmd *fluxSuspendCmd) Run(ctx context.Context) error {
 	ns := cmd.KluctlDeploymentFlags.Namespace
 	kd := cmd.KluctlDeploymentFlags.KluctlDeployment
 
@@ -33,7 +33,7 @@ func (cmd *fluxSuspendCmd) Run() error {
 		Value: true,
 	}}
 
-	s := status.Start(cliCtx, "Suspending KluctlDeployment %s in %s namespace", kd, ns)
+	s := status.Start(ctx, "Suspending KluctlDeployment %s in %s namespace", kd, ns)
 	defer s.Failed()
 
 	_, _, err = k.PatchObjectWithJsonPatch(ref, patch, k8s.PatchOptions{})

--- a/cmd/kluctl/commands/cmd_flux_suspend.go
+++ b/cmd/kluctl/commands/cmd_flux_suspend.go
@@ -17,7 +17,7 @@ func (cmd *fluxSuspendCmd) Run(ctx context.Context) error {
 	ns := cmd.KluctlDeploymentFlags.Namespace
 	kd := cmd.KluctlDeploymentFlags.KluctlDeployment
 
-	cf, err := k8s.NewClientFactoryFromDefaultConfig(nil)
+	cf, err := k8s.NewClientFactoryFromDefaultConfig(ctx, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/cmd_helm_pull.go
+++ b/cmd/kluctl/commands/cmd_helm_pull.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"github.com/hashicorp/go-multierror"
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
@@ -25,7 +26,7 @@ func (cmd *helmPullCmd) Help() string {
 pulling is only needed when really required (e.g. when the chart version changes).`
 }
 
-func (cmd *helmPullCmd) Run() error {
+func (cmd *helmPullCmd) Run(ctx context.Context) error {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -52,10 +53,10 @@ func (cmd *helmPullCmd) Run() error {
 			return err
 		}
 
-		utils.GoLimitedMultiError(cliCtx, sem, &errs, &mutex, &wg, func() error {
-			s := status.Start(cliCtx, "%s: Pulling Chart", statusPrefix)
+		utils.GoLimitedMultiError(ctx, sem, &errs, &mutex, &wg, func() error {
+			s := status.Start(ctx, "%s: Pulling Chart", statusPrefix)
 			defer s.Failed()
-			err := doPull(statusPrefix, p, cmd.HelmCredentials, s)
+			err := doPull(ctx, statusPrefix, p, cmd.HelmCredentials, s)
 			if err != nil {
 				return err
 			}
@@ -77,7 +78,7 @@ func (cmd *helmPullCmd) Run() error {
 	return nil
 }
 
-func doPull(statusPrefix string, p string, helmCredentials args.HelmCredentials, s *status.StatusContext) error {
+func doPull(ctx context.Context, statusPrefix string, p string, helmCredentials args.HelmCredentials, s *status.StatusContext) error {
 	doError := func(err error) error {
 		s.FailedWithMessage("%s: %s", statusPrefix, err.Error())
 		return err
@@ -92,7 +93,7 @@ func doPull(statusPrefix string, p string, helmCredentials args.HelmCredentials,
 
 	s.UpdateAndInfoFallback("%s: Pulling Chart %s with version %s", statusPrefix, chart.GetChartName(), *chart.Config.ChartVersion)
 
-	err = chart.Pull(cliCtx)
+	err = chart.Pull(ctx)
 	if err != nil {
 		return doError(err)
 	}

--- a/cmd/kluctl/commands/cmd_helm_pull.go
+++ b/cmd/kluctl/commands/cmd_helm_pull.go
@@ -11,12 +11,12 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"golang.org/x/sync/semaphore"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"sync"
 )
 
 type helmPullCmd struct {
+	args.ProjectDir
 	args.HelmCredentials
 }
 
@@ -27,12 +27,12 @@ pulling is only needed when really required (e.g. when the chart version changes
 }
 
 func (cmd *helmPullCmd) Run(ctx context.Context) error {
-	cwd, err := os.Getwd()
+	projectDir, err := cmd.ProjectDir.GetProjectDir()
 	if err != nil {
 		return err
 	}
 
-	gitRootPath, err := git2.DetectGitRepositoryRoot(cwd)
+	gitRootPath, err := git2.DetectGitRepositoryRoot(projectDir)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func (cmd *helmPullCmd) Run(ctx context.Context) error {
 	var mutex sync.Mutex
 	sem := semaphore.NewWeighted(8)
 
-	err = filepath.WalkDir(cwd, func(p string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(projectDir, func(p string, d fs.DirEntry, err error) error {
 		fname := filepath.Base(p)
 		if fname != "helm-chart.yml" && fname != "helm-chart.yaml" {
 			return nil

--- a/cmd/kluctl/commands/cmd_helm_update.go
+++ b/cmd/kluctl/commands/cmd_helm_update.go
@@ -20,6 +20,7 @@ import (
 )
 
 type helmUpdateCmd struct {
+	args.ProjectDir
 	args.HelmCredentials
 
 	Upgrade bool `group:"misc" help:"Write new versions into helm-chart.yaml and perform helm-pull afterwards"`
@@ -33,12 +34,12 @@ func (cmd *helmUpdateCmd) Help() string {
 }
 
 func (cmd *helmUpdateCmd) Run(ctx context.Context) error {
-	cwd, err := os.Getwd()
+	projectDir, err := cmd.ProjectDir.GetProjectDir()
 	if err != nil {
 		return err
 	}
 
-	gitRootPath, err := git2.DetectGitRepositoryRoot(cwd)
+	gitRootPath, err := git2.DetectGitRepositoryRoot(projectDir)
 	if err != nil {
 		return err
 	}
@@ -57,7 +58,7 @@ func (cmd *helmUpdateCmd) Run(ctx context.Context) error {
 	}
 	var updatedCharts []*updatedChart
 
-	err = filepath.WalkDir(cwd, func(p string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(projectDir, func(p string, d fs.DirEntry, err error) error {
 		fname := filepath.Base(p)
 		if fname != "helm-chart.yml" && fname != "helm-chart.yaml" {
 			return nil

--- a/cmd/kluctl/commands/cmd_list_images.go
+++ b/cmd/kluctl/commands/cmd_list_images.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 )
@@ -26,7 +27,7 @@ If fixed images ('-f/--fixed-image') are provided, these are also taken into acc
 as described in the deploy command.`
 }
 
-func (cmd *listImagesCmd) Run() error {
+func (cmd *listImagesCmd) Run(ctx context.Context) error {
 	ptArgs := projectTargetCommandArgs{
 		projectFlags:         cmd.ProjectFlags,
 		targetFlags:          cmd.TargetFlags,
@@ -38,10 +39,10 @@ func (cmd *listImagesCmd) Run() error {
 		offlineKubernetes:    cmd.OfflineKubernetes,
 		kubernetesVersion:    cmd.KubernetesVersion,
 	}
-	return withProjectCommandContext(ptArgs, func(ctx *commandCtx) error {
+	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
 		result := types.FixedImagesConfig{
-			Images: ctx.images.SeenImages(cmd.Simple),
+			Images: cmdCtx.images.SeenImages(cmd.Simple),
 		}
-		return outputYamlResult(cmd.Output, result, false)
+		return outputYamlResult(ctx, cmd.Output, result, false)
 	})
 }

--- a/cmd/kluctl/commands/cmd_list_targets.go
+++ b/cmd/kluctl/commands/cmd_list_targets.go
@@ -16,12 +16,12 @@ func (cmd *listTargetsCmd) Help() string {
 	return `Outputs a yaml list with all target, including dynamic targets`
 }
 
-func (cmd *listTargetsCmd) Run() error {
-	return withKluctlProjectFromArgs(cmd.ProjectFlags, true, false, func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error {
+func (cmd *listTargetsCmd) Run(ctx context.Context) error {
+	return withKluctlProjectFromArgs(ctx, cmd.ProjectFlags, true, false, func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error {
 		var result []*types.Target
 		for _, t := range p.DynamicTargets {
 			result = append(result, t.Target)
 		}
-		return outputYamlResult(cmd.Output, result, false)
+		return outputYamlResult(ctx, cmd.Output, result, false)
 	})
 }

--- a/cmd/kluctl/commands/cmd_poke_images.go
+++ b/cmd/kluctl/commands/cmd_poke_images.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
@@ -26,7 +27,7 @@ deploying the target. Only images used in combination with 'images.get_image(...
 replaced`
 }
 
-func (cmd *pokeImagesCmd) Run() error {
+func (cmd *pokeImagesCmd) Run(ctx context.Context) error {
 	ptArgs := projectTargetCommandArgs{
 		projectFlags:         cmd.ProjectFlags,
 		targetFlags:          cmd.TargetFlags,
@@ -37,20 +38,20 @@ func (cmd *pokeImagesCmd) Run() error {
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 	}
-	return withProjectCommandContext(ptArgs, func(ctx *commandCtx) error {
+	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
 		if !cmd.Yes && !cmd.DryRun {
-			if !status.AskForConfirmation(cliCtx, fmt.Sprintf("Do you really want to poke images to the context/cluster %s?", ctx.targetCtx.ClusterContext)) {
+			if !status.AskForConfirmation(ctx, fmt.Sprintf("Do you really want to poke images to the context/cluster %s?", cmdCtx.targetCtx.ClusterContext)) {
 				return fmt.Errorf("aborted")
 			}
 		}
 
-		cmd2 := commands.NewPokeImagesCommand(ctx.targetCtx.DeploymentCollection)
+		cmd2 := commands.NewPokeImagesCommand(cmdCtx.targetCtx.DeploymentCollection)
 
-		result, err := cmd2.Run(ctx.ctx, ctx.targetCtx.SharedContext.K)
+		result, err := cmd2.Run(ctx, cmdCtx.targetCtx.SharedContext.K)
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(cmd.OutputFormat, result)
+		err = outputCommandResult(ctx, cmd.OutputFormat, result)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_prune.go
+++ b/cmd/kluctl/commands/cmd_prune.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
@@ -27,7 +28,7 @@ func (cmd *pruneCmd) Help() string {
   3. Remove all objects from the list of 1. that are part of the list in 2.`
 }
 
-func (cmd *pruneCmd) Run() error {
+func (cmd *pruneCmd) Run(ctx context.Context) error {
 	ptArgs := projectTargetCommandArgs{
 		projectFlags:         cmd.ProjectFlags,
 		targetFlags:          cmd.TargetFlags,
@@ -38,22 +39,22 @@ func (cmd *pruneCmd) Run() error {
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 	}
-	return withProjectCommandContext(ptArgs, func(ctx *commandCtx) error {
-		return cmd.runCmdPrune(ctx)
+	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
+		return cmd.runCmdPrune(cmdCtx)
 	})
 }
 
-func (cmd *pruneCmd) runCmdPrune(ctx *commandCtx) error {
-	cmd2 := commands.NewPruneCommand(ctx.targetCtx.DeploymentCollection)
-	objects, err := cmd2.Run(ctx.ctx, ctx.targetCtx.SharedContext.K)
+func (cmd *pruneCmd) runCmdPrune(cmdCtx *commandCtx) error {
+	cmd2 := commands.NewPruneCommand(cmdCtx.targetCtx.DeploymentCollection)
+	objects, err := cmd2.Run(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K)
 	if err != nil {
 		return err
 	}
-	result, err := confirmedDeleteObjects(ctx.ctx, ctx.targetCtx.SharedContext.K, objects, cmd.DryRun, cmd.Yes)
+	result, err := confirmedDeleteObjects(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K, objects, cmd.DryRun, cmd.Yes)
 	if err != nil {
 		return err
 	}
-	err = outputCommandResult(cmd.OutputFormat, result)
+	err = outputCommandResult(cmdCtx.ctx, cmd.OutputFormat, result)
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/cmd_render.go
+++ b/cmd/kluctl/commands/cmd_render.go
@@ -60,7 +60,7 @@ func (cmd *renderCmd) Run(ctx context.Context) error {
 				defer os.RemoveAll(cmd.RenderOutputDir)
 			}
 			status.Flush(cmdCtx.ctx)
-			return yaml.WriteYamlAllStream(os.Stdout, all)
+			return yaml.WriteYamlAllStream(getStdout(ctx), all)
 		} else {
 			status.Info(cmdCtx.ctx, "Rendered into %s", cmdCtx.targetCtx.SharedContext.RenderDir)
 		}

--- a/cmd/kluctl/commands/cmd_render.go
+++ b/cmd/kluctl/commands/cmd_render.go
@@ -30,7 +30,7 @@ a temporary directory or a specified directory.`
 func (cmd *renderCmd) Run(ctx context.Context) error {
 	isTmp := false
 	if cmd.RenderOutputDir == "" {
-		p, err := ioutil.TempDir(utils.GetTmpBaseDir(), "rendered-")
+		p, err := ioutil.TempDir(utils.GetTmpBaseDir(ctx), "rendered-")
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_validate.go
+++ b/cmd/kluctl/commands/cmd_validate.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
@@ -28,7 +29,7 @@ func (cmd *validateCmd) Help() string {
 TODO: This needs to be better documented!`
 }
 
-func (cmd *validateCmd) Run() error {
+func (cmd *validateCmd) Run(ctx context.Context) error {
 	ptArgs := projectTargetCommandArgs{
 		projectFlags:         cmd.ProjectFlags,
 		targetFlags:          cmd.TargetFlags,
@@ -37,17 +38,17 @@ func (cmd *validateCmd) Run() error {
 		helmCredentials:      cmd.HelmCredentials,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 	}
-	return withProjectCommandContext(ptArgs, func(ctx *commandCtx) error {
+	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
 		startTime := time.Now()
-		cmd2 := commands.NewValidateCommand(ctx.ctx, ctx.targetCtx.DeploymentCollection)
+		cmd2 := commands.NewValidateCommand(cmdCtx.ctx, cmdCtx.targetCtx.DeploymentCollection)
 		for true {
-			result, err := cmd2.Run(ctx.ctx, ctx.targetCtx.SharedContext.K)
+			result, err := cmd2.Run(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K)
 			if err != nil {
 				return err
 			}
 			failed := len(result.Errors) != 0 || (cmd.WarningsAsErrors && len(result.Warnings) != 0)
 
-			err = outputValidateResult(cmd.Output, result)
+			err = outputValidateResult(ctx, cmd.Output, result)
 			if err != nil {
 				return err
 			}

--- a/cmd/kluctl/commands/cmd_validate.go
+++ b/cmd/kluctl/commands/cmd_validate.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
-	"os"
 	"time"
 )
 
@@ -54,7 +53,7 @@ func (cmd *validateCmd) Run(ctx context.Context) error {
 			}
 
 			if !failed {
-				_, _ = os.Stderr.WriteString("Validation succeeded\n")
+				_, _ = getStderr(ctx).WriteString("Validation succeeded\n")
 				return nil
 			}
 

--- a/cmd/kluctl/commands/cmd_version.go
+++ b/cmd/kluctl/commands/cmd_version.go
@@ -3,13 +3,12 @@ package commands
 import (
 	"context"
 	"github.com/kluctl/kluctl/v2/pkg/version"
-	"os"
 )
 
 type versionCmd struct {
 }
 
 func (cmd *versionCmd) Run(ctx context.Context) error {
-	_, err := os.Stdout.WriteString(version.GetVersion() + "\n")
+	_, err := getStdout(ctx).WriteString(version.GetVersion() + "\n")
 	return err
 }

--- a/cmd/kluctl/commands/cmd_version.go
+++ b/cmd/kluctl/commands/cmd_version.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"github.com/kluctl/kluctl/v2/pkg/version"
 	"os"
 )
@@ -8,7 +9,7 @@ import (
 type versionCmd struct {
 }
 
-func (cmd *versionCmd) Run() error {
+func (cmd *versionCmd) Run(ctx context.Context) error {
 	_, err := os.Stdout.WriteString(version.GetVersion() + "\n")
 	return err
 }

--- a/cmd/kluctl/commands/cobra_utils.go
+++ b/cmd/kluctl/commands/cobra_utils.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/term"
@@ -20,7 +21,7 @@ type helpProvider interface {
 }
 
 type runProvider interface {
-	Run() error
+	Run(ctx context.Context) error
 }
 
 type rootCommand struct {
@@ -68,7 +69,7 @@ func (c *rootCommand) buildCobraCmd(parent *commandAndGroups, cmdStruct interfac
 	runP, ok := cmdStruct.(runProvider)
 	if ok {
 		cg.cmd.RunE = func(cmd *cobra.Command, args []string) error {
-			return runP.Run()
+			return runP.Run(cmd.Context())
 		}
 	}
 

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/types"
@@ -196,24 +197,24 @@ func outputHelper(output []string, cb func(format string) (string, error)) error
 	return nil
 }
 
-func outputCommandResult(output []string, cr *types.CommandResult) error {
-	status.Flush(cliCtx)
+func outputCommandResult(ctx context.Context, output []string, cr *types.CommandResult) error {
+	status.Flush(ctx)
 
 	return outputHelper(output, func(format string) (string, error) {
 		return formatCommandResult(cr, format)
 	})
 }
 
-func outputValidateResult(output []string, vr *types.ValidateResult) error {
-	status.Flush(cliCtx)
+func outputValidateResult(ctx context.Context, output []string, vr *types.ValidateResult) error {
+	status.Flush(ctx)
 
 	return outputHelper(output, func(format string) (string, error) {
 		return formatValidateResult(vr, format)
 	})
 }
 
-func outputYamlResult(output []string, result interface{}, multiDoc bool) error {
-	status.Flush(cliCtx)
+func outputYamlResult(ctx context.Context, output []string, result interface{}, multiDoc bool) error {
+	status.Flush(ctx)
 
 	if len(output) == 0 {
 		output = []string{"-"}

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -173,7 +173,7 @@ func formatValidateResult(vr *types.ValidateResult, format string) (string, erro
 	}
 }
 
-func outputHelper(output []string, cb func(format string) (string, error)) error {
+func outputHelper(ctx context.Context, output []string, cb func(format string) (string, error)) error {
 	if len(output) == 0 {
 		output = []string{"text"}
 	}
@@ -189,7 +189,7 @@ func outputHelper(output []string, cb func(format string) (string, error)) error
 			return err
 		}
 
-		err = outputResult(path, r)
+		err = outputResult(ctx, path, r)
 		if err != nil {
 			return err
 		}
@@ -200,7 +200,7 @@ func outputHelper(output []string, cb func(format string) (string, error)) error
 func outputCommandResult(ctx context.Context, output []string, cr *types.CommandResult) error {
 	status.Flush(ctx)
 
-	return outputHelper(output, func(format string) (string, error) {
+	return outputHelper(ctx, output, func(format string) (string, error) {
 		return formatCommandResult(cr, format)
 	})
 }
@@ -208,7 +208,7 @@ func outputCommandResult(ctx context.Context, output []string, cr *types.Command
 func outputValidateResult(ctx context.Context, output []string, vr *types.ValidateResult) error {
 	status.Flush(ctx)
 
-	return outputHelper(output, func(format string) (string, error) {
+	return outputHelper(ctx, output, func(format string) (string, error) {
 		return formatValidateResult(vr, format)
 	})
 }
@@ -238,7 +238,7 @@ func outputYamlResult(ctx context.Context, output []string, result interface{}, 
 		s = x
 	}
 	for _, path := range output {
-		err := outputResult(&path, s)
+		err := outputResult(ctx, &path, s)
 		if err != nil {
 			return err
 		}
@@ -246,8 +246,9 @@ func outputYamlResult(ctx context.Context, output []string, result interface{}, 
 	return nil
 }
 
-func outputResult(f *string, result string) error {
-	w := os.Stdout
+func outputResult(ctx context.Context, f *string, result string) error {
+	var w io.Writer
+	w = getStdout(ctx)
 	if f != nil && *f != "-" {
 		f, err := os.Create(*f)
 		if err != nil {

--- a/cmd/kluctl/commands/override_std_streams.go
+++ b/cmd/kluctl/commands/override_std_streams.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"context"
+	"io"
+	"os"
+)
+
+type overrideStdStreamsKey int
+type overrideStdStreamsValue struct {
+	stdout io.Writer
+	stderr io.Writer
+}
+
+var overrideStdStreamsKeyInst overrideStdStreamsKey
+
+func WithStdStreams(ctx context.Context, stdout io.Writer, stderr io.Writer) context.Context {
+	return context.WithValue(ctx, overrideStdStreamsKeyInst, &overrideStdStreamsValue{
+		stdout: stdout,
+		stderr: stderr,
+	})
+}
+
+func getStdStreams(ctx context.Context) (io.Writer, io.Writer) {
+	v := ctx.Value(overrideStdStreamsKeyInst)
+	if v == nil {
+		return os.Stdout, os.Stderr
+	}
+	v2 := v.(*overrideStdStreamsValue)
+	return v2.stdout, v2.stderr
+}
+
+type stringWriter struct {
+	w io.Writer
+}
+
+func (w *stringWriter) WriteString(s string) (n int, err error) {
+	return w.w.Write([]byte(s))
+}
+
+func (w *stringWriter) Write(b []byte) (n int, err error) {
+	return w.w.Write(b)
+}
+
+func getStdout(ctx context.Context) *stringWriter {
+	stdout, _ := getStdStreams(ctx)
+	return &stringWriter{stdout}
+}
+
+func getStderr(ctx context.Context) *stringWriter {
+	_, stderr := getStdStreams(ctx)
+	return &stringWriter{stderr}
+}

--- a/cmd/kluctl/commands/root.go
+++ b/cmd/kluctl/commands/root.go
@@ -197,7 +197,7 @@ func (c *cli) preRun() error {
 	return nil
 }
 
-func (c *cli) Run() error {
+func (c *cli) Run(ctx context.Context) error {
 	return nil
 }
 
@@ -237,7 +237,11 @@ composed of multiple smaller parts (Helm/Kustomize/...) in a manageable and unif
 		if err != nil {
 			return err
 		}
-		return root.preRun()
+		err = root.preRun()
+		for c := cmd; c != nil; c = c.Parent() {
+			c.SetContext(cliCtx)
+		}
+		return err
 	}
 
 	initViper()

--- a/cmd/kluctl/commands/root.go
+++ b/cmd/kluctl/commands/root.go
@@ -149,7 +149,7 @@ func checkNewVersion(ctx context.Context) {
 		return
 	}
 
-	versionCheckPath := filepath.Join(utils.GetTmpBaseDir(), "version_check.yaml")
+	versionCheckPath := filepath.Join(utils.GetTmpBaseDir(ctx), "version_check.yaml")
 	var versionCheckState VersionCheckState
 	err := yaml.ReadYamlFile(versionCheckPath, &versionCheckState)
 	if err == nil {

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -37,12 +37,12 @@ func withKluctlProjectFromArgs(ctx context.Context, projectFlags args.ProjectFla
 	}
 	defer j2.Close()
 
-	cwd, err := os.Getwd()
+	projectDir, err := projectFlags.ProjectDir.GetProjectDir()
 	if err != nil {
 		return err
 	}
 
-	repoRoot, err := git.DetectGitRepositoryRoot(cwd)
+	repoRoot, err := git.DetectGitRepositoryRoot(projectDir)
 	if err != nil {
 		status.Warning(ctx, "Failed to detect git project root. This might cause follow-up errors")
 	}
@@ -74,7 +74,7 @@ func withKluctlProjectFromArgs(ctx context.Context, projectFlags args.ProjectFla
 
 	loadArgs := kluctl_project.LoadKluctlProjectArgs{
 		RepoRoot:           repoRoot,
-		ProjectDir:         cwd,
+		ProjectDir:         projectDir,
 		ProjectConfig:      projectFlags.ProjectConfig.String(),
 		RP:                 rp,
 		ClientConfigGetter: clientConfigGetter(forCompletion),

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -25,7 +25,7 @@ import (
 )
 
 func withKluctlProjectFromArgs(ctx context.Context, projectFlags args.ProjectFlags, strictTemplates bool, forCompletion bool, cb func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error) error {
-	tmpDir, err := os.MkdirTemp(utils.GetTmpBaseDir(), "project-")
+	tmpDir, err := os.MkdirTemp(utils.GetTmpBaseDir(ctx), "project-")
 	if err != nil {
 		return fmt.Errorf("creating temporary project directory failed: %w", err)
 	}

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 )
 
-func withKluctlProjectFromArgs(projectFlags args.ProjectFlags, strictTemplates bool, forCompletion bool, cb func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error) error {
+func withKluctlProjectFromArgs(ctx context.Context, projectFlags args.ProjectFlags, strictTemplates bool, forCompletion bool, cb func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error) error {
 	tmpDir, err := os.MkdirTemp(utils.GetTmpBaseDir(), "project-")
 	if err != nil {
 		return fmt.Errorf("creating temporary project directory failed: %w", err)
@@ -44,10 +44,10 @@ func withKluctlProjectFromArgs(projectFlags args.ProjectFlags, strictTemplates b
 
 	repoRoot, err := git.DetectGitRepositoryRoot(cwd)
 	if err != nil {
-		status.Warning(cliCtx, "Failed to detect git project root. This might cause follow-up errors")
+		status.Warning(ctx, "Failed to detect git project root. This might cause follow-up errors")
 	}
 
-	ctx, cancel := context.WithTimeout(cliCtx, projectFlags.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, projectFlags.Timeout)
 	defer cancel()
 
 	sshPool := &ssh_pool.SshPool{}
@@ -110,13 +110,13 @@ type commandCtx struct {
 	images    *deployment.Images
 }
 
-func withProjectCommandContext(args projectTargetCommandArgs, cb func(ctx *commandCtx) error) error {
-	return withKluctlProjectFromArgs(args.projectFlags, true, false, func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error {
+func withProjectCommandContext(ctx context.Context, args projectTargetCommandArgs, cb func(cmdCtx *commandCtx) error) error {
+	return withKluctlProjectFromArgs(ctx, args.projectFlags, true, false, func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error {
 		return withProjectTargetCommandContext(ctx, args, p, cb)
 	})
 }
 
-func withProjectTargetCommandContext(ctx context.Context, args projectTargetCommandArgs, p *kluctl_project.LoadedKluctlProject, cb func(ctx *commandCtx) error) error {
+func withProjectTargetCommandContext(ctx context.Context, args projectTargetCommandArgs, p *kluctl_project.LoadedKluctlProject, cb func(cmdCtx *commandCtx) error) error {
 	rh := registries.NewRegistryHelper(ctx)
 	err := rh.ParseAuthEntriesFromEnv()
 	if err != nil {

--- a/docs/reference/commands/common-arguments.md
+++ b/docs/reference/commands/common-arguments.md
@@ -62,6 +62,7 @@ Project arguments:
                                              'github.com:my-org/my-repo:my-branch=/local/path/to/override'
   -c, --project-config existingfile          Location of the .kluctl.yaml config file. Defaults to
                                              $PROJECT/.kluctl.yaml
+      --project-dir existingdir              Specify the project directory. Defaults to the current working directory.
   -t, --target string                        Target name to run command for. Target must exist in .kluctl.yaml.
   -T, --target-name-override string          Overrides the target name. If -t is used at the same time, then the
                                              target will be looked up based on -t <name> and then renamed to the

--- a/e2e/args_test.go
+++ b/e2e/args_test.go
@@ -13,7 +13,7 @@ func testArgs(t *testing.T, deprecated bool) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -136,7 +136,7 @@ func TestArgsFromEnv(t *testing.T) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -169,7 +169,7 @@ func TestArgsFromEnvAndCli(t *testing.T) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 

--- a/e2e/args_test.go
+++ b/e2e/args_test.go
@@ -128,15 +128,14 @@ func TestArgs(t *testing.T) {
 }
 
 func TestArgsFromEnv(t *testing.T) {
-	t.Setenv("KLUCTL_ARG", "a=a")
-	t.Setenv("KLUCTL_ARG_1", "b=b")
-	t.Setenv("KLUCTL_ARG_2", `c={"nested":{"nested2":"c"}}`)
-	t.Setenv("KLUCTL_ARG_3", "d=true")
-	t.Setenv("KLUCTL_ARG_4", "e='true'")
-
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t)
+	p := test_utils.NewTestProject(t, test_utils.WithUseProcess(true))
+	p.AddExtraEnv("KLUCTL_ARG=a=a")
+	p.AddExtraEnv("KLUCTL_ARG_1=b=b")
+	p.AddExtraEnv(`KLUCTL_ARG_2=c={"nested":{"nested2":"c"}}`)
+	p.AddExtraEnv("KLUCTL_ARG_3=d=true")
+	p.AddExtraEnv("KLUCTL_ARG_4=e='true'")
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -164,12 +163,11 @@ func TestArgsFromEnv(t *testing.T) {
 }
 
 func TestArgsFromEnvAndCli(t *testing.T) {
-	t.Setenv("KLUCTL_ARG_1", "a=a")
-	t.Setenv("KLUCTL_ARG_2", "c=c")
-
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t)
+	p := test_utils.NewTestProject(t, test_utils.WithUseProcess(true))
+	p.AddExtraEnv("KLUCTL_ARG_1=a=a")
+	p.AddExtraEnv("KLUCTL_ARG_2=c=c")
 
 	createNamespace(t, k, p.TestSlug())
 

--- a/e2e/call_kluctl_hack.go
+++ b/e2e/call_kluctl_hack.go
@@ -13,7 +13,7 @@ func init() {
 	// We use the Golang's initializing mechanism to run kluctl even though the test executable was invoked
 	// This is clearly a hack, but it avoids the requirement to have a kluctl executable pre-built
 	if isCallKluctlHack() {
-		commands.Execute()
+		commands.Main()
 		os.Exit(0)
 	}
 }

--- a/e2e/contexts_test.go
+++ b/e2e/contexts_test.go
@@ -3,13 +3,11 @@ package e2e
 import (
 	"github.com/kluctl/kluctl/v2/e2e/test-utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
-	"k8s.io/client-go/tools/clientcmd/api"
 	"testing"
 )
 
 func prepareContextTest(t *testing.T) *test_utils.TestProject {
-	p := test_utils.NewTestProject(t, defaultCluster1)
-	p.MergeKubeconfig(defaultCluster2)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, defaultCluster1, p.TestSlug())
 	createNamespace(t, defaultCluster2, p.TestSlug())
@@ -23,8 +21,6 @@ func prepareContextTest(t *testing.T) *test_utils.TestProject {
 }
 
 func TestContextCurrent(t *testing.T) {
-	t.Parallel()
-
 	p := prepareContextTest(t)
 
 	p.UpdateTarget("test1", func(target *uo.UnstructuredObject) {
@@ -35,9 +31,7 @@ func TestContextCurrent(t *testing.T) {
 	assertConfigMapExists(t, defaultCluster1, p.TestSlug(), "cm")
 	assertConfigMapNotExists(t, defaultCluster2, p.TestSlug(), "cm")
 
-	p.UpdateMergedKubeconfig(func(config *api.Config) {
-		config.CurrentContext = defaultCluster2.Context
-	})
+	setMergedKubeconfigContext(t, defaultCluster2.Context)
 
 	p.KluctlMust("deploy", "--yes", "-t", "test1")
 	assertConfigMapExists(t, defaultCluster2, p.TestSlug(), "cm")

--- a/e2e/default_clusters.go
+++ b/e2e/default_clusters.go
@@ -1,14 +1,21 @@
 package e2e
 
+import "C"
 import (
+	"github.com/imdario/mergo"
 	"github.com/kluctl/kluctl/v2/e2e/test-utils"
 	"github.com/kluctl/kluctl/v2/e2e/test_resources"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+	"runtime"
 	"sync"
+	"testing"
 )
 
 var defaultCluster1 = test_utils.CreateEnvTestCluster("cluster1")
 var defaultCluster2 = test_utils.CreateEnvTestCluster("cluster2")
+var mergedKubeconfig string
 
 func init() {
 	if isCallKluctlHack() {
@@ -37,4 +44,60 @@ func init() {
 		test_resources.ApplyYaml("sealed-secrets.yaml", defaultCluster2)
 	}()
 	wg.Wait()
+
+	tmpKubeconfig, err := os.CreateTemp("", "")
+	if err != nil {
+		panic(err)
+	}
+	_ = tmpKubeconfig.Close()
+	runtime.SetFinalizer(defaultCluster1, func(_ *test_utils.EnvTestCluster) {
+		_ = os.Remove(tmpKubeconfig.Name())
+	})
+
+	mergeKubeconfig(tmpKubeconfig.Name(), defaultCluster1.Kubeconfig)
+	mergeKubeconfig(tmpKubeconfig.Name(), defaultCluster2.Kubeconfig)
+
+	mergedKubeconfig = tmpKubeconfig.Name()
+	_ = os.Setenv("KUBECONFIG", mergedKubeconfig)
+}
+
+func mergeKubeconfig(path string, kubeconfig []byte) {
+	mkcfg, err := clientcmd.LoadFromFile(path)
+	if err != nil {
+		panic(err)
+	}
+
+	nkcfg, err := clientcmd.Load(kubeconfig)
+	if err != nil {
+		panic(err)
+	}
+
+	err = mergo.Merge(mkcfg, nkcfg)
+	if err != nil {
+		panic(err)
+	}
+
+	err = clientcmd.WriteToFile(*mkcfg, path)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func setMergedKubeconfigContext(t *testing.T, newContext string) {
+	tmpKubeconfig, err := os.CreateTemp(t.TempDir(), "kubeconfig-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tmpKubeconfig.Close()
+
+	kcfg, err := clientcmd.LoadFromFile(mergedKubeconfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kcfg.CurrentContext = newContext
+	err = clientcmd.WriteToFile(*kcfg, tmpKubeconfig.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KUBECONFIG", tmpKubeconfig.Name())
 }

--- a/e2e/deployment_items_test.go
+++ b/e2e/deployment_items_test.go
@@ -11,7 +11,7 @@ func TestKustomize(t *testing.T) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -39,7 +39,7 @@ func TestGeneratedKustomize(t *testing.T) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 

--- a/e2e/flux_test.go
+++ b/e2e/flux_test.go
@@ -36,7 +36,7 @@ func TestFluxCommands(t *testing.T) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/e2e/flux_test.go
+++ b/e2e/flux_test.go
@@ -36,7 +36,7 @@ func TestFluxCommands(t *testing.T) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t)
+	p := test_utils.NewTestProject(t, test_utils.WithUseProcess(true))
 
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/e2e/helm_test.go
+++ b/e2e/helm_test.go
@@ -33,7 +33,7 @@ func testHelmPull(t *testing.T, tc testCase, prePull bool) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -124,7 +124,7 @@ func testHelmManualUpgrade(t *testing.T, oci bool) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -168,7 +168,7 @@ func testHelmUpdate(t *testing.T, oci bool, upgrade bool, commit bool) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -278,7 +278,7 @@ func testHelmUpdateConstraints(t *testing.T, oci bool) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -341,7 +341,7 @@ func TestHelmValues(t *testing.T) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -406,7 +406,7 @@ func TestHelmTemplateChartYaml(t *testing.T) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 	createNamespace(t, k, p.TestSlug()+"-a")
@@ -437,7 +437,7 @@ func TestHelmRenderOfflineKubernetes(t *testing.T) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 

--- a/e2e/hooks_test.go
+++ b/e2e/hooks_test.go
@@ -96,10 +96,9 @@ func prepareHookTestProject(t *testing.T, hook string, hookDeletionPolicy string
 	s := &hooksTestContext{
 		t: t,
 		k: defaultCluster2, // use cluster2 as it has webhooks setup
+		p: test_utils.NewTestProject(t),
 	}
 	s.setupWebhook()
-
-	s.p = test_utils.NewTestProject(t)
 	t.Cleanup(func() {
 		s.removeWebhook()
 	})

--- a/e2e/hooks_test.go
+++ b/e2e/hooks_test.go
@@ -99,14 +99,16 @@ func prepareHookTestProject(t *testing.T, hook string, hookDeletionPolicy string
 	}
 	s.setupWebhook()
 
-	s.p = test_utils.NewTestProject(t, s.k)
+	s.p = test_utils.NewTestProject(t)
 	t.Cleanup(func() {
 		s.removeWebhook()
 	})
 
 	createNamespace(s.t, s.k, s.p.TestSlug())
 
-	s.p.UpdateTarget("test", nil)
+	s.p.UpdateTarget("test", func(target *uo.UnstructuredObject) {
+		_ = target.SetNestedField(s.k.Context, "context")
+	})
 
 	s.p.AddKustomizeDeployment("hook", nil, nil)
 

--- a/e2e/inclusion_test.go
+++ b/e2e/inclusion_test.go
@@ -10,7 +10,7 @@ import (
 
 func prepareInclusionTestProject(t *testing.T, withIncludes bool) (*test_utils.TestProject, *test_utils.EnvTestCluster) {
 	k := defaultCluster1
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 

--- a/e2e/no_target_test.go
+++ b/e2e/no_target_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func prepareNoTargetTest(t *testing.T, withDeploymentYaml bool) *test_utils.TestProject {
-	p := test_utils.NewTestProject(t, defaultCluster1)
-	p.MergeKubeconfig(defaultCluster2)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, defaultCluster1, p.TestSlug())
 	createNamespace(t, defaultCluster2, p.TestSlug())

--- a/e2e/seal_test.go
+++ b/e2e/seal_test.go
@@ -98,7 +98,7 @@ func addProxyVars(p *test_utils.TestProject) {
 }
 
 func prepareSealTest(t *testing.T, k *test_utils.EnvTestCluster, secrets map[string]string, varsSources []*uo.UnstructuredObject, proxy bool) *test_utils.TestProject {
-	p := test_utils.NewTestProject(t)
+	p := test_utils.NewTestProject(t, test_utils.WithUseProcess(true))
 
 	if proxy {
 		addProxyVars(p)

--- a/e2e/seal_test.go
+++ b/e2e/seal_test.go
@@ -98,7 +98,7 @@ func addProxyVars(p *test_utils.TestProject) {
 }
 
 func prepareSealTest(t *testing.T, k *test_utils.EnvTestCluster, secrets map[string]string, varsSources []*uo.UnstructuredObject, proxy bool) *test_utils.TestProject {
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	if proxy {
 		addProxyVars(p)
@@ -341,7 +341,6 @@ func TestSeal_MultipleTargets(t *testing.T) {
 	})
 	addSecretsSetToTarget(p, "test-target2", "test2")
 
-	p.MergeKubeconfig(defaultCluster2)
 	createNamespace(t, defaultCluster2, p.TestSlug())
 	p.UpdateTarget("test-target", func(target *uo.UnstructuredObject) {
 		_ = target.SetNestedField(defaultCluster1.Context, "context")

--- a/e2e/sops_test.go
+++ b/e2e/sops_test.go
@@ -15,7 +15,7 @@ func TestSopsVars(t *testing.T) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -55,7 +55,7 @@ func TestSopsResources(t *testing.T) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -88,7 +88,7 @@ func TestSopsHelmValues(t *testing.T) {
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t, k)
+	p := test_utils.NewTestProject(t)
 
 	createNamespace(t, k, p.TestSlug())
 

--- a/e2e/sops_test.go
+++ b/e2e/sops_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"fmt"
 	"github.com/kluctl/kluctl/v2/e2e/test-utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/kluctl/kluctl/v2/pkg/vars/sops_test_resources"
@@ -9,13 +10,18 @@ import (
 	"testing"
 )
 
-func TestSopsVars(t *testing.T) {
+func setSopsKey(p *test_utils.TestProject) {
 	key, _ := sops_test_resources.TestResources.ReadFile("test-key.txt")
-	t.Setenv(age.SopsAgeKeyEnv, string(key))
+	p.AddExtraEnv(fmt.Sprintf("%s=%s", age.SopsAgeKeyEnv, string(key)))
+}
+
+func TestSopsVars(t *testing.T) {
+	t.Parallel()
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t)
+	p := test_utils.NewTestProject(t, test_utils.WithUseProcess(true))
+	setSopsKey(p)
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -50,12 +56,12 @@ func TestSopsVars(t *testing.T) {
 }
 
 func TestSopsResources(t *testing.T) {
-	key, _ := sops_test_resources.TestResources.ReadFile("test-key.txt")
-	t.Setenv(age.SopsAgeKeyEnv, string(key))
+	t.Parallel()
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t)
+	p := test_utils.NewTestProject(t, test_utils.WithUseProcess(true))
+	setSopsKey(p)
 
 	createNamespace(t, k, p.TestSlug())
 
@@ -83,12 +89,12 @@ func TestSopsResources(t *testing.T) {
 }
 
 func TestSopsHelmValues(t *testing.T) {
-	key, _ := sops_test_resources.TestResources.ReadFile("test-key.txt")
-	t.Setenv(age.SopsAgeKeyEnv, string(key))
+	t.Parallel()
 
 	k := defaultCluster1
 
-	p := test_utils.NewTestProject(t)
+	p := test_utils.NewTestProject(t, test_utils.WithUseProcess(true))
+	setSopsKey(p)
 
 	createNamespace(t, k, p.TestSlug())
 

--- a/e2e/test-utils/project.go
+++ b/e2e/test-utils/project.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -420,6 +421,7 @@ func (p *TestProject) KluctlExecute(argsIn ...string) (string, string, error) {
 
 	p.t.Logf("Runnning kluctl: %s", strings.Join(args, " "))
 
+	var m sync.Mutex
 	stdout := bytes.NewBuffer(nil)
 	stderr := bytes.NewBuffer(nil)
 
@@ -427,6 +429,8 @@ func (p *TestProject) KluctlExecute(argsIn ...string) (string, string, error) {
 	ctx = utils.WithTmpBaseDir(ctx, p.t.TempDir())
 	ctx = commands.WithStdStreams(ctx, stdout, stderr)
 	sh := status.NewSimpleStatusHandler(func(message string) {
+		m.Lock()
+		defer m.Unlock()
 		p.t.Log(message)
 		stderr.WriteString(message + "\n")
 	}, false, true)

--- a/internal/replace-commands-help/main.go
+++ b/internal/replace-commands-help/main.go
@@ -1,92 +1,92 @@
 package main
 
 import (
-    "flag"
-    "fmt"
-    "github.com/kluctl/kluctl/v2/cmd/kluctl/commands"
-    "io/fs"
-    "io/ioutil"
-    "log"
-    "os"
-    "os/exec"
-    "path/filepath"
-    "reflect"
-    "regexp"
-    "strings"
-    "syscall"
+	"flag"
+	"fmt"
+	"github.com/kluctl/kluctl/v2/cmd/kluctl/commands"
+	"io/fs"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+	"syscall"
 )
 
 var docsDir = flag.String("docs-dir", "", "Path to documentation")
 
 type section struct {
-    start   int
-    end     int
-    command string
-    section string
-    code    bool
+	start   int
+	end     int
+	command string
+	section string
+	code    bool
 }
 
 func main() {
-    _ = syscall.Setenv("COLUMNS", "120")
+	_ = syscall.Setenv("COLUMNS", "120")
 
-    if os.Getenv("CALL_KLUCTL") == "true" {
-        kluctlMain()
-        return
-    }
+	if os.Getenv("CALL_KLUCTL") == "true" {
+		kluctlMain()
+		return
+	}
 
-    flag.Parse()
+	flag.Parse()
 
-    filepath.WalkDir(*docsDir, func(path string, d fs.DirEntry, err error) error {
-        if !strings.HasSuffix(path, ".md") {
-            return nil
-        }
-        processFile(path)
-        return nil
-    })
+	filepath.WalkDir(*docsDir, func(path string, d fs.DirEntry, err error) error {
+		if !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		processFile(path)
+		return nil
+	})
 }
 
 func kluctlMain() {
-    commands.Execute()
+	commands.Execute()
 }
 
 func processFile(path string) {
-    text, err := ioutil.ReadFile(path)
-    if err != nil {
-        log.Fatal(err)
-    }
-    lines := strings.Split(string(text), "\n")
+	text, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	lines := strings.Split(string(text), "\n")
 
-    var newLines []string
-    pos := 0
-    for true {
-        s := findNextSection(lines, pos)
-        if s == nil {
-            newLines = append(newLines, lines[pos:]...)
-            break
-        }
+	var newLines []string
+	pos := 0
+	for true {
+		s := findNextSection(lines, pos)
+		if s == nil {
+			newLines = append(newLines, lines[pos:]...)
+			break
+		}
 
-        newLines = append(newLines, lines[pos:s.start+1]...)
+		newLines = append(newLines, lines[pos:s.start+1]...)
 
-        s2 := getHelpSection(s.command, s.section)
+		s2 := getHelpSection(s.command, s.section)
 
-        if s.code {
-            newLines = append(newLines, "```")
-        }
-        newLines = append(newLines, s2...)
-        if s.code {
-            newLines = append(newLines, "```")
-        }
+		if s.code {
+			newLines = append(newLines, "```")
+		}
+		newLines = append(newLines, s2...)
+		if s.code {
+			newLines = append(newLines, "```")
+		}
 
-        newLines = append(newLines, lines[s.end])
-        pos = s.end + 1
-    }
+		newLines = append(newLines, lines[s.end])
+		pos = s.end + 1
+	}
 
-    if !reflect.DeepEqual(lines, newLines) {
-        err = ioutil.WriteFile(path, []byte(strings.Join(newLines, "\n")), 0o600)
-        if err != nil {
-            log.Fatal(err)
-        }
-    }
+	if !reflect.DeepEqual(lines, newLines) {
+		err = ioutil.WriteFile(path, []byte(strings.Join(newLines, "\n")), 0o600)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
 }
 
 var beginPattern = regexp.MustCompile(`<!-- BEGIN SECTION "([^"]*)" "([^"]*)" (true|false) -->`)
@@ -94,79 +94,79 @@ var endPattern = regexp.MustCompile(`<!-- END SECTION -->`)
 
 func findNextSection(lines []string, start int) *section {
 
-    for i := start; i < len(lines); i++ {
-        m := beginPattern.FindSubmatch([]byte(lines[i]))
-        if m == nil {
-            continue
-        }
+	for i := start; i < len(lines); i++ {
+		m := beginPattern.FindSubmatch([]byte(lines[i]))
+		if m == nil {
+			continue
+		}
 
-        var s section
-        s.start = i
-        s.command = string(m[1])
-        s.section = string(m[2])
-        s.code = string(m[3]) == "true"
+		var s section
+		s.start = i
+		s.command = string(m[1])
+		s.section = string(m[2])
+		s.code = string(m[3]) == "true"
 
-        for j := i + 1; j < len(lines); j++ {
-            m = endPattern.FindSubmatch([]byte(lines[j]))
-            if m == nil {
-                continue
-            }
-            s.end = j
-            return &s
-        }
-    }
-    return nil
+		for j := i + 1; j < len(lines); j++ {
+			m = endPattern.FindSubmatch([]byte(lines[j]))
+			if m == nil {
+				continue
+			}
+			s.end = j
+			return &s
+		}
+	}
+	return nil
 }
 
 func countIndent(str string) int {
-    for i := 0; i < len(str); i++ {
-        if str[i] != ' ' {
-            return i
-        }
-    }
-    return 0
+	for i := 0; i < len(str); i++ {
+		if str[i] != ' ' {
+			return i
+		}
+	}
+	return 0
 }
 
 func getHelpSection(command string, section string) []string {
-    log.Printf("Getting section '%s' from command '%s'", section, command)
+	log.Printf("Getting section '%s' from command '%s'", section, command)
 
-    exe, err := os.Executable()
-    if err != nil {
-        log.Fatal(err)
-    }
+	exe, err := os.Executable()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    helpCmd := exec.Command(exe, command, "--help")
-    helpCmd.Env = os.Environ()
-    helpCmd.Env = append(helpCmd.Env, "CALL_KLUCTL=true")
+	helpCmd := exec.Command(exe, command, "--help")
+	helpCmd.Env = os.Environ()
+	helpCmd.Env = append(helpCmd.Env, "CALL_KLUCTL=true")
 
-    out, err := helpCmd.CombinedOutput()
-    if err != nil {
-        log.Fatal(err)
-    }
+	out, err := helpCmd.CombinedOutput()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    lines := strings.Split(string(out), "\n")
+	lines := strings.Split(string(out), "\n")
 
-    sectionStart := -1
-    for i := 0; i < len(lines); i++ {
-        indent := countIndent(lines[i])
-        if strings.HasPrefix(lines[i][indent:], fmt.Sprintf("%s:", section)) {
-            sectionStart = i
-            break
-        }
-    }
-    if sectionStart == -1 {
-        log.Fatalf("Section %s not found in command %s", section, command)
-    }
+	sectionStart := -1
+	for i := 0; i < len(lines); i++ {
+		indent := countIndent(lines[i])
+		if strings.HasPrefix(lines[i][indent:], fmt.Sprintf("%s:", section)) {
+			sectionStart = i
+			break
+		}
+	}
+	if sectionStart == -1 {
+		log.Fatalf("Section %s not found in command %s", section, command)
+	}
 
-    var ret []string
-    ret = append(ret, lines[sectionStart])
-    for i := sectionStart + 1; i < len(lines); i++ {
-        indent := countIndent(lines[i])
-        if len(lines[i]) != 0 && indent == 0 && lines[i][len(lines[i])-1] == ':' {
-            // new section has started
-            break
-        }
-        ret = append(ret, lines[i])
-    }
-    return ret
+	var ret []string
+	ret = append(ret, lines[sectionStart])
+	for i := sectionStart + 1; i < len(lines); i++ {
+		indent := countIndent(lines[i])
+		if len(lines[i]) != 0 && indent == 0 && lines[i][len(lines[i])-1] == ':' {
+			// new section has started
+			break
+		}
+		ret = append(ret, lines[i])
+	}
+	return ret
 }

--- a/internal/replace-commands-help/main.go
+++ b/internal/replace-commands-help/main.go
@@ -46,7 +46,7 @@ func main() {
 }
 
 func kluctlMain() {
-	commands.Execute()
+	commands.Main()
 }
 
 func processFile(path string) {

--- a/main.go
+++ b/main.go
@@ -24,5 +24,5 @@ var version = "0.0.0"
 
 func main() {
 	version2.SetVersion(version)
-	commands.Execute()
+	commands.Main()
 }

--- a/pkg/kluctl_project/target_context.go
+++ b/pkg/kluctl_project/target_context.go
@@ -80,7 +80,7 @@ func (p *LoadedKluctlProject) NewTargetContext(ctx context.Context, params Targe
 	var k *k8s.K8sCluster
 	if clientConfig != nil {
 		s := status.Start(ctx, fmt.Sprintf("Initializing k8s client"))
-		clientFactory, err := k8s.NewClientFactory(clientConfig)
+		clientFactory, err := k8s.NewClientFactory(ctx, clientConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -284,7 +284,7 @@ func (rh *RegistryHelper) realmFromRequest(req *http.Request) string {
 }
 
 func (rh *RegistryHelper) getCachePath(key string) string {
-	return filepath.Join(utils.GetTmpBaseDir(), "registries-cache", key[0:2], key[2:4], key)
+	return filepath.Join(utils.GetTmpBaseDir(rh.ctx), "registries-cache", key[0:2], key[2:4], key)
 }
 
 func (rh *RegistryHelper) checkInvalidToken(resBody []byte) bool {

--- a/pkg/repocache/cache.go
+++ b/pkg/repocache/cache.go
@@ -87,7 +87,7 @@ func (rp *GitRepoCache) GetEntry(url git_url.GitUrl) (*CacheEntry, error) {
 
 	e, ok := rp.repos[url.NormalizedRepoKey()]
 	if !ok {
-		mr, err := git.NewMirroredGitRepo(rp.ctx, url, filepath.Join(utils.GetTmpBaseDir(), "git-cache"), rp.sshPool, rp.authProviders)
+		mr, err := git.NewMirroredGitRepo(rp.ctx, url, filepath.Join(utils.GetTmpBaseDir(rp.ctx), "git-cache"), rp.sshPool, rp.authProviders)
 		if err != nil {
 			return nil, err
 		}
@@ -198,7 +198,7 @@ func (e *CacheEntry) GetClonedDir(ref string) (string, git.CheckoutInfo, error) 
 		return "", git.CheckoutInfo{}, err
 	}
 
-	tmpDir := filepath.Join(utils.GetTmpBaseDir(), "git-cloned")
+	tmpDir := filepath.Join(utils.GetTmpBaseDir(e.rp.ctx), "git-cloned")
 	err = os.MkdirAll(tmpDir, 0700)
 	if err != nil {
 		return "", git.CheckoutInfo{}, err

--- a/pkg/sops/utils.go
+++ b/pkg/sops/utils.go
@@ -2,6 +2,7 @@ package sops
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
@@ -60,8 +61,8 @@ func MaybeDecryptFileTo(decrypter SopsDecrypter, path string, to string) error {
 	return nil
 }
 
-func MaybeDecryptFileToTmp(decrypter SopsDecrypter, path string) (string, error) {
-	tmp, err := os.CreateTemp(utils.GetTmpBaseDir(), "sops-decrypt-")
+func MaybeDecryptFileToTmp(ctx context.Context, decrypter SopsDecrypter, path string) (string, error) {
+	tmp, err := os.CreateTemp(utils.GetTmpBaseDir(ctx), "sops-decrypt-")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/utils/term/term_size.go
+++ b/pkg/utils/term/term_size.go
@@ -15,7 +15,7 @@ func GetWidth() int {
 		}
 	}
 	w, _, err := GetSize(int(origStdout.Fd()))
-	if err != nil {
+	if err != nil || w == 0 {
 		return 80
 	}
 	return w

--- a/pkg/utils/tmpdir.go
+++ b/pkg/utils/tmpdir.go
@@ -1,0 +1,98 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+type tmpBaseDirKey int
+type tmpBaseDirValue struct {
+	dir      string
+	initOnce sync.Once
+}
+
+var tmpBaseDirKeyInst tmpBaseDirKey
+var tmpBaseDirValueDefault = &tmpBaseDirValue{
+	dir: getDefaultTmpBaseDir(),
+}
+
+func WithTmpBaseDir(ctx context.Context, tmpBaseDir string) context.Context {
+	return context.WithValue(ctx, tmpBaseDirKeyInst, &tmpBaseDirValue{
+		dir: tmpBaseDir,
+	})
+}
+
+func GetTmpBaseDir(ctx context.Context) string {
+	v := ctx.Value(tmpBaseDirKeyInst)
+	if v == nil {
+		v = tmpBaseDirValueDefault
+	}
+	v2 := v.(*tmpBaseDirValue)
+	v2.initOnce.Do(func() {
+		v2.dir = createTmpBaseDir(v2.dir)
+	})
+	return v2.dir
+}
+
+func getDefaultTmpBaseDir() string {
+	dir := os.Getenv("KLUCTL_BASE_TMP_DIR")
+	if dir != "" {
+		return dir
+	}
+
+	return filepath.Join(os.TempDir(), "kluctl-workdir")
+}
+
+func createTmpBaseDir(dir string) string {
+	ensureDir(dir, 0o777, true)
+
+	// every user gets its own tmp dir
+	if runtime.GOOS == "windows" {
+		u, err := user.Current()
+		if err != nil {
+			panic(err)
+		}
+		dir = filepath.Join(dir, u.Uid)
+	} else {
+		uid := os.Getuid()
+		dir = filepath.Join(dir, fmt.Sprintf("%d", uid))
+	}
+
+	ensureDir(dir, 0o700, true)
+	return dir
+}
+
+func ensureDir(path string, perm fs.FileMode, allowCreate bool) {
+	if Exists(path) {
+		st, err := os.Lstat(path)
+		if err != nil {
+			panic(err)
+		}
+		if !st.IsDir() {
+			panic(fmt.Sprintf("%s is not a directory", path))
+		}
+		if st.Mode().Perm() != perm {
+			err = os.Chmod(path, perm)
+			if err != nil {
+				panic(err)
+			}
+		}
+	} else if !allowCreate {
+		panic(fmt.Sprintf("failed to ensure directory %s", path))
+	} else {
+		err := os.Mkdir(path, perm)
+		if err != nil {
+			if os.IsExist(err) {
+				ensureDir(path, perm, false)
+			} else {
+				panic(err)
+			}
+		}
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,83 +3,9 @@ package utils
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"github.com/jinzhu/copier"
-	"io/fs"
-	"os"
-	"os/user"
-	"path/filepath"
-	"runtime"
 	"strconv"
-	"sync"
 )
-
-var createTmpBaseDirOnce sync.Once
-var tmpBaseDir string
-
-func GetTmpBaseDir() string {
-	createTmpBaseDirOnce.Do(func() {
-		createTmpBaseDir()
-	})
-	return tmpBaseDir
-}
-
-func createTmpBaseDir() {
-	envTmpDir := os.Getenv("KLUCTL_BASE_TMP_DIR")
-	if envTmpDir != "" {
-		tmpBaseDir = envTmpDir
-		return
-	}
-
-	dir := filepath.Join(os.TempDir(), "kluctl-workdir")
-
-	ensureDir(dir, 0o777, true)
-
-	// every user gets its own tmp dir
-	if runtime.GOOS == "windows" {
-		u, err := user.Current()
-		if err != nil {
-			panic(err)
-		}
-		dir = filepath.Join(dir, u.Uid)
-	} else {
-		uid := os.Getuid()
-		dir = filepath.Join(dir, fmt.Sprintf("%d", uid))
-	}
-
-	ensureDir(dir, 0o700, true)
-
-	tmpBaseDir = dir
-}
-
-func ensureDir(path string, perm fs.FileMode, allowCreate bool) {
-	if Exists(path) {
-		st, err := os.Lstat(path)
-		if err != nil {
-			panic(err)
-		}
-		if !st.IsDir() {
-			panic(fmt.Sprintf("%s is not a directory", path))
-		}
-		if st.Mode().Perm() != perm {
-			err = os.Chmod(path, perm)
-			if err != nil {
-				panic(err)
-			}
-		}
-	} else if !allowCreate {
-		panic(fmt.Sprintf("failed to ensure directory %s", path))
-	} else {
-		err := os.Mkdir(path, perm)
-		if err != nil {
-			if os.IsExist(err) {
-				ensureDir(path, perm, false)
-			} else {
-				panic(err)
-			}
-		}
-	}
-}
 
 func Sha256String(data string) string {
 	return Sha256Bytes([]byte(data))


### PR DESCRIPTION
# Description

This PR performs multiple refactorings to allow execution of Kluctl commands without being called from main(). It then changes the e2e tests to directly call commands.Execute() and finally tries to fix flakiness in the hooks tests.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
