### PR TITLE
Revert "chore: Download kubebuilder-tools for windows from kubebuilder-tools-releases-windows repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,21 +64,11 @@ setup-envtest: ## Download envtest-setup locally if necessary.
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
 # Download the envtest binaries to testbin
-ENVTEST_KUBERNETES_VERSION?=1.25.0
 ENVTEST_ASSETS_DIR=$(BUILD_DIR)/testbin
-
-ifeq ($(OS),Windows_NT)
-ENVTEST_ASSETS_DIR_WINDOWS=$(ENVTEST_ASSETS_DIR)/k8s/$(ENVTEST_KUBERNETES_VERSION)-windows-amd64
-install-envtest: setup-envtest $(ENVTEST_ASSETS_DIR_WINDOWS)/etcd.exe
-$(ENVTEST_ASSETS_DIR_WINDOWS)/etcd.exe:
-	mkdir -p $(ENVTEST_ASSETS_DIR_WINDOWS)
-	curl -o $(ENVTEST_ASSETS_DIR_WINDOWS)/kubebuilder-tools.tar.gz "https://raw.githubusercontent.com/kluctl/kubebuilder-tools-releases-windows/main/releases/kubebuilder-tools-$(ENVTEST_KUBERNETES_VERSION)_windows_amd64.tar.gz"
-	cd $(ENVTEST_ASSETS_DIR_WINDOWS) && tar xzf kubebuilder-tools.tar.gz && mv kubebuilder/bin/* .
-	rm $(ENVTEST_ASSETS_DIR_WINDOWS)/kubebuilder-tools.tar.gz
-else
+ENVTEST_KUBERNETES_VERSION?=latest
 install-envtest: setup-envtest
+	mkdir -p ${ENVTEST_ASSETS_DIR}
 	$(ENVTEST) use $(ENVTEST_KUBERNETES_VERSION) --arch=$(ENVTEST_ARCH) --bin-dir=$(ENVTEST_ASSETS_DIR)
-endif
 
 ## Test:
 test: test-unit test-e2e ## Runs the complete test suite


### PR DESCRIPTION
# Description

No need to download our own version of kubebuilder-tools for Windows anymore due to https://github.com/kubernetes-sigs/kubebuilder/issues/3005 being finished.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
