### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/git/test_git_server.go
+++ b/pkg/git/test_git_server.go
@@ -3,10 +3,6 @@ package git
 import (
 	"context"
 	"fmt"
-	"github.com/fluxcd/go-git/v5"
-	"github.com/jinzhu/copier"
-	http_server "github.com/kluctl/kluctl/v2/pkg/git/http-server"
-	"gopkg.in/yaml.v3"
 	"log"
 	"net"
 	"net/http"
@@ -14,6 +10,11 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/fluxcd/go-git/v5"
+	"github.com/jinzhu/copier"
+	http_server "github.com/kluctl/kluctl/v2/pkg/git/http-server"
+	"gopkg.in/yaml.v3"
 )
 
 type TestGitServer struct {
@@ -28,14 +29,9 @@ type TestGitServer struct {
 
 func NewTestGitServer(t *testing.T) *TestGitServer {
 	p := &TestGitServer{
-		t: t,
+		t:       t,
+		baseDir: t.TempDir(),
 	}
-
-	baseDir, err := os.MkdirTemp(os.TempDir(), "kluctl-tests-")
-	if err != nil {
-		p.t.Fatal(err)
-	}
-	p.baseDir = baseDir
 
 	p.initGitServer()
 
@@ -73,10 +69,6 @@ func (p *TestGitServer) Cleanup() {
 		p.gitServer = nil
 	}
 
-	if p.baseDir == "" {
-		return
-	}
-	_ = os.RemoveAll(p.baseDir)
 	p.baseDir = ""
 }
 


### PR DESCRIPTION
# Description

A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.  This saves us at least 2 lines (error check, and cleanup) on every instance.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	assert.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```

## Type of change

- [x] Refactoring

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
