### PR TITLE
fix: Don't fail known_hosts verification when the key-type doesn't match

### DIFF
--- a/pkg/git/auth/ssh_known_hosts.go
+++ b/pkg/git/auth/ssh_known_hosts.go
@@ -74,9 +74,6 @@ func verifyHost(messageCallbacks messages.MessageCallbacks, host string, remote 
 
 	for _, f := range files {
 		hostFound, err := goph.CheckKnownHost(host, remote, key, f)
-		if hostFound && err != nil {
-			return err
-		}
 		if hostFound && err == nil {
 			return nil
 		}


### PR DESCRIPTION
# Description

This fixes issues when your ~/.ssh/known_hosts file contains entries with with different key types then the ones that Kluctl would end up using. In that case, Kluctl should ask for confirmation instead of bailing out. If confirmed, Kluctl will add another entry in known_hosts that matches the new key type.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
