### PR TITLE
fix: Fix globals flags being ignored when specified via env variables

### DIFF
--- a/cmd/kluctl/commands/root.go
+++ b/cmd/kluctl/commands/root.go
@@ -223,7 +223,7 @@ func Main() {
 
 	initViper(ctx)
 
-	err := Execute(ctx, os.Args[1:], func(ctxIn context.Context, cmd *cobra.Command, flags GlobalFlags) (context.Context, error) {
+	err := Execute(ctx, os.Args[1:], func(ctxIn context.Context, cmd *cobra.Command, flags *GlobalFlags) (context.Context, error) {
 		err := copyViperValuesToCobraCmd(cmd)
 		if err != nil {
 			return ctx, err
@@ -257,7 +257,7 @@ func Main() {
 	}
 }
 
-func Execute(ctx context.Context, args []string, preRun func(ctx context.Context, rootCmd *cobra.Command, flags GlobalFlags) (context.Context, error)) error {
+func Execute(ctx context.Context, args []string, preRun func(ctx context.Context, rootCmd *cobra.Command, flags *GlobalFlags) (context.Context, error)) error {
 	root := cli{}
 	rootCmd, err := buildRootCobraCmd(&root, "kluctl",
 		"Deploy and manage complex deployments on Kubernetes",
@@ -277,7 +277,7 @@ composed of multiple smaller parts (Helm/Kustomize/...) in a manageable and unif
 
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		if preRun != nil {
-			ctx, err = preRun(ctx, cmd, root.GlobalFlags)
+			ctx, err = preRun(ctx, cmd, &root.GlobalFlags)
 			if ctx != nil {
 				for c := cmd; c != nil; c = c.Parent() {
 					c.SetContext(ctx)


### PR DESCRIPTION
# Description

GlobalFlags must be passed as pointer as otherwise updates to the flags via `copyViperValuesToCobraCmd` are not reflected into GlobalFlags.

Fixes #225 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
