### PR TITLE
fix: Also add full resource strings to Helm's APIVersions

### DIFF
--- a/pkg/k8s/resources.go
+++ b/pkg/k8s/resources.go
@@ -310,7 +310,7 @@ func (k *k8sResources) GetFilteredGVKs(filter func(ar *v1.APIResource) bool) []s
 
 	var ret []schema.GroupVersionKind
 	for _, ar := range k.allResources {
-		if !filter(&ar) {
+		if filter != nil && !filter(&ar) {
 			continue
 		}
 		gvk := schema.GroupVersionKind{


### PR DESCRIPTION
# Description

Helm internally adds GroupVersion strings AND GroupVersionKind strings to APIVersions. We must replicate this behavior as otherwise things like `.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress"` will not work.

Fixes a bug reported on Slack. Thanks to @jsaalfeld 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
