### PR TITLE
fix: Don't crash when encountering nil maps in SetNestedField

### DIFF
--- a/pkg/utils/uo/nested_fields.go
+++ b/pkg/utils/uo/nested_fields.go
@@ -28,7 +28,7 @@ func (uo *UnstructuredObject) SetNestedField(value interface{}, keys ...interfac
 		if err != nil {
 			return err
 		}
-		if ok {
+		if ok && val != nil {
 			o = val
 		} else {
 			newVal := make(map[string]interface{})


### PR DESCRIPTION
# Description

This caused a crash when a resource had things like this included:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: test
  labels: # notice that this is empty/nil
  annotations:
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
