### PR TITLE
fix: Only query for known GroupKinds when calling validate

### DIFF
--- a/pkg/deployment/commands/delete.go
+++ b/pkg/deployment/commands/delete.go
@@ -42,7 +42,7 @@ func (cmd *DeleteCommand) Run(ctx context.Context, k *k8s.K8sCluster) ([]k8s2.Ob
 		inclusion = cmd.c.Inclusion
 	}
 
-	err := ru.UpdateRemoteObjects(k, labels, nil)
+	err := ru.UpdateRemoteObjects(k, labels, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployment/commands/deploy.go
+++ b/pkg/deployment/commands/deploy.go
@@ -30,7 +30,7 @@ func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResult
 	dew := utils2.NewDeploymentErrorsAndWarnings()
 
 	ru := utils2.NewRemoteObjectsUtil(ctx, dew)
-	err := ru.UpdateRemoteObjects(k, cmd.c.Project.GetCommonLabels(), cmd.c.LocalObjectRefs())
+	err := ru.UpdateRemoteObjects(k, cmd.c.Project.GetCommonLabels(), cmd.c.LocalObjectRefs(), false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployment/commands/diff.go
+++ b/pkg/deployment/commands/diff.go
@@ -29,7 +29,7 @@ func (cmd *DiffCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*types.Comm
 	dew := utils.NewDeploymentErrorsAndWarnings()
 
 	ru := utils.NewRemoteObjectsUtil(ctx, dew)
-	err := ru.UpdateRemoteObjects(k, cmd.c.Project.GetCommonLabels(), cmd.c.LocalObjectRefs())
+	err := ru.UpdateRemoteObjects(k, cmd.c.Project.GetCommonLabels(), cmd.c.LocalObjectRefs(), false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployment/commands/poke_images.go
+++ b/pkg/deployment/commands/poke_images.go
@@ -28,7 +28,7 @@ func (cmd *PokeImagesCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*type
 	dew := utils2.NewDeploymentErrorsAndWarnings()
 
 	ru := utils2.NewRemoteObjectsUtil(ctx, dew)
-	err := ru.UpdateRemoteObjects(k, cmd.c.Project.GetCommonLabels(), cmd.c.LocalObjectRefs())
+	err := ru.UpdateRemoteObjects(k, nil, cmd.c.LocalObjectRefs(), false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployment/commands/prune.go
+++ b/pkg/deployment/commands/prune.go
@@ -22,7 +22,7 @@ func (cmd *PruneCommand) Run(ctx context.Context, k *k8s.K8sCluster) ([]k8s2.Obj
 	dew := utils2.NewDeploymentErrorsAndWarnings()
 
 	ru := utils2.NewRemoteObjectsUtil(ctx, dew)
-	err := ru.UpdateRemoteObjects(k, cmd.c.Project.GetCommonLabels(), nil)
+	err := ru.UpdateRemoteObjects(k, cmd.c.Project.GetCommonLabels(), nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployment/commands/validate.go
+++ b/pkg/deployment/commands/validate.go
@@ -31,7 +31,7 @@ func (cmd *ValidateCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*types.
 
 	cmd.dew.Init()
 
-	err := cmd.ru.UpdateRemoteObjects(k, cmd.c.Project.GetCommonLabels(), cmd.c.LocalObjectRefs())
+	err := cmd.ru.UpdateRemoteObjects(k, cmd.c.Project.GetCommonLabels(), cmd.c.LocalObjectRefs(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployment/utils/remote_objects_utils_test.go
+++ b/pkg/deployment/utils/remote_objects_utils_test.go
@@ -39,7 +39,7 @@ func TestRemoteObjectUtils_PermissionErrors(t *testing.T) {
 	u := NewRemoteObjectsUtil(context.Background(), dew)
 	err = u.UpdateRemoteObjects(k, map[string]string{"l1": "v1"}, []k8s2.ObjectRef{
 		k8s2.NewObjectRef("", "v1", "Secret", "secret", "default"),
-	})
+	}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, []types.DeploymentError{{
 		Error: "at least one permission error was encountered while gathering objects by labels. This might result in orphan object detection to not work properly"},


### PR DESCRIPTION
# Description

This should remove some load to the apiserver when validate is used periodically (like in the Kluctl Controller).
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
