### PR TITLE
Add tests for parsing ARNs and throw an error when using wildcard

### DIFF
--- a/pkg/vars/aws/arn.go
+++ b/pkg/vars/aws/arn.go
@@ -17,6 +17,9 @@ type Arn struct {
 
 func ParseArn(arn string) (Arn, error) {
 	// http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
+	if strings.Contains(arn, "*") {
+		return Arn{}, fmt.Errorf("%s is not a valid ARN. Use of wildcard is not allowed", arn)
+	}
 	elements := strings.SplitN(arn, ":", 6)
 	if len(elements) < 6 {
 		return Arn{}, fmt.Errorf("%s is not a valid arn", arn)

--- a/pkg/vars/aws/arn.go
+++ b/pkg/vars/aws/arn.go
@@ -22,7 +22,7 @@ func ParseArn(arn string) (Arn, error) {
 	}
 	elements := strings.SplitN(arn, ":", 6)
 	if len(elements) < 6 {
-		return Arn{}, fmt.Errorf("%s is not a valid arn", arn)
+		return Arn{}, fmt.Errorf("%s is not a valid ARN. Too few components", arn)
 	}
 	var result Arn
 	result.Arn = elements[0]

--- a/pkg/vars/aws/arn_test.go
+++ b/pkg/vars/aws/arn_test.go
@@ -1,0 +1,57 @@
+package aws
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseArn(t *testing.T) {
+	arns := map[string]Arn{
+		//Full ARN
+		"arn:aws:iam:eu-central-1:123456789012:user/Development/product_1234": {
+			Arn:          "arn",
+			Partition:    "aws",
+			Service:      "iam",
+			Region:       "eu-central-1",
+			Account:      "123456789012",
+			Resource:     "Development/product_1234",
+			ResourceType: "user",
+		},
+		//ARN without region
+		"arn:aws:iam::123456789012:user/Development/product_1234": {
+			Arn:          "arn",
+			Partition:    "aws",
+			Service:      "iam",
+			Region:       "",
+			Account:      "123456789012",
+			Resource:     "Development/product_1234",
+			ResourceType: "user",
+		},
+		//ARN without resource type
+		"arn:aws:iam:eu-central-1:123456789012:i-1234567890abcdef0": {
+			Arn:          "arn",
+			Partition:    "aws",
+			Service:      "iam",
+			Region:       "eu-central-1",
+			Account:      "123456789012",
+			Resource:     "i-1234567890abcdef0",
+			ResourceType: "",
+		},
+	}
+	for strArn, expectedArn := range arns {
+		resultArn, err := ParseArn(strArn)
+		if err != nil {
+			t.Errorf("Can't parse ARN: %s", strArn)
+		}
+		if !reflect.DeepEqual(resultArn, expectedArn) {
+			t.Errorf("ARNs should match but %s != %s", resultArn, expectedArn)
+		}
+	}
+
+	//Check error when using wildcards
+	incorrectArn := "arn:aws:iam:eu-central-1:123456789012:user/Development/product_1234/*"
+	_, err := ParseArn(incorrectArn)
+	if err == nil {
+		t.Errorf("ARN uses wildcard and should throw an error: %s", incorrectArn)
+	}
+}


### PR DESCRIPTION
# Description

In order to improve test coverage, this PR adds tests for parsing ARNs. Additionally, it adds error handling when an ARN with a wildcard is used because at this point only unambiguous ARNs are allowed.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] New tests (non-breaking change which adds tests)


All Submissions:

* [ ] A corresponding issue exists
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] Have you lint your code locally before submission?
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream modules
* [x] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
