### PR TITLE
feat: Implement discriminators to identify deployment objects for pruning and deletion

### DIFF
--- a/cmd/kluctl/commands/cmd_deploy.go
+++ b/cmd/kluctl/commands/cmd_deploy.go
@@ -55,7 +55,7 @@ func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
 	status.Trace(cmdCtx.ctx, "enter runCmdDeploy")
 	defer status.Trace(cmdCtx.ctx, "leave runCmdDeploy")
 
-	cmd2 := commands.NewDeployCommand(cmdCtx.targetCtx.DeploymentCollection)
+	cmd2 := commands.NewDeployCommand(cmdCtx.targetCtx.Target.Discriminator, cmdCtx.targetCtx.DeploymentCollection)
 	cmd2.ForceApply = cmd.ForceApply
 	cmd2.ReplaceOnError = cmd.ReplaceOnError
 	cmd2.ForceReplaceOnError = cmd.ForceReplaceOnError

--- a/cmd/kluctl/commands/cmd_diff.go
+++ b/cmd/kluctl/commands/cmd_diff.go
@@ -39,7 +39,7 @@ func (cmd *diffCmd) Run(ctx context.Context) error {
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 	}
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
-		cmd2 := commands.NewDiffCommand(cmdCtx.targetCtx.DeploymentCollection)
+		cmd2 := commands.NewDiffCommand(cmdCtx.targetCtx.Target.Discriminator, cmdCtx.targetCtx.DeploymentCollection)
 		cmd2.ForceApply = cmd.ForceApply
 		cmd2.ReplaceOnError = cmd.ReplaceOnError
 		cmd2.ForceReplaceOnError = cmd.ForceReplaceOnError

--- a/cmd/kluctl/commands/cmd_list_targets.go
+++ b/cmd/kluctl/commands/cmd_list_targets.go
@@ -17,7 +17,7 @@ func (cmd *listTargetsCmd) Help() string {
 }
 
 func (cmd *listTargetsCmd) Run(ctx context.Context) error {
-	return withKluctlProjectFromArgs(ctx, cmd.ProjectFlags, true, false, func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error {
+	return withKluctlProjectFromArgs(ctx, cmd.ProjectFlags, nil, true, false, func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error {
 		var result []*types.Target
 		for _, t := range p.DynamicTargets {
 			result = append(result, t.Target)

--- a/cmd/kluctl/commands/cmd_prune.go
+++ b/cmd/kluctl/commands/cmd_prune.go
@@ -45,7 +45,7 @@ func (cmd *pruneCmd) Run(ctx context.Context) error {
 }
 
 func (cmd *pruneCmd) runCmdPrune(cmdCtx *commandCtx) error {
-	cmd2 := commands.NewPruneCommand(cmdCtx.targetCtx.DeploymentCollection)
+	cmd2 := commands.NewPruneCommand(cmdCtx.targetCtx.Target.Discriminator, cmdCtx.targetCtx.DeploymentCollection)
 	objects, err := cmd2.Run(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K)
 	if err != nil {
 		return err

--- a/cmd/kluctl/commands/cmd_seal.go
+++ b/cmd/kluctl/commands/cmd_seal.go
@@ -155,7 +155,7 @@ func (cmd *sealCmd) loadCert(cmdCtx *commandCtx) (*x509.Certificate, error) {
 }
 
 func (cmd *sealCmd) Run(ctx context.Context) error {
-	return withKluctlProjectFromArgs(ctx, cmd.ProjectFlags, true, false, func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error {
+	return withKluctlProjectFromArgs(ctx, cmd.ProjectFlags, nil, true, false, func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error {
 		hadError := false
 
 		baseTargets := make(map[string]bool)

--- a/cmd/kluctl/commands/cmd_validate.go
+++ b/cmd/kluctl/commands/cmd_validate.go
@@ -39,7 +39,7 @@ func (cmd *validateCmd) Run(ctx context.Context) error {
 	}
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
 		startTime := time.Now()
-		cmd2 := commands.NewValidateCommand(cmdCtx.ctx, cmdCtx.targetCtx.DeploymentCollection)
+		cmd2 := commands.NewValidateCommand(cmdCtx.ctx, cmdCtx.targetCtx.Target.Discriminator, cmdCtx.targetCtx.DeploymentCollection)
 		for true {
 			result, err := cmd2.Run(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K)
 			if err != nil {

--- a/docs/reference/commands/delete.md
+++ b/docs/reference/commands/delete.md
@@ -34,7 +34,7 @@ In addition, the following arguments are available:
 Misc arguments:
   Command specific arguments.
 
-  -l, --delete-by-label stringArray                 Override the labels used to find objects for deletion.
+      --discriminator string                        Override the discriminator used to find objects for deletion.
       --dry-run                                     Performs all kubernetes API calls in dry-run mode.
       --helm-insecure-skip-tls-verify stringArray   Controls skipping of TLS verification. Must be in the form
                                                     --helm-insecure-skip-tls-verify=<credentialsId>, where

--- a/docs/reference/kluctl-project/README.md
+++ b/docs/reference/kluctl-project/README.md
@@ -19,6 +19,8 @@ available to invoke [commands](../commands) on.
 An example .kluctl.yaml looks like this:
 
 ```yaml
+discriminator: "my-project-{{ target.name }}"
+
 targets:
   # test cluster, dev env
   - name: dev
@@ -41,6 +43,13 @@ args:
 ```
 
 ## Allowed fields
+
+### discriminator
+
+Specifies a default discriminator template to be used for targets that don't have
+their own discriminator specified.
+
+See [target discriminator](./targets/README.md#discriminator) for details.
 
 ### targets
 

--- a/docs/reference/kluctl-project/targets/README.md
+++ b/docs/reference/kluctl-project/targets/README.md
@@ -32,6 +32,7 @@ targets:
     images:
       - image: my-image
         resultImage: my-image:1.2.3
+    discriminator: "my-project-{{ target.name }}"
 ...
 ```
 
@@ -58,3 +59,27 @@ The format is identical to the [fixed images file](../../deployments/images.md#c
 
 The fixed images specified in the [dynamic target config](../../kluctl-project/targets/dynamic-targets.md#images)
 have higher priority.
+
+## discriminator
+
+Specifies a discriminator which is used to uniquely identify all deployed objects on the cluster. It is added to all
+objects as the value of the `kluctl.io/discriminator` label. This label is then later used to identify all objects
+belonging to the deployment project and target, so that Kluctl can determine which objects got orphaned and need to
+be pruned. The discriminator is also used to identify all objects that need to be deleted when
+[kluctl delete](../../commands/delete.md) is called.
+
+If no discriminator is set for a target, [kluctl prune](../../commands/prune.md) and
+[kluctl delete](../../commands/delete.md) are not supported.
+
+The discriminator can be a [template](../../templating/README.md) which is rendered at project loading time. While
+rendering, only the `target` and `args` are available as global variables in the templating context.
+
+The rendered discriminator should be unique on the target cluster to avoid mis-identification of objects from other
+deployments or targets. It's good practice to prefix the discriminator with a project name and at least use the target
+name to make it unique. Example discriminator to achieve this: `my-project-name-{{ target.name }}`.
+
+If a target is meant to be deployed multiple times, e.g. by using external [arguments](../README.md#args), the external
+arguments should be taken into account as well. Example: `my-project-name-{{ target.name }}-{{ args.environment_name }}`.
+
+A [default discriminator](../../kluctl-project/README.md#discriminator) can also be specified which is used whenever
+a target has no discriminator configured.

--- a/docs/reference/templating/filters.md
+++ b/docs/reference/templating/filters.md
@@ -84,5 +84,11 @@ Renders the input string with the current Jinja2 context. Example:
 {{ a | render }}
 ```
 
+### sha256
+Calculates the sha256 digest of the input string. Example:
+```
+{{ "some-string" | sha256 }}
+```
+
 ### slugify
 Slugify a string based on [python-slugify](https://github.com/un33k/python-slugify).

--- a/e2e/inclusion_test.go
+++ b/e2e/inclusion_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"github.com/kluctl/kluctl/v2/e2e/test-utils"
+	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	corev1 "k8s.io/api/core/v1"
 	"path/filepath"
 	"reflect"
@@ -14,7 +15,7 @@ func prepareInclusionTestProject(t *testing.T, withIncludes bool) (*test_utils.T
 
 	createNamespace(t, k, p.TestSlug())
 
-	p.UpdateTarget("test", nil)
+	p.UpdateTarget("test", func(target *uo.UnstructuredObject) {})
 
 	addConfigMapDeployment(p, "cm1", nil, resourceOpts{name: "cm1", namespace: p.TestSlug()})
 	addConfigMapDeployment(p, "cm2", nil, resourceOpts{name: "cm2", namespace: p.TestSlug()})

--- a/e2e/test-utils/project.go
+++ b/e2e/test-utils/project.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	registry2 "helm.sh/helm/v3/pkg/registry"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"net/url"
 	"os"
 	"os/exec"
@@ -78,6 +79,7 @@ func NewTestProject(t *testing.T, opts ...TestProjectOption) *TestProject {
 	p.gitServer.GitInit(p.gitRepoName)
 
 	p.UpdateKluctlYaml(func(o *uo.UnstructuredObject) error {
+		_ = o.SetNestedField(fmt.Sprintf("%s-{{ target.name }}", rand.String(16)), "discriminator")
 		return nil
 	})
 	p.UpdateDeploymentYaml(".", func(c *uo.UnstructuredObject) error {

--- a/pkg/deployment/commands/delete.go
+++ b/pkg/deployment/commands/delete.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/kluctl/kluctl/v2/pkg/deployment"
 	utils2 "github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
@@ -11,41 +10,28 @@ import (
 )
 
 type DeleteCommand struct {
-	c                      *deployment.DeploymentCollection
-	OverrideDeleteByLabels map[string]string
+	discriminator string
+	inclusion     *utils.Inclusion
 }
 
-func NewDeleteCommand(c *deployment.DeploymentCollection) *DeleteCommand {
+func NewDeleteCommand(discriminator string, inclusion *utils.Inclusion) *DeleteCommand {
 	return &DeleteCommand{
-		c: c,
+		discriminator: discriminator,
+		inclusion:     inclusion,
 	}
 }
 
 func (cmd *DeleteCommand) Run(ctx context.Context, k *k8s.K8sCluster) ([]k8s2.ObjectRef, error) {
+	if cmd.discriminator == "" {
+		return nil, fmt.Errorf("deletion without a discriminator is not supported")
+	}
+
 	dew := utils2.NewDeploymentErrorsAndWarnings()
-
 	ru := utils2.NewRemoteObjectsUtil(ctx, dew)
-
-	var labels map[string]string
-	if len(cmd.OverrideDeleteByLabels) != 0 {
-		labels = cmd.OverrideDeleteByLabels
-	} else {
-		labels = cmd.c.Project.GetCommonLabels()
-	}
-
-	if len(labels) == 0 {
-		return nil, fmt.Errorf("deletion without using commonLabels in the root deployment.yaml is not allowed")
-	}
-
-	var inclusion *utils.Inclusion
-	if cmd.c != nil {
-		inclusion = cmd.c.Inclusion
-	}
-
-	err := ru.UpdateRemoteObjects(k, labels, nil, false)
+	err := ru.UpdateRemoteObjects(k, &cmd.discriminator, nil, false)
 	if err != nil {
 		return nil, err
 	}
 
-	return utils2.FindObjectsForDelete(k, ru.GetFilteredRemoteObjects(inclusion), inclusion.HasType("tags"), nil)
+	return utils2.FindObjectsForDelete(k, ru.GetFilteredRemoteObjects(cmd.inclusion), cmd.inclusion.HasType("tags"), nil)
 }

--- a/pkg/deployment/commands/deploy.go
+++ b/pkg/deployment/commands/deploy.go
@@ -2,15 +2,19 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"github.com/kluctl/kluctl/v2/pkg/deployment"
 	utils2 "github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/types"
+	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
 	"time"
 )
 
 type DeployCommand struct {
-	c *deployment.DeploymentCollection
+	c             *deployment.DeploymentCollection
+	discriminator string
 
 	ForceApply          bool
 	ReplaceOnError      bool
@@ -20,17 +24,23 @@ type DeployCommand struct {
 	NoWait              bool
 }
 
-func NewDeployCommand(c *deployment.DeploymentCollection) *DeployCommand {
+func NewDeployCommand(discriminator string, c *deployment.DeploymentCollection) *DeployCommand {
 	return &DeployCommand{
-		c: c,
+		discriminator: discriminator,
+		c:             c,
 	}
 }
 
 func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResultCb func(diffResult *types.CommandResult) error) (*types.CommandResult, error) {
 	dew := utils2.NewDeploymentErrorsAndWarnings()
 
+	if cmd.discriminator == "" {
+		status.Warning(ctx, "No discriminator configured. Orphan object detection will not work")
+		dew.AddWarning(k8s2.ObjectRef{}, fmt.Errorf("no discriminator configured. Orphan object detection will not work"))
+	}
+
 	ru := utils2.NewRemoteObjectsUtil(ctx, dew)
-	err := ru.UpdateRemoteObjects(k, cmd.c.Project.GetCommonLabels(), cmd.c.LocalObjectRefs(), false)
+	err := ru.UpdateRemoteObjects(k, &cmd.discriminator, cmd.c.LocalObjectRefs(), false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployment/commands/validate.go
+++ b/pkg/deployment/commands/validate.go
@@ -11,15 +11,18 @@ import (
 )
 
 type ValidateCommand struct {
-	c   *deployment.DeploymentCollection
+	c             *deployment.DeploymentCollection
+	discriminator string
+
 	dew *utils2.DeploymentErrorsAndWarnings
 	ru  *utils2.RemoteObjectUtils
 }
 
-func NewValidateCommand(ctx context.Context, c *deployment.DeploymentCollection) *ValidateCommand {
+func NewValidateCommand(ctx context.Context, discriminator string, c *deployment.DeploymentCollection) *ValidateCommand {
 	cmd := &ValidateCommand{
-		c:   c,
-		dew: utils2.NewDeploymentErrorsAndWarnings(),
+		c:             c,
+		discriminator: discriminator,
+		dew:           utils2.NewDeploymentErrorsAndWarnings(),
 	}
 	cmd.ru = utils2.NewRemoteObjectsUtil(ctx, cmd.dew)
 	return cmd
@@ -31,7 +34,7 @@ func (cmd *ValidateCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*types.
 
 	cmd.dew.Init()
 
-	err := cmd.ru.UpdateRemoteObjects(k, cmd.c.Project.GetCommonLabels(), cmd.c.LocalObjectRefs(), true)
+	err := cmd.ru.UpdateRemoteObjects(k, &cmd.discriminator, cmd.c.LocalObjectRefs(), true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -95,6 +95,9 @@ func NewDeploymentItem(ctx SharedContext, project *DeploymentProject, collection
 
 func (di *DeploymentItem) getCommonLabels() map[string]string {
 	l := di.Project.GetCommonLabels()
+	if di.ctx.Discriminator != "" {
+		l["kluctl.io/discriminator"] = di.ctx.Discriminator
+	}
 	i := 0
 	for _, t := range di.Tags.ListKeys() {
 		l[fmt.Sprintf("kluctl.io/tag-%d", i)] = t

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -104,9 +104,8 @@ func (di *DeploymentItem) getCommonLabels() map[string]string {
 }
 
 func (di *DeploymentItem) getCommonAnnotations() map[string]string {
-	// TODO change it to kluctl.io/deployment_dir
 	a := map[string]string{
-		"kluctl.io/kustomize_dir": filepath.ToSlash(di.RelToSourceItemDir),
+		"kluctl.io/deployment-item-dir": filepath.ToSlash(di.RelToSourceItemDir),
 	}
 	if di.Config.SkipDeleteIfTags {
 		a["kluctl.io/skip-delete-if-tags"] = "true"

--- a/pkg/deployment/shared_context.go
+++ b/pkg/deployment/shared_context.go
@@ -18,6 +18,7 @@ type SharedContext struct {
 	VarsLoader      *vars.VarsLoader
 	HelmCredentials helm.HelmCredentialsProvider
 
+	Discriminator                     string
 	RenderDir                         string
 	SealedSecretsDir                  string
 	DefaultSealedSecretsOutputPattern string

--- a/pkg/deployment/utils/remote_objects_utils.go
+++ b/pkg/deployment/utils/remote_objects_utils.go
@@ -30,13 +30,21 @@ func NewRemoteObjectsUtil(ctx context.Context, dew *DeploymentErrorsAndWarnings)
 	}
 }
 
-func (u *RemoteObjectUtils) getAllByLabels(k *k8s.K8sCluster, labels map[string]string, onlyUsedGKs map[schema.GroupKind]bool) error {
+func (u *RemoteObjectUtils) getAllByDiscriminator(k *k8s.K8sCluster, discriminator *string, onlyUsedGKs map[schema.GroupKind]bool) error {
 	var mutex sync.Mutex
-	if len(labels) == 0 {
+	if discriminator == nil {
+		return nil
+	}
+	if *discriminator == "" {
+		status.Warning(u.ctx, "No discriminator configured for target, retrieval of remote objects will be slow.")
 		return nil
 	}
 
-	baseStatus := "Getting remote objects by commonLabels"
+	labels := map[string]string{
+		"kluctl.io/discriminator": *discriminator,
+	}
+
+	baseStatus := "Getting remote objects by discriminator"
 	s := status.Start(u.ctx, baseStatus)
 	defer s.Failed()
 
@@ -87,7 +95,7 @@ func (u *RemoteObjectUtils) getAllByLabels(k *k8s.K8sCluster, labels map[string]
 			s.UpdateAndInfoFallback("%s: Failed with %d errors", baseStatus, errCount)
 			s.Warning()
 			if permissionErrCount != 0 {
-				u.dew.AddWarning(k8s2.ObjectRef{}, fmt.Errorf("at least one permission error was encountered while gathering objects by labels. This might result in orphan object detection to not work properly"))
+				u.dew.AddWarning(k8s2.ObjectRef{}, fmt.Errorf("at least one permission error was encountered while gathering objects by discriminator labels. This might result in orphan object detection to not work properly"))
 			}
 		} else {
 			s.Success()
@@ -157,7 +165,7 @@ func (u *RemoteObjectUtils) getMissingObjects(k *k8s.K8sCluster, refs []k8s2.Obj
 	return g.ErrorOrNil()
 }
 
-func (u *RemoteObjectUtils) UpdateRemoteObjects(k *k8s.K8sCluster, labels map[string]string, refs []k8s2.ObjectRef, onlyUsedGKs bool) error {
+func (u *RemoteObjectUtils) UpdateRemoteObjects(k *k8s.K8sCluster, discriminator *string, refs []k8s2.ObjectRef, onlyUsedGKs bool) error {
 	if k == nil {
 		return nil
 	}
@@ -171,7 +179,7 @@ func (u *RemoteObjectUtils) UpdateRemoteObjects(k *k8s.K8sCluster, labels map[st
 		}
 	}
 
-	err := u.getAllByLabels(k, labels, usedGKs)
+	err := u.getAllByDiscriminator(k, discriminator, usedGKs)
 	if err != nil {
 		return err
 	}

--- a/pkg/deployment/utils/remote_objects_utils.go
+++ b/pkg/deployment/utils/remote_objects_utils.go
@@ -237,7 +237,7 @@ func (u *RemoteObjectUtils) getInclusionEntries(o *uo.UnstructuredObject) []util
 		})
 	}
 
-	if itemDir := o.GetK8sAnnotation("kluctl.io/kustomize_dir"); itemDir != nil {
+	if itemDir := o.GetK8sAnnotation("kluctl.io/deployment-item-dir"); itemDir != nil {
 		iv = append(iv, utils.InclusionEntry{
 			Type:  "deploymentItemDir",
 			Value: *itemDir,

--- a/pkg/deployment/utils/remote_objects_utils_test.go
+++ b/pkg/deployment/utils/remote_objects_utils_test.go
@@ -37,12 +37,13 @@ func TestRemoteObjectUtils_PermissionErrors(t *testing.T) {
 
 	dew := NewDeploymentErrorsAndWarnings()
 	u := NewRemoteObjectsUtil(context.Background(), dew)
-	err = u.UpdateRemoteObjects(k, map[string]string{"l1": "v1"}, []k8s2.ObjectRef{
+	discriminator := "d"
+	err = u.UpdateRemoteObjects(k, &discriminator, []k8s2.ObjectRef{
 		k8s2.NewObjectRef("", "v1", "Secret", "secret", "default"),
 	}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, []types.DeploymentError{{
-		Error: "at least one permission error was encountered while gathering objects by labels. This might result in orphan object detection to not work properly"},
+		Error: "at least one permission error was encountered while gathering objects by discriminator labels. This might result in orphan object detection to not work properly"},
 	}, dew.GetWarningsList())
 	assert.Empty(t, dew.GetErrorsList())
 }

--- a/pkg/kluctl_project/project_load.go
+++ b/pkg/kluctl_project/project_load.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/sops/decryptor"
 	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
+	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -15,6 +16,7 @@ type LoadKluctlProjectArgs struct {
 	RepoRoot      string
 	ProjectDir    string
 	ProjectConfig string
+	ExternalArgs  *uo.UnstructuredObject
 
 	SopsDecrypter *decryptor.Decryptor
 	RP            *repocache.GitRepoCache

--- a/pkg/kluctl_project/target_context.go
+++ b/pkg/kluctl_project/target_context.go
@@ -34,7 +34,6 @@ type TargetContextParams struct {
 	OfflineK8s         bool
 	K8sVersion         string
 	DryRun             bool
-	ExternalArgs       *uo.UnstructuredObject
 	ForSeal            bool
 	Images             *deployment.Images
 	Inclusion          *utils.Inclusion
@@ -73,7 +72,7 @@ func (p *LoadedKluctlProject) NewTargetContext(ctx context.Context, params Targe
 	}
 	target.Context = &clusterContext
 
-	varsCtx, err := p.buildVars(target, params.ExternalArgs, params.ForSeal)
+	varsCtx, err := p.buildVars(target, params.ForSeal)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +159,7 @@ func (p *LoadedKluctlProject) loadK8sConfig(target *types.Target, offlineK8s boo
 	return clientConfig, "", nil
 }
 
-func (p *LoadedKluctlProject) buildVars(target *types.Target, externalArgs *uo.UnstructuredObject, forSeal bool) (*vars.VarsCtx, error) {
+func (p *LoadedKluctlProject) buildVars(target *types.Target, forSeal bool) (*vars.VarsCtx, error) {
 	varsCtx := vars.NewVarsCtx(p.J2)
 
 	targetVars, err := uo.FromStruct(target)
@@ -181,7 +180,9 @@ func (p *LoadedKluctlProject) buildVars(target *types.Target, externalArgs *uo.U
 			}
 		}
 	}
-	allArgs.Merge(externalArgs)
+	if p.loadArgs.ExternalArgs != nil {
+		allArgs.Merge(p.loadArgs.ExternalArgs)
+	}
 
 	err = deployment.LoadDefaultArgs(p.Config.Args, allArgs)
 	if err != nil {

--- a/pkg/kluctl_project/target_context.go
+++ b/pkg/kluctl_project/target_context.go
@@ -109,6 +109,7 @@ func (p *LoadedKluctlProject) NewTargetContext(ctx context.Context, params Targe
 		SopsDecrypter:                     p.SopsDecrypter,
 		VarsLoader:                        varsLoader,
 		HelmCredentials:                   params.HelmCredentials,
+		Discriminator:                     target.Discriminator,
 		RenderDir:                         params.RenderOutputDir,
 		SealedSecretsDir:                  p.sealedSecretsDir,
 		DefaultSealedSecretsOutputPattern: target.Name,

--- a/pkg/kluctl_project/targets.go
+++ b/pkg/kluctl_project/targets.go
@@ -75,7 +75,7 @@ func (c *LoadedKluctlProject) renderTarget(target *types.Target) error {
 	// Try rendering the target multiple times, until all values can be rendered successfully. This allows the target
 	// to reference itself in complex ways. We'll also try loading the cluster vars in each iteration.
 
-	var errors []error
+	var retErr error
 	for i := 0; i < 10; i++ {
 		varsCtx, err := c.buildVars(target, false)
 		if err != nil {
@@ -86,11 +86,9 @@ func (c *LoadedKluctlProject) renderTarget(target *types.Target) error {
 		if err == nil && !changed {
 			return nil
 		}
+		retErr = err
 	}
-	if len(errors) != 0 {
-		return errors[0]
-	}
-	return nil
+	return retErr
 }
 
 func (c *LoadedKluctlProject) prepareDynamicTargets(baseTarget *types.Target) ([]*dynamicTargetInfo, error) {

--- a/pkg/kluctl_project/targets.go
+++ b/pkg/kluctl_project/targets.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
-	"github.com/kluctl/kluctl/v2/pkg/vars"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	"os"
 	"regexp"
@@ -52,7 +51,8 @@ func (c *LoadedKluctlProject) loadTargets() error {
 
 		err = c.renderTarget(target)
 		if err != nil {
-			return err
+			status.Warning(c.ctx, "Failed to load target %s: %v", target.Name, err)
+			continue
 		}
 
 		if _, ok := targetNames[target.Name]; ok {
@@ -77,8 +77,7 @@ func (c *LoadedKluctlProject) renderTarget(target *types.Target) error {
 
 	var errors []error
 	for i := 0; i < 10; i++ {
-		varsCtx := vars.NewVarsCtx(c.J2)
-		err := varsCtx.UpdateChildFromStruct("target", target)
+		varsCtx, err := c.buildVars(target, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/kluctl_project/targets.go
+++ b/pkg/kluctl_project/targets.go
@@ -228,6 +228,9 @@ func (c *LoadedKluctlProject) buildDynamicTarget(targetInfo *dynamicTargetInfo) 
 	if err != nil {
 		return nil, err
 	}
+	if target.Discriminator == "" {
+		target.Discriminator = c.Config.Discriminator
+	}
 	if targetInfo.baseTarget.TargetConfig == nil {
 		return &target, nil
 	}

--- a/pkg/types/kluctl_project.go
+++ b/pkg/types/kluctl_project.go
@@ -34,6 +34,7 @@ type Target struct {
 	TargetConfig  *ExternalTargetConfig  `yaml:"targetConfig,omitempty"`
 	SealingConfig *SealingConfig         `yaml:"sealingConfig,omitempty"`
 	Images        []FixedImage           `yaml:"images,omitempty"`
+	Discriminator string                 `yaml:"discriminator,omitempty"`
 }
 
 type DynamicTarget struct {
@@ -66,4 +67,5 @@ type KluctlProject struct {
 	Targets       []*Target        `yaml:"targets,omitempty"`
 	Args          []*DeploymentArg `yaml:"args,omitempty"`
 	SecretsConfig *SecretsConfig   `yaml:"secretsConfig,omitempty"`
+	Discriminator string           `yaml:"discriminator,omitempty"`
 }


### PR DESCRIPTION
# Description

This PR implements discriminators on Kluctl project/target level. These are from now on used to identify objects for deletion and pruning. `commonLabels` will now only be used to set labels on all objects but for nothing else.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
