### PR TITLE
docs: change environment args to a working default case

### DIFF
--- a/docs/reference/kluctl-project/README.md
+++ b/docs/reference/kluctl-project/README.md
@@ -26,17 +26,17 @@ targets:
   - name: dev
     context: dev.example.com
     args:
-      environment_name: dev
+      environment: dev
   # test cluster, test env
   - name: test
     context: test.example.com
     args:
-      environment_name: test
+      environment: test
   # prod cluster, prod env
   - name: prod
     context: prod.example.com
     args:
-      environment_name: prod
+      environment: prod
 
 args:
   - name: environment


### PR DESCRIPTION
# Description

The default case had the user to declare `target` and `environment` separately. With this change the user only has to use the `target` and the `environment` will be set accordingly. 
