### PR TITLE
feat: Allow to define fixed images via variable sources and deprecate registry access

### DIFF
--- a/cmd/kluctl/args/images.go
+++ b/cmd/kluctl/args/images.go
@@ -11,7 +11,7 @@ type ImageFlags struct {
 	FixedImage      []string         `group:"images" short:"F" help:"Pin an image to a given version. Expects '--fixed-image=image<:namespace:deployment:container>=result'"`
 	FixedImagesFile existingFileType `group:"images" help:"Use .yaml file to pin image versions. See output of list-images sub-command or read the documentation for details about the output format" exts:"yml,yaml"`
 	UpdateImages    bool             `group:"images" short:"u" help:"This causes kluctl to prefer the latest image found in registries, based on the 'latest_image' filters provided to 'images.get_image(...)' calls. Use this flag if you want to update to the latest versions/tags of all images. '-u' takes precedence over '--fixed-image/--fixed-images-file', meaning that the latest images are used even if an older image is given via fixed images."`
-	OfflineImages   bool             `group:"images" help:"Omit contacting image registries and do not query for latest image tags."`
+	OfflineImages   bool             `group:"images" help:"DEPRECATED: Omit contacting image registries and do not query for latest image tags. This flag is by default set to true. At the same time, the whole requesting of image tags from registries functionality is deprecated and will be removed from kluctl in a future release." default:"true"`
 }
 
 func (args *ImageFlags) LoadFixedImagesFromArgs() ([]types.FixedImage, error) {

--- a/cmd/kluctl/commands/cmd_check_image_updates.go
+++ b/cmd/kluctl/commands/cmd_check_image_updates.go
@@ -19,10 +19,11 @@ type checkImageUpdatesCmd struct {
 }
 
 func (cmd *checkImageUpdatesCmd) Help() string {
-	return `This is based on a best effort approach and might give many false-positives.`
+	return `DEPRECATED: This is based on a best effort approach and might give many false-positives.`
 }
 
 func (cmd *checkImageUpdatesCmd) Run(ctx context.Context) error {
+	status.Deprecation(ctx, "check-image-updates", "check-image-updates is deprecated and will be removed in a future kluctl release.")
 	ptArgs := projectTargetCommandArgs{
 		projectFlags: cmd.ProjectFlags,
 		targetFlags:  cmd.TargetFlags,

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -130,6 +130,12 @@ func withProjectTargetCommandContext(ctx context.Context, args projectTargetComm
 	if err != nil {
 		return fmt.Errorf("failed to parse registry auth from environment: %w", err)
 	}
+	if args.imageFlags.UpdateImages {
+		status.Deprecation(ctx, "update-images", "--update-images is deprecated and will be removed in a future kluctl release.")
+	}
+	if !args.imageFlags.OfflineImages {
+		status.Deprecation(ctx, "online-images", "--offline-images=false is deprecated and will be removed in a future kluctl release.")
+	}
 	images, err := deployment.NewImages(rh, args.imageFlags.UpdateImages, args.imageFlags.OfflineImages || args.forCompletion)
 	if err != nil {
 		return err

--- a/docs/reference/commands/common-arguments.md
+++ b/docs/reference/commands/common-arguments.md
@@ -98,7 +98,10 @@ Image arguments:
                                          '--fixed-image=image<:namespace:deployment:container>=result'
       --fixed-images-file existingfile   Use .yaml file to pin image versions. See output of list-images
                                          sub-command or read the documentation for details about the output format
-      --offline-images                   Omit contacting image registries and do not query for latest image tags.
+      --offline-images                   DEPRECATED: Omit contacting image registries and do not query for latest
+                                         image tags. This flag is by default set to true. At the same time, the
+                                         whole requesting of image tags from registries functionality is
+                                         deprecated and will be removed from kluctl in a future release. (default true)
   -u, --update-images                    This causes kluctl to prefer the latest image found in registries, based
                                          on the 'latest_image' filters provided to 'images.get_image(...)' calls.
                                          Use this flag if you want to update to the latest versions/tags of all

--- a/docs/reference/deployments/images.md
+++ b/docs/reference/deployments/images.md
@@ -13,54 +13,26 @@ description: >
 
 There are usually 2 different scenarios where Container Images need to be specified:
 1. When deploying third party applications like nginx, redis, ... (e.g. via the [Helm integration](./helm.md)). <br>
-   * In this case, image versions/tags rarely change, and if they do, this is an explicit change to the deployment.
-1. When deploying your own applications. <br>
-   * In this case, image versions/tags might change very rapidly, sometimes multiple times per hour. It would be too much
-     effort and overhead when this would be managed explicitly via your deployment. Even with Jinja2 templating, this
-     would be hard to maintain.
+   * In this case, image versions/tags rarely change, and if they do, this is an explicit change to the deployment. This
+     means it's fine to have the image versions/tags directly in the deployment manifests.
+2. When deploying your own applications. <br>
+   * In this case, image versions/tags might change very rapidly, sometimes multiple times per hour. Having these
+     versions/tags directly in the deployment manifests can easily lead to commit spam and hard to manage 
+     multi-environment deployments.
      
 kluctl offers a better solution for the second case.
-
-## Dynamic versions/tags
-
-kluctl is able to ask the used container registry for a list of tags/versions available for an image. It then can
-sort the list of images via a configurable order and then use the latest image for your deployment.
-
-It however only does this when the involved resource (e.g. a `Deployment` or `StatefulSet`) is not yet deployed. In case
-it is already deployed, the already deployed image will be reused to avoid undesired re-deployment/re-starting of
-otherwise unchanged resources.
 
 ## images.get_image()
 
 This is solved via a templating function that is available in all templates/resources. The function is part of the global
 `images` object and expects the following arguments:
 
-`images.get_image(image, latest_version)`
+`images.get_image(image)`
 
 * image
-    * The image location, excluding the tag. Please see [supported image registries](#supported-image-registries-and-authentication) to
-      understand which registries are supported.`
-* latest_version
-    * Configures how tags/versions are sorted and thus how the latest image is determined. Can be:
-        * `version.semver()` <br>
-          Filters and sorts by loose semantic versioning. Versions must start with a number. It allows unlimited
-          `.` inside the version. It treats versions with a suffix as less then versions without a suffix
-          (e.g. 1.0-rc1 < 1.0). Two versions which only differ by suffix are sorted semantically.
-        * `version.prefix(prefix)` <br>
-          Only allows tags with the given prefix and then applies the same logic as images.semver() to whatever
-          follows right after the prefix. You can override the handling of the right part by providing `suffix=xxx`,
-          while `xxx` is another version filter, e.g. `version.prefix("master-", suffix=version.number())
-        * `version.number()` <br>
-          Only allows plain numbers as version numbers sorts them accordingly.
-        * `version.regex(regex)` <br>
-          Only allows versions/tags that match the given regex. Sorting is done the same way as in version.semver(),
-          except that versions do not necessarily need to start with a number.
+    * The image name/repository. It is looked up the list of fixed images.
 
-The mentioned version filters must be specified as strings. For example,
-
-`images.get_version("my-image", "prefix('master-', suffix=number())")`.
-
-If no version_filter is specified, then it defaults to `"semver()"`.
+The function will lookup the given image in the list of fixed images and return the last match.
 
 Example deployment:
 
@@ -77,59 +49,58 @@ spec:
         image: "{{ images.get_image('registry.gitlab.com/my-group/my-project') }}"
 ```
 
-## Always using the latest images
-If you want to use the latest image no matter if an older version is already deployed, use the `-u` flag to your 
-`deploy`, `diff` or `list-images` commands.
+## Fixed images
 
-You can restrict updating to individual images by using `-I/--include-tag`. This is useful when using CI/CD for example,
-where you often want to perform a deployment that only updates a single application/service from your large deployment.
+Fixed images can be configured multiple methods:
+1. Command line argument `--fixed-image`
+2. Command line argument `--fixed-images-file`
+3. Target definition
+4. Global 'images' variable
 
-## Fixed images via CLI
-The described `images.get_image` logic however leads to a loosely defined state on your target cluster/environment. This
-might be fine in a CI/CD environment, but might be undesired when deploying to production. In that case, it might be
-desirable to explicitly define which versions need to be deployed.
+## Command line argument `--fixed-image`
 
-To achieve this, you can use the `-F FIXED_IMAGE` [argument](../commands/common-arguments.md#image-arguments).
-`FIXED_IMAGE` must be in the form of `-F image<:namespace:deployment:container>=result`. For example, to pin the image
-`registry.gitlab.com/my-group/my-project` to the tag `1.1.2` you'd have to specify
-`-F registry.gitlab.com/my-group/my-project=registry.gitlab.com/my-group/my-project:1.1.2`.
+You can pass fixed images configuration via the `--fixed-image` [argument](../commands/common-arguments.md#image-arguments).
+Due to [environment variables support](../commands/environment-variables.md) in the CLI, you can also use the
+environment variable `KLUCTL_FIXED_IMAGE_XXX` to configure fixed images.
 
-## Fixed images via a yaml file
+The format of the `--fixed-image` argument is `--fixed-image image<:namespace:deployment:container>=result`. The simplest
+example is `--fixed-image registry.gitlab.com/my-group/my-project=registry.gitlab.com/my-group/my-project:1.1.2`.
 
-As an alternative to specifying each fixed image via CLI (`--fixed-images-file=<file>`), you can also specify a single
-yaml file via CLI which then contains a list of entries that define image/deployment -> imageResult mappings.
+## Command line argument `--fixed-images-file`
 
-An example fixed-images files looks like this:
+You can also configure fixed images via a yaml file by using `--fixed-images-file /path/to/fixed-images.yaml`.
+file:
 
 ```yaml
 images:
   - image: registry.gitlab.com/my-group/my-project
-    resultImage: registry.gitlab.com/my-group/my-project:1.1.0
-  - image: registry.gitlab.com/my-group/my-project2
-    resultImage: registry.gitlab.com/my-group/my-project2:2.0.0
-  - deployment: StatefulSet/my-sts
-    resultImage: registry.gitlab.com/my-group/my-project3:1.0.0
+    resultImage: registry.gitlab.com/my-group/my-project:1.1.2
 ```
 
-You can also take an existing deployment and export the already deployed image versions into a fixed-images file by
-using the `list-images` command. It will produce a compatible fixed-images file based on the calls to
-`images.get_image` if a deployment would be performed with the given arguments. The result of that call is quite
-expressive, as it contains all the information gathered while images were collected. Use `--simple` to only return
-a list with image -> resultImage mappings.
+The file must contain a single root list named `images` with each entry having the following form:
 
-## Supported image registries and authentication
-All [v2 API](https://docs.docker.com/registry/spec/api/) based image registries are supported, including the Docker Hub,
-Gitlab, and many more. Private registries will need credentials to be setup correctly. This can be done by locally
-logging in via `docker login <registry>` or by specifying the following environment variables:
+```yaml
+images:
+  - image: <image_name>
+    resultImage: <result_image>
+    # optional fields
+    namespace: <namespace>
+    deployment: <kind>/<name>
+    container: <name>
+```
 
-Simply set the following environment variables to pass credentials to you private repository:
-1. KLUCTL_REGISTRY_HOST=registry.example.com
-2. KLUCTL_REGISTRY_USERNAME=username
-3. KLUCTL_REGISTRY_PASSWORD=password
+`image` and `resultImage` are required. All the other fields are optional and allow to specify in detail for which
+object the fixed is specified.
 
-You can also pass credentials for more registries by adding an index to the environment variables,
-e.g. "KLUCTL_REGISTRY_1_HOST=registry.gitlab.com"
+## Target definition
 
-In case your registry uses self-signed TLS certificates, it is currently required to disable TLS verification for these.
-You can do this via `KLUCTL_REGISTRY_TLSVERIFY=1`/`KLUCTL_REGISTRY_<idx>_TLSVERIFY=1` for the corresponding
-`KLUCTL_REGISTRY_HOST`/`KLUCTL_REGISTRY_<idx>_HOST` or by globally disabling it via `KLUCTL_REGISTRY_DEFAULT_TLSVERIFY=1`.
+The [target](../kluctl-project/targets/README.md#targets) definition can optionally specify an `images` field that can
+contain the same fixed images configuration as found in the `--fixed-images-file` file.
+
+## Global 'images' variable
+
+You can also define a global variable named `images` via one of the [variable sources](../templating/variable-sources.md).
+This variable must be a list of the same format as the images list in the `--fixed-images-file` file.
+
+This option allows to externalize fixed images configuration, meaning that you can maintain image versions outside
+the deployment project, e.g. in another [Git repository](../templating/variable-sources.md#git).

--- a/docs/reference/kluctl-project/targets/README.md
+++ b/docs/reference/kluctl-project/targets/README.md
@@ -54,7 +54,7 @@ have higher priority.
 
 ## images
 This field specifies a list of fixed images to be used by [`images.get_image(...)`](../../deployments/images.md#imagesget_image).
-The format is identical to the [fixed images file](../../deployments/images.md#fixed-images-via-a-yaml-file).
+The format is identical to the [fixed images file](../../deployments/images.md#command-line-argument---fixed-images-file).
 
 The fixed images specified in the [dynamic target config](../../kluctl-project/targets/dynamic-targets.md#images)
 have higher priority.

--- a/docs/reference/templating/predefined-variables.md
+++ b/docs/reference/templating/predefined-variables.md
@@ -23,6 +23,3 @@ This is the target definition of the currently processed target. It contains all
 
 ### images
 This global object provides the dynamic images features described in [images](../deployments/images.md).
-
-### version
-This global object defines latest version filters for `images.get_image(...)`. See [images](../deployments/images.md) for details.

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -592,7 +592,7 @@ func (di *DeploymentItem) postprocessObjects(images *Images) error {
 			}
 
 			// Resolve image placeholders
-			err := images.ResolvePlaceholders(di.ctx.K, o, di.RelRenderedDir, di.Tags.ListKeys())
+			err := images.ResolvePlaceholders(di.ctx.K, o, di.RelRenderedDir, di.Tags.ListKeys(), di.VarsCtx.Vars)
 			if err != nil {
 				errs = multierror.Append(errs, err)
 			}

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -592,7 +592,7 @@ func (di *DeploymentItem) postprocessObjects(images *Images) error {
 			}
 
 			// Resolve image placeholders
-			err := images.ResolvePlaceholders(di.ctx.K, o, di.RelRenderedDir, di.Tags.ListKeys(), di.VarsCtx.Vars)
+			err := images.ResolvePlaceholders(di.ctx.Ctx, di.ctx.K, o, di.RelRenderedDir, di.Tags.ListKeys(), di.VarsCtx.Vars)
 			if err != nil {
 				errs = multierror.Append(errs, err)
 			}

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
+	"github.com/kluctl/kluctl/v2/pkg/vars"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	"io/fs"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -27,6 +28,7 @@ type DeploymentItem struct {
 	Project   *DeploymentProject
 	Inclusion *utils.Inclusion
 	Config    *types.DeploymentItemConfig
+	VarsCtx   *vars.VarsCtx
 	dir       *string
 	index     int
 
@@ -51,6 +53,7 @@ func NewDeploymentItem(ctx SharedContext, project *DeploymentProject, collection
 		Project:   project,
 		Inclusion: collection.Inclusion,
 		Config:    config,
+		VarsCtx:   project.VarsCtx.Copy(),
 		dir:       dir,
 		index:     index,
 	}
@@ -81,6 +84,12 @@ func NewDeploymentItem(ctx SharedContext, project *DeploymentProject, collection
 		di.RenderedDir = filepath.Join(di.RenderedSourceRootDir, di.RelRenderedDir)
 		di.renderedYamlPath = filepath.Join(di.RenderedDir, ".rendered.yml")
 	}
+
+	err = di.Project.loadVarsList(di.VarsCtx, di.Config.Vars)
+	if err != nil {
+		return nil, err
+	}
+
 	return di, nil
 }
 
@@ -111,13 +120,6 @@ func (di *DeploymentItem) render(forSeal bool) error {
 	}
 
 	err := os.MkdirAll(di.RenderedDir, 0o700)
-	if err != nil {
-		return err
-	}
-
-	varsCtx := di.Project.VarsCtx.Copy()
-
-	err = di.Project.loadVarsList(varsCtx, di.Config.Vars)
 	if err != nil {
 		return err
 	}
@@ -154,7 +156,7 @@ func (di *DeploymentItem) render(forSeal bool) error {
 	// also add deployment item dir to search dirs
 	searchDirs = append([]string{*di.dir}, searchDirs...)
 
-	return varsCtx.RenderDirectory(
+	return di.VarsCtx.RenderDirectory(
 		filepath.Join(di.Project.source.dir, di.RelToSourceItemDir),
 		di.RenderedDir,
 		excludePatterns,

--- a/pkg/deployment/deployment_project.go
+++ b/pkg/deployment/deployment_project.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	"fmt"
 	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
@@ -58,6 +59,10 @@ func NewDeploymentProject(ctx SharedContext, varsCtx *vars.VarsCtx, source Sourc
 	err = dp.loadIncludes()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load includes for %s: %w", dir, err)
+	}
+
+	if dp.Config.SealedSecrets != nil {
+		status.Deprecation(ctx.Ctx, "sealed-secrets-config", "'sealedSecrets' is deprecated in deployment projects. Support for it will be removed in a future kluctl release.")
 	}
 
 	return dp, nil

--- a/pkg/kluctl_jinja2/ext/images_ext.py
+++ b/pkg/kluctl_jinja2/ext/images_ext.py
@@ -12,11 +12,15 @@ class ImagesExtension(Extension):
         environment.globals.update(self.build_images_vars())
 
     def get_image_wrapper(self, image, latest_version=None):
+        has_latest_version = False
         if latest_version is None:
             latest_version = "semver()"
+        else:
+            has_latest_version = True
         placeholder = {
             "image": image,
             "latestVersion": str(latest_version),
+            "hasLatestVersion": has_latest_version,
         }
         j = json.dumps(placeholder)
         j = base64.b64encode(j.encode("utf8")).decode("utf8")

--- a/pkg/kluctl_project/target_context.go
+++ b/pkg/kluctl_project/target_context.go
@@ -183,6 +183,11 @@ func (p *LoadedKluctlProject) buildVars(target *types.Target, externalArgs *uo.U
 	}
 	allArgs.Merge(externalArgs)
 
+	err = deployment.LoadDefaultArgs(p.Config.Args, allArgs)
+	if err != nil {
+		return nil, err
+	}
+
 	deprecatedArgs, err := deployment.LoadDeprecatedDeploymentArgs(p.ctx, p.ProjectDir, varsCtx, allArgs)
 	if err != nil {
 		return nil, err
@@ -190,11 +195,6 @@ func (p *LoadedKluctlProject) buildVars(target *types.Target, externalArgs *uo.U
 
 	if deprecatedArgs && len(p.Config.Args) != 0 {
 		return nil, fmt.Errorf("mixing deprecated 'args' from deployment.yaml and .kluctl.yaml is not allowed")
-	}
-
-	err = deployment.LoadDefaultArgs(p.Config.Args, allArgs)
-	if err != nil {
-		return nil, err
 	}
 
 	varsCtx.UpdateChild("args", allArgs)

--- a/pkg/kluctl_project/targets.go
+++ b/pkg/kluctl_project/targets.go
@@ -252,6 +252,9 @@ func (c *LoadedKluctlProject) buildDynamicTarget(targetInfo *dynamicTargetInfo) 
 	if targetConfig.Args != nil {
 		target.Args.Merge(targetConfig.Args)
 	}
+	if len(targetConfig.Images) != 0 {
+		status.Deprecation(c.ctx, "target-config-images", "specifying fixed images via external 'targetConfig' is deprecated and support for this will be removed in a future kluctl release.")
+	}
 	// We prepend the dynamic images to ensure they get higher priority later
 	target.Images = append(targetConfig.Images, target.Images...)
 


### PR DESCRIPTION
# Description

This PR does two things:
1. Allow defining fixed images via a global `images` variable.
2. Deprecate all functionality regarding querying docker registries for latest images. This functionality should be provided outside of Kluctl, e.g. via Renovate.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
