### PR TITLE
feat: Don't force-replace objects marked with kluctl.io/skip-delete

### DIFF
--- a/e2e/skip_delete_test.go
+++ b/e2e/skip_delete_test.go
@@ -1,0 +1,132 @@
+package e2e
+
+import (
+	test_utils "github.com/kluctl/kluctl/v2/e2e/test-utils"
+	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestSkipDelete(t *testing.T) {
+	t.Parallel()
+
+	k := defaultCluster1
+
+	p := test_utils.NewTestProject(t)
+
+	createNamespace(t, k, p.TestSlug())
+
+	p.UpdateTarget("test", nil)
+
+	addConfigMapDeployment(p, "cm1", map[string]string{}, resourceOpts{
+		name:      "cm1",
+		namespace: p.TestSlug(),
+	})
+	addConfigMapDeployment(p, "cm2", map[string]string{}, resourceOpts{
+		name:      "cm2",
+		namespace: p.TestSlug(),
+	})
+	addConfigMapDeployment(p, "cm3", map[string]string{}, resourceOpts{
+		name:      "cm3",
+		namespace: p.TestSlug(),
+		annotations: map[string]string{
+			"kluctl.io/skip-delete": "true",
+		},
+	})
+	addConfigMapDeployment(p, "cm4", map[string]string{}, resourceOpts{
+		name:      "cm4",
+		namespace: p.TestSlug(),
+		annotations: map[string]string{
+			"helm.sh/resource-policy": "keep",
+		},
+	})
+
+	p.KluctlMust("deploy", "--yes", "-t", "test")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+	cm2 := assertConfigMapExists(t, k, p.TestSlug(), "cm2")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm3")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm4")
+
+	cm2.SetK8sAnnotation("kluctl.io/skip-delete", "true")
+	updateObject(t, k, cm2)
+
+	p.KluctlMust("delete", "--yes", "-t", "test")
+	assertConfigMapNotExists(t, k, p.TestSlug(), "cm1")
+	cm2 = assertConfigMapExists(t, k, p.TestSlug(), "cm2")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm3")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm4")
+
+	p.KluctlMust("deploy", "--yes", "-t", "test")
+	cm1 := assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+	cm1.SetK8sAnnotation("kluctl.io/skip-delete", "true")
+	cm2.SetK8sAnnotation("kluctl.io/skip-delete", "false")
+	updateObject(t, k, cm1)
+	updateObject(t, k, cm2)
+	p.DeleteKustomizeDeployment("cm1")
+	p.DeleteKustomizeDeployment("cm2")
+	p.DeleteKustomizeDeployment("cm3")
+	p.KluctlMust("prune", "--yes", "-t", "test")
+	cm1 = assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+	assertConfigMapNotExists(t, k, p.TestSlug(), "cm2")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm3")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm4")
+}
+
+func TestForceReplaceSkipDelete(t *testing.T) {
+	t.Parallel()
+
+	k := defaultCluster1
+
+	p := test_utils.NewTestProject(t)
+
+	createNamespace(t, k, p.TestSlug())
+
+	p.UpdateTarget("test", nil)
+
+	addConfigMapDeployment(p, "cm1", map[string]string{
+		"k1": "v1",
+	}, resourceOpts{
+		name:      "cm1",
+		namespace: p.TestSlug(),
+		annotations: map[string]string{
+			"kluctl.io/skip-delete": "true",
+		},
+	})
+
+	p.KluctlMust("deploy", "--yes", "-t", "test")
+	cm1 := assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+	assert.Equal(t, map[string]any{
+		"k1": "v1",
+	}, cm1.Object["data"])
+
+	p.UpdateYaml("cm1/configmap-cm1.yml", func(o *uo.UnstructuredObject) error {
+		_ = o.SetNestedField("v2", "data", "k1")
+		return nil
+	}, "")
+
+	p.KluctlMust("deploy", "--yes", "-t", "test")
+	cm1 = assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+	assert.Equal(t, map[string]any{
+		"k1": "v2",
+	}, cm1.Object["data"])
+
+	invalidLabel := "invalid_label_" + strings.Repeat("x", 63)
+	p.UpdateYaml("cm1/configmap-cm1.yml", func(o *uo.UnstructuredObject) error {
+		o.SetK8sLabel(invalidLabel, "invalid_label")
+		return nil
+	}, "")
+	stdout, _, err := p.Kluctl("deploy", "--yes", "-t", "test")
+	assert.Error(t, err)
+	assert.Contains(t, stdout, "invalid: metadata.labels")
+	// make sure it did not try to replace it
+	assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+
+	stdout, stderr, err := p.Kluctl("deploy", "--yes", "-t", "test", "--force-replace-on-error")
+	assert.Error(t, err)
+	assert.Contains(t, stdout, "retrying with replace instead of patch")
+	assert.Contains(t, stderr, "skipped forced replace")
+	assert.Contains(t, stdout, "invalid: metadata.labels")
+	// make sure it did not try to replace it
+	assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+}

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"github.com/kluctl/kluctl/v2/e2e/test-utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
+	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"reflect"
 	"testing"
 )
@@ -52,4 +54,12 @@ func assertNestedFieldEquals(t *testing.T, o *uo.UnstructuredObject, expected in
 	if !reflect.DeepEqual(v, expected) {
 		t.Fatalf("%v != %v", v, expected)
 	}
+}
+
+func updateObject(t *testing.T, k *test_utils.EnvTestCluster, o *uo.UnstructuredObject) {
+	_, err := k.DynamicClient.Resource(schema.GroupVersionResource{
+		Version:  "v1",
+		Resource: "configmaps",
+	}).Namespace(o.GetK8sNamespace()).Update(context.Background(), o.ToUnstructured(), metav1.UpdateOptions{})
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
# Description

This PR makes Kluctl honor `kluctl.io/skip-delete` and `helm.sh/resource-policy` when using it with `--force-replace-on-error`.

Fixes #148

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
