### PR TITLE
fix: Fix onlyRender to actually not treat the path as deployment item

### DIFF
--- a/docs/reference/deployments/deployment-yml.md
+++ b/docs/reference/deployments/deployment-yml.md
@@ -196,6 +196,17 @@ deployments:
 - path: kustomizeDeployment2
 ```
 
+### onlyRender
+Causes a path to be rendered only but not treated as a deployment item. This can be useful if you for example want to
+use Kustomize components which you'd refer from other deployment items.
+
+```yaml
+deployments:
+- path: component
+  onlyRender: true
+- path: kustomizeDeployment2
+```
+
 ## vars (deployment project)
 A list of variable sets to be loaded into the templating context, which is then available in all [deployment items](#deployments)
 and [sub-deployments](#includes).

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -494,6 +494,9 @@ func (di *DeploymentItem) buildKustomize() error {
 	if di.dir == nil {
 		return nil
 	}
+	if di.Config.OnlyRender {
+		return nil
+	}
 
 	ky, err := di.prepareKustomizationYaml()
 	if err != nil {

--- a/pkg/git/test_git_server.go
+++ b/pkg/git/test_git_server.go
@@ -183,6 +183,10 @@ func (p *TestGitServer) UpdateFile(repo string, pth string, update func(f string
 	if f == newF {
 		return
 	}
+	err = os.MkdirAll(filepath.Dir(fullPath), 0o700)
+	if err != nil {
+		p.t.Fatal(err)
+	}
 	err = os.WriteFile(fullPath, []byte(newF), 0o600)
 	if err != nil {
 		p.t.Fatal(err)


### PR DESCRIPTION
# Description

`onlyRender` was available since a very long time and was working in the past. Somehow the functionality got lost and due to missing e2e tests this was never discovered. This MR fixes all that, including the missing documentation.

Fixes #275

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
