### PR TITLE
fix: Don't consider objects as ready when the observedGeneration != generation

### DIFF
--- a/pkg/utils/uo/k8s_fields.go
+++ b/pkg/utils/uo/k8s_fields.go
@@ -186,6 +186,14 @@ func (uo *UnstructuredObject) GetK8sAnnotationsWithRegex(r interface{}) map[stri
 	return ret
 }
 
+func (uo *UnstructuredObject) GetK8sGeneration() int64 {
+	ret, ok, _ := uo.GetNestedInt("metadata", "generation")
+	if !ok {
+		return -1
+	}
+	return ret
+}
+
 func (uo *UnstructuredObject) GetK8sResourceVersion() string {
 	ret, _, _ := uo.GetNestedString("metadata", "resourceVersion")
 	return ret

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -258,6 +258,12 @@ func ValidateObject(k *k8s.K8sCluster, o *uo.UnstructuredObject, notReadyIsError
 		return i, nil
 	}
 
+	observedGeneration := getStatusFieldInt("observedGeneration", reactIgnore, false, -1)
+	if observedGeneration != -1 && observedGeneration != o.GetK8sGeneration() {
+		addNotReady("Waiting for reconciliation")
+		return
+	}
+
 	switch o.GetK8sGVK().GroupKind() {
 	case schema.GroupKind{Group: "", Kind: "Pod"}:
 		containerStatuses, _, err := status.GetNestedObjectList("containerStatuses")


### PR DESCRIPTION
# Description

This fixes issues with Deployment objects being marked as ready right after applying changes that would make in non-ready.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
