### PR TITLE
fix: Also try to parse repo key without dummy scheme

### DIFF
--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -239,13 +239,16 @@ func parseRepoOverride(s string, isGroup bool) (ret repocache.RepoOverride, err 
 		return repocache.RepoOverride{}, fmt.Errorf("%s", s)
 	}
 
-	// we need to prepend a dummy scheme to the repo key so that it is properly parsed
-	dummyUrl := fmt.Sprintf("git://%s", sp[0])
-
-	u, err := git_url.Parse(dummyUrl)
+	u, err := git_url.Parse(sp[0])
 	if err != nil {
-		return repocache.RepoOverride{}, fmt.Errorf("%s: %w", s, err)
+		// we need to prepend a dummy scheme to the repo key so that it is properly parsed
+		dummyUrl := fmt.Sprintf("git://%s", sp[0])
+		u, err = git_url.Parse(dummyUrl)
+		if err != nil {
+			return repocache.RepoOverride{}, fmt.Errorf("%s: %w", s, err)
+		}
 	}
+
 	u = u.Normalize()
 	ret.RepoUrl = *u
 	ret.Override = sp[1]

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
-	github.com/whilp/git-urls v1.0.0
 	github.com/xanzy/ssh-agent v0.3.3
 	golang.org/x/crypto v0.6.0
 	golang.org/x/net v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -762,8 +762,6 @@ github.com/urfave/cli v1.22.7/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlIME=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
-github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 github.com/xanzy/ssh-agent v0.3.2/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=

--- a/pkg/git/auth/git_credentials_file.go
+++ b/pkg/git/auth/git_credentials_file.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"github.com/fluxcd/go-git/v5/plumbing/transport/http"
 	git_url "github.com/kluctl/kluctl/v2/pkg/git/git-url"
+	"github.com/kluctl/kluctl/v2/pkg/git/git-url/giturls"
 	"github.com/kluctl/kluctl/v2/pkg/git/messages"
-	giturls "github.com/whilp/git-urls"
 	"os"
 	"path/filepath"
 )

--- a/pkg/git/git-url/giturls/LICENSE
+++ b/pkg/git/git-url/giturls/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Will Maier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/git/git-url/giturls/urls.go
+++ b/pkg/git/git-url/giturls/urls.go
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2014 Will Maier <wcmaier@m.aier.us>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+/*
+Package giturls parses Git URLs.
+
+These URLs include standard RFC 3986 URLs as well as special formats that
+are specific to Git. Examples are provided in the Git documentation at
+https://www.kernel.org/pub/software/scm/git/docs/git-clone.html.
+*/
+package giturls
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+var (
+	// scpSyntax was modified from https://golang.org/src/cmd/go/vcs.go.
+	scpSyntax = regexp.MustCompile(`^([a-zA-Z0-9_]+@)?([a-zA-Z0-9._-]+):([a-zA-Z0-9./._-]+)(?:\?||$)(.*)$`)
+
+	// Transports is a set of known Git URL schemes.
+	Transports = NewTransportSet(
+		"ssh",
+		"git",
+		"git+ssh",
+		"http",
+		"https",
+		"ftp",
+		"ftps",
+		"rsync",
+		"file",
+	)
+)
+
+// Parser converts a string into a URL.
+type Parser func(string) (*url.URL, error)
+
+// Parse parses rawurl into a URL structure. Parse first attempts to
+// find a standard URL with a valid Git transport as its scheme. If
+// that cannot be found, it then attempts to find a SCP-like URL. And
+// if that cannot be found, it assumes rawurl is a local path. If none
+// of these rules apply, Parse returns an error.
+func Parse(rawurl string) (u *url.URL, err error) {
+	parsers := []Parser{
+		ParseTransport,
+		ParseScp,
+		ParseLocal,
+	}
+
+	// Apply each parser in turn; if the parser succeeds, accept its
+	// result and return.
+	for _, p := range parsers {
+		u, err = p(rawurl)
+		if err == nil {
+			return u, err
+		}
+	}
+
+	// It's unlikely that none of the parsers will succeed, since
+	// ParseLocal is very forgiving.
+	return new(url.URL), fmt.Errorf("failed to parse %q", rawurl)
+}
+
+// ParseTransport parses rawurl into a URL object. Unless the URL's
+// scheme is a known Git transport, ParseTransport returns an error.
+func ParseTransport(rawurl string) (*url.URL, error) {
+	u, err := url.Parse(rawurl)
+	if err == nil && !Transports.Valid(u.Scheme) {
+		err = fmt.Errorf("scheme %q is not a valid transport", u.Scheme)
+	}
+	return u, err
+}
+
+// ParseScp parses rawurl into a URL object. The rawurl must be
+// an SCP-like URL, otherwise ParseScp returns an error.
+func ParseScp(rawurl string) (*url.URL, error) {
+	match := scpSyntax.FindAllStringSubmatch(rawurl, -1)
+	if len(match) == 0 {
+		return nil, fmt.Errorf("no scp URL found in %q", rawurl)
+	}
+	m := match[0]
+	user := strings.TrimRight(m[1], "@")
+	var userinfo *url.Userinfo
+	if user != "" {
+		userinfo = url.User(user)
+	}
+	rawquery := ""
+	if len(m) > 3 {
+		rawquery = m[4]
+	}
+	return &url.URL{
+		Scheme:   "ssh",
+		User:     userinfo,
+		Host:     m[2],
+		Path:     m[3],
+		RawQuery: rawquery,
+	}, nil
+}
+
+// ParseLocal parses rawurl into a URL object with a "file"
+// scheme. This will effectively never return an error.
+func ParseLocal(rawurl string) (*url.URL, error) {
+	return &url.URL{
+		Scheme: "file",
+		Host:   "",
+		Path:   rawurl,
+	}, nil
+}
+
+// TransportSet represents a set of valid Git transport schemes. It
+// maps these schemes to empty structs, providing a set-like
+// interface.
+type TransportSet struct {
+	Transports map[string]struct{}
+}
+
+// NewTransportSet returns a TransportSet with the items keys mapped
+// to empty struct values.
+func NewTransportSet(items ...string) *TransportSet {
+	t := &TransportSet{
+		Transports: map[string]struct{}{},
+	}
+	for _, i := range items {
+		t.Transports[i] = struct{}{}
+	}
+	return t
+}
+
+// Valid returns true if transport is a known Git URL scheme and false
+// if not.
+func (t *TransportSet) Valid(transport string) bool {
+	_, ok := t.Transports[transport]
+	return ok
+}

--- a/pkg/git/git-url/giturls/urls.go
+++ b/pkg/git/git-url/giturls/urls.go
@@ -32,7 +32,7 @@ import (
 
 var (
 	// scpSyntax was modified from https://golang.org/src/cmd/go/vcs.go.
-	scpSyntax = regexp.MustCompile(`^([a-zA-Z0-9_]+@)?([a-zA-Z0-9._-]+):([a-zA-Z0-9./._-]+)(?:\?||$)(.*)$`)
+	scpSyntax = regexp.MustCompile(`^([a-zA-Z0-9_]+@)?([a-zA-Z0-9._-]+):([0-9]+/)?([a-zA-Z0-9./._-]+)(?:\?||$)(.*)$`)
 
 	// Transports is a set of known Git URL schemes.
 	Transports = NewTransportSet(
@@ -101,14 +101,22 @@ func ParseScp(rawurl string) (*url.URL, error) {
 		userinfo = url.User(user)
 	}
 	rawquery := ""
-	if len(m) > 3 {
-		rawquery = m[4]
+	if len(m) > 4 {
+		rawquery = m[5]
+	}
+	host := m[2]
+	path := m[4]
+	if m[3] != "" {
+		port := strings.TrimRight(m[3], "/")
+		host = fmt.Sprintf("%s:%s", host, port)
+		// host.xyz:1234/path/ only supports absolute paths
+		path = "/" + path
 	}
 	return &url.URL{
 		Scheme:   "ssh",
 		User:     userinfo,
-		Host:     m[2],
-		Path:     m[3],
+		Host:     host,
+		Path:     path,
 		RawQuery: rawquery,
 	}, nil
 }

--- a/pkg/git/git-url/giturls/urls_test.go
+++ b/pkg/git/git-url/giturls/urls_test.go
@@ -1,0 +1,215 @@
+package giturls
+
+import (
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+var tests []*Test
+
+type Test struct {
+	in      string
+	wantURL *url.URL
+	wantStr string // expected result of reserializing the URL; empty means same as "in".
+}
+
+func NewTest(in, transport, user, host, path, str, rawquery string) *Test {
+	var userinfo *url.Userinfo
+
+	if user != "" {
+		if strings.Contains(user, ":") {
+			username := strings.Split(user, ":")[0]
+			password := strings.Split(user, ":")[1]
+			userinfo = url.UserPassword(username, password)
+		} else {
+			userinfo = url.User(user)
+		}
+	}
+	if str == "" {
+		str = in
+	}
+
+	return &Test{
+		in: in,
+		wantURL: &url.URL{
+			Scheme:   transport,
+			Host:     host,
+			Path:     path,
+			User:     userinfo,
+			RawQuery: rawquery,
+		},
+		wantStr: str,
+	}
+}
+
+func init() {
+	// https://www.kernel.org/pub/software/scm/git/docs/git-clone.html
+	tests = []*Test{
+		NewTest(
+			"user@host.xz:path/to/repo.git/",
+			"ssh", "user", "host.xz", "path/to/repo.git/",
+			"ssh://user@host.xz/path/to/repo.git/", "",
+		),
+		NewTest(
+			"host.xz:path/to/repo.git/",
+			"ssh", "", "host.xz", "path/to/repo.git/",
+			"ssh://host.xz/path/to/repo.git/", "",
+		),
+		NewTest(
+			"host.xz:/path/to/repo.git/",
+			"ssh", "", "host.xz", "/path/to/repo.git/",
+			"ssh://host.xz/path/to/repo.git/", "",
+		),
+		NewTest(
+			"host.xz:path/to/repo-with_specials.git/",
+			"ssh", "", "host.xz", "path/to/repo-with_specials.git/",
+			"ssh://host.xz/path/to/repo-with_specials.git/", "",
+		),
+		NewTest(
+			"git://host.xz/path/to/repo.git/",
+			"git", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"git://host.xz:1234/path/to/repo.git/",
+			"git", "", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"http://host.xz/path/to/repo.git/",
+			"http", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"http://host.xz:1234/path/to/repo.git/",
+			"http", "", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"https://host.xz/path/to/repo.git/",
+			"https", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"https://host.xz:1234/path/to/repo.git/",
+			"https", "", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"ftp://host.xz/path/to/repo.git/",
+			"ftp", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"ftp://host.xz:1234/path/to/repo.git/",
+			"ftp", "", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"ftps://host.xz/path/to/repo.git/",
+			"ftps", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"ftps://host.xz:1234/path/to/repo.git/",
+			"ftps", "", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"rsync://host.xz/path/to/repo.git/",
+			"rsync", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"ssh://user@host.xz:1234/path/to/repo.git/",
+			"ssh", "user", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"ssh://host.xz:1234/path/to/repo.git/",
+			"ssh", "", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"ssh://host.xz/path/to/repo.git/",
+			"ssh", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"git+ssh://host.xz/path/to/repo.git/",
+			"git+ssh", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"/path/to/repo.git/",
+			"file", "", "", "/path/to/repo.git/",
+			"file:///path/to/repo.git/", "",
+		),
+		NewTest(
+			"file:///path/to/repo.git/",
+			"file", "", "", "/path/to/repo.git/",
+			"", "",
+		),
+		// Tests with query strings
+		NewTest(
+			"https://host.xz/organization/repo.git?ref=",
+			"https", "", "host.xz", "/organization/repo.git",
+			"", "ref=",
+		),
+		NewTest(
+			"https://host.xz/organization/repo.git?ref=test",
+			"https", "", "host.xz", "/organization/repo.git",
+			"", "ref=test",
+		),
+		NewTest(
+			"https://host.xz/organization/repo.git?ref=feature/test",
+			"https", "", "host.xz", "/organization/repo.git",
+			"", "ref=feature/test",
+		),
+		NewTest(
+			"git@host.xz:organization/repo.git?ref=test",
+			"ssh", "git", "host.xz", "organization/repo.git",
+			"ssh://git@host.xz/organization/repo.git?ref=test", "ref=test",
+		),
+		NewTest(
+			"git@host.xz:organization/repo.git?ref=feature/test",
+			"ssh", "git", "host.xz", "organization/repo.git",
+			"ssh://git@host.xz/organization/repo.git?ref=feature/test", "ref=feature/test",
+		),
+		// Tests with user+password and some with query strings
+		NewTest(
+			"https://user:password@host.xz/organization/repo.git/",
+			"https", "user:password", "host.xz", "/organization/repo.git/",
+			"", "",
+		),
+		NewTest(
+			"https://user:password@host.xz/organization/repo.git?ref=test",
+			"https", "user:password", "host.xz", "/organization/repo.git",
+			"", "ref=test",
+		),
+		NewTest(
+			"https://user:password@host.xz/organization/repo.git?ref=feature/test",
+			"https", "user:password", "host.xz", "/organization/repo.git",
+			"", "ref=feature/test",
+		),
+	}
+}
+
+func TestParse(t *testing.T) {
+	for _, tt := range tests {
+		got, err := Parse(tt.in)
+		if err != nil {
+			t.Errorf("Parse(%q) = unexpected err %q, want %q", tt.in, err, tt.wantURL)
+			continue
+		}
+		if !reflect.DeepEqual(got, tt.wantURL) {
+			t.Errorf("Parse(%q) = %q, want %q", tt.in, got, tt.wantURL)
+		}
+		str := got.String()
+		if str != tt.wantStr {
+			t.Errorf("Parse(%q).String() = %q, want %q", tt.in, str, tt.wantStr)
+		}
+	}
+}

--- a/pkg/git/git-url/giturls/urls_test.go
+++ b/pkg/git/git-url/giturls/urls_test.go
@@ -68,6 +68,11 @@ func init() {
 			"ssh://host.xz/path/to/repo-with_specials.git/", "",
 		),
 		NewTest(
+			"host.xz:1234/path/to/repo-with_specials.git/",
+			"ssh", "", "host.xz:1234", "/path/to/repo-with_specials.git/",
+			"ssh://host.xz:1234/path/to/repo-with_specials.git/", "",
+		),
+		NewTest(
 			"git://host.xz/path/to/repo.git/",
 			"git", "", "host.xz", "/path/to/repo.git/",
 			"", "",

--- a/pkg/git/git-url/url.go
+++ b/pkg/git/git-url/url.go
@@ -2,7 +2,7 @@ package git_url
 
 import (
 	"fmt"
-	giturls "github.com/whilp/git-urls"
+	"github.com/kluctl/kluctl/v2/pkg/git/git-url/giturls"
 	"net/url"
 	"strings"
 )


### PR DESCRIPTION
# Description

This fixes simple overrides like `github.com:my-org/my-repo=/local/path/to/override` (as found in the docs).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
