### PR TITLE
fix: Use correct .helm-charts dir when using git includes

### DIFF
--- a/cmd/kluctl/commands/cmd_helm_update.go
+++ b/cmd/kluctl/commands/cmd_helm_update.go
@@ -40,7 +40,7 @@ func (cmd *helmUpdateCmd) Run(ctx context.Context) error {
 	}
 
 	if !yaml.Exists(filepath.Join(projectDir, ".kluctl.yaml")) {
-		return fmt.Errorf("helm-pull can only be used on the root of a Kluctl project that must have a .kluctl.yaml file")
+		return fmt.Errorf("helm-update can only be used on the root of a Kluctl project that must have a .kluctl.yaml file")
 	}
 
 	gitRootPath, err := git2.DetectGitRepositoryRoot(projectDir)

--- a/pkg/deployment/shared_context.go
+++ b/pkg/deployment/shared_context.go
@@ -21,5 +21,4 @@ type SharedContext struct {
 	RenderDir                         string
 	SealedSecretsDir                  string
 	DefaultSealedSecretsOutputPattern string
-	HelmChartsDir                     string
 }

--- a/pkg/kluctl_project/project.go
+++ b/pkg/kluctl_project/project.go
@@ -20,7 +20,6 @@ type LoadedKluctlProject struct {
 	ProjectDir     string
 
 	sealedSecretsDir string
-	helmChartsDir    string
 
 	Config         types2.KluctlProject
 	DynamicTargets []*types2.DynamicTarget

--- a/pkg/kluctl_project/project_load.go
+++ b/pkg/kluctl_project/project_load.go
@@ -61,7 +61,6 @@ func (c *LoadedKluctlProject) loadKluctlProject() error {
 	}
 
 	c.sealedSecretsDir = filepath.Join(c.ProjectDir, ".sealed-secrets")
-	c.helmChartsDir = filepath.Join(c.ProjectDir, ".helm-charts")
 
 	sealedSecretsUsed := false
 	if c.Config.SecretsConfig != nil {

--- a/pkg/kluctl_project/target_context.go
+++ b/pkg/kluctl_project/target_context.go
@@ -113,7 +113,6 @@ func (p *LoadedKluctlProject) NewTargetContext(ctx context.Context, params Targe
 		RenderDir:                         params.RenderOutputDir,
 		SealedSecretsDir:                  p.sealedSecretsDir,
 		DefaultSealedSecretsOutputPattern: target.Name,
-		HelmChartsDir:                     p.helmChartsDir,
 	}
 
 	d, err := deployment.NewDeploymentProject(dctx, varsCtx, deployment.NewSource(deploymentDir), ".", nil)


### PR DESCRIPTION
# Description

We should use the .helm-charts dir from the included repository and not from the local one.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
