### PR TITLE
fix: Also obfuscate secrets when data/stringData was empty before

### DIFF
--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -204,7 +204,10 @@ func outputCommandResult(ctx context.Context, output []string, noObfuscate bool,
 	if !noObfuscate {
 		var obfuscator diff.Obfuscator
 		for _, c := range cr.ChangedObjects {
-			obfuscator.Obfuscate(c.Ref, c.Changes)
+			err := obfuscator.Obfuscate(c.Ref, c.Changes)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/e2e/obfuscate_test.go
+++ b/e2e/obfuscate_test.go
@@ -25,16 +25,25 @@ func TestObfuscateSecrets(t *testing.T) {
 		name:      "secret",
 		namespace: p.TestSlug(),
 	}, false)
+	addSecretDeployment(p, "secret2", nil, resourceOpts{
+		name:      "secret2",
+		namespace: p.TestSlug(),
+	}, false)
+	addSecretDeployment(p, "secret3", nil, resourceOpts{
+		name:      "secret3",
+		namespace: p.TestSlug(),
+	}, false)
+
 	stdout, _ := p.KluctlMust("deploy", "--yes", "-t", "test")
 	assertSecretExists(t, k, p.TestSlug(), "secret")
-	assert.NotContains(t, stdout, "secret_value")
+	assert.NotContains(t, stdout, base64.StdEncoding.EncodeToString([]byte("secret_value")))
 
 	p.UpdateYaml("secret/secret-secret.yml", func(o *uo.UnstructuredObject) error {
 		_ = o.SetNestedField("secret_value_2", "stringData", "secret")
 		return nil
 	}, "")
 	stdout, _ = p.KluctlMust("deploy", "--yes", "-t", "test")
-	assert.NotContains(t, stdout, "secret_value")
+	assert.NotContains(t, stdout, base64.StdEncoding.EncodeToString([]byte("secret_value")))
 	assert.Contains(t, stdout, "***** (obfuscated)")
 
 	p.UpdateYaml("secret/secret-secret.yml", func(o *uo.UnstructuredObject) error {
@@ -45,4 +54,29 @@ func TestObfuscateSecrets(t *testing.T) {
 	assert.Contains(t, stdout, "-"+base64.StdEncoding.EncodeToString([]byte("secret_value_2")))
 	assert.Contains(t, stdout, "+"+base64.StdEncoding.EncodeToString([]byte("secret_value_3")))
 	assert.NotContains(t, stdout, "***** (obfuscated)")
+
+	// also test changing from empty data to filled data
+	p.UpdateYaml("secret2/secret-secret2.yml", func(o *uo.UnstructuredObject) error {
+		_ = o.SetNestedField(map[string]any{
+			"secret2": "secret_value_2",
+		}, "stringData")
+		return nil
+	}, "")
+
+	stdout, _ = p.KluctlMust("deploy", "--yes", "-t", "test")
+	assert.NotContains(t, stdout, base64.StdEncoding.EncodeToString([]byte("secret_value_2")))
+	assert.Contains(t, stdout, "+secret2: '***** (obfuscated)'")
+
+	p.UpdateYaml("secret3/secret-secret3.yml", func(o *uo.UnstructuredObject) error {
+		_ = o.SetNestedField(map[string]any{
+			"secret3": "secret_value_3",
+			"secret4": "secret_value_4",
+		}, "stringData")
+		return nil
+	}, "")
+	stdout, _ = p.KluctlMust("deploy", "--yes", "-t", "test")
+	assert.NotContains(t, stdout, base64.StdEncoding.EncodeToString([]byte("secret_value_3")))
+	assert.NotContains(t, stdout, base64.StdEncoding.EncodeToString([]byte("secret_value_4")))
+	assert.Contains(t, stdout, "+secret3: '***** (obfuscated)'")
+	assert.Contains(t, stdout, "+secret4: '***** (obfuscated)'")
 }

--- a/e2e/obfuscate_test.go
+++ b/e2e/obfuscate_test.go
@@ -79,4 +79,17 @@ func TestObfuscateSecrets(t *testing.T) {
 	assert.NotContains(t, stdout, base64.StdEncoding.EncodeToString([]byte("secret_value_4")))
 	assert.Contains(t, stdout, "+secret3: '***** (obfuscated)'")
 	assert.Contains(t, stdout, "+secret4: '***** (obfuscated)'")
+
+	p.UpdateYaml("secret3/secret-secret3.yml", func(o *uo.UnstructuredObject) error {
+		_ = o.SetNestedField(map[string]any{
+			"secret.dot1": "secret_value_5",
+			"secret.dot2": "secret_value_6",
+		}, "stringData")
+		return nil
+	}, "")
+	stdout, _ = p.KluctlMust("deploy", "--yes", "-t", "test")
+	assert.NotContains(t, stdout, base64.StdEncoding.EncodeToString([]byte("secret_value_5")))
+	assert.NotContains(t, stdout, base64.StdEncoding.EncodeToString([]byte("secret_value_6")))
+	assert.Contains(t, stdout, "data[\"secret.dot1\"] | +***** (obfuscated)")
+	assert.Contains(t, stdout, "data[\"secret.dot2\"] | +***** (obfuscated)")
 }

--- a/pkg/diff/obfuscate.go
+++ b/pkg/diff/obfuscate.go
@@ -19,6 +19,18 @@ func (o *Obfuscator) Obfuscate(ref k8s.ObjectRef, changes []types.Change) {
 }
 
 func (o *Obfuscator) obfuscateSecret(ref k8s.ObjectRef, changes []types.Change) {
+	setMapValues := func(m any, v string) {
+		if m == nil {
+			return
+		}
+		m2, ok := m.(map[string]any)
+		if ok {
+			for k, _ := range m2 {
+				m2[k] = v
+			}
+		}
+	}
+
 	for i, _ := range changes {
 		c := &changes[i]
 		if strings.HasPrefix(c.JsonPath, "data.") || strings.HasPrefix(c.JsonPath, "stringData.") {
@@ -37,6 +49,14 @@ func (o *Obfuscator) obfuscateSecret(ref k8s.ObjectRef, changes []types.Change) 
 				c.OldValue = "*****"
 				c.UnifiedDiff = strings.ReplaceAll(c.UnifiedDiff, "*****b", "***** (obfuscated)")
 			}
+		} else if c.JsonPath == "data" || c.JsonPath == "stringData" {
+			setMapValues(c.NewValue, "*****a")
+			setMapValues(c.OldValue, "*****b")
+			_ = updateUnifiedDiff(c)
+			c.UnifiedDiff = strings.ReplaceAll(c.UnifiedDiff, "*****a", "***** (obfuscated)")
+			c.UnifiedDiff = strings.ReplaceAll(c.UnifiedDiff, "*****b", "***** (obfuscated)")
+			setMapValues(c.NewValue, "*****")
+			setMapValues(c.OldValue, "*****")
 		}
 	}
 }

--- a/pkg/diff/obfuscate.go
+++ b/pkg/diff/obfuscate.go
@@ -1,8 +1,10 @@
 package diff
 
 import (
+	"fmt"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/ohler55/ojg/jp"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"strings"
 )
@@ -12,51 +14,58 @@ var secretGvk = schema.GroupKind{Group: "", Kind: "Secret"}
 type Obfuscator struct {
 }
 
-func (o *Obfuscator) Obfuscate(ref k8s.ObjectRef, changes []types.Change) {
+func (o *Obfuscator) Obfuscate(ref k8s.ObjectRef, changes []types.Change) error {
 	if ref.GVK.GroupKind() == secretGvk {
-		o.obfuscateSecret(ref, changes)
+		err := o.obfuscateSecret(ref, changes)
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-func (o *Obfuscator) obfuscateSecret(ref k8s.ObjectRef, changes []types.Change) {
-	setMapValues := func(m any, v string) {
-		if m == nil {
-			return
+func (o *Obfuscator) obfuscateSecret(ref k8s.ObjectRef, changes []types.Change) error {
+	replaceValues := func(x any, v string) any {
+		if x == nil {
+			return nil
 		}
-		m2, ok := m.(map[string]any)
-		if ok {
-			for k, _ := range m2 {
-				m2[k] = v
+		if m, ok := x.(map[string]any); ok {
+			for k, _ := range m {
+				m[k] = v
 			}
+			return m
+		} else if a, ok := x.([]any); ok {
+			for i, _ := range a {
+				a[i] = v
+			}
+			return a
 		}
+		return v
 	}
 
 	for i, _ := range changes {
 		c := &changes[i]
-		if strings.HasPrefix(c.JsonPath, "data.") || strings.HasPrefix(c.JsonPath, "stringData.") {
-			if c.NewValue != nil {
-				c.NewValue = "*****a"
-			}
-			if c.OldValue != nil {
-				c.OldValue = "*****b"
-			}
+		j, err := jp.ParseString(c.JsonPath)
+		if err != nil {
+			return err
+		}
+		if len(j) == 0 {
+			return fmt.Errorf("unexpected empty jsonPath")
+		}
+		child, ok := j[0].(jp.Child)
+		if !ok {
+			return fmt.Errorf("unexpected jsonPath fragment: %s", c.JsonPath)
+		}
+
+		if child == "data" || child == "stringData" {
+			c.NewValue = replaceValues(c.NewValue, "*****a")
+			c.OldValue = replaceValues(c.OldValue, "*****b")
 			_ = updateUnifiedDiff(c)
-			if c.NewValue != nil {
-				c.NewValue = "*****"
-				c.UnifiedDiff = strings.ReplaceAll(c.UnifiedDiff, "*****a", "***** (obfuscated)")
-			}
-			if c.OldValue != nil {
-				c.OldValue = "*****"
-				c.UnifiedDiff = strings.ReplaceAll(c.UnifiedDiff, "*****b", "***** (obfuscated)")
-			}
-		} else if c.JsonPath == "data" || c.JsonPath == "stringData" {
-			setMapValues(c.NewValue, "*****a")
-			setMapValues(c.OldValue, "*****b")
-			_ = updateUnifiedDiff(c)
+			c.NewValue = replaceValues(c.NewValue, "*****")
+			c.OldValue = replaceValues(c.OldValue, "*****")
 			c.UnifiedDiff = strings.ReplaceAll(c.UnifiedDiff, "*****a", "***** (obfuscated)")
 			c.UnifiedDiff = strings.ReplaceAll(c.UnifiedDiff, "*****b", "***** (obfuscated)")
-			setMapValues(c.NewValue, "*****")
-			setMapValues(c.OldValue, "*****")
 		}
 	}
+	return nil
 }


### PR DESCRIPTION
# Description

A secret that was empty before must also be obfuscated. Previously, this was omitted as it did not match the `data.` path prefix.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
