### PR TITLE
docs: link to target discriminator gives a 404

### DIFF
--- a/docs/reference/kluctl-project/README.md
+++ b/docs/reference/kluctl-project/README.md
@@ -49,7 +49,7 @@ args:
 Specifies a default discriminator template to be used for targets that don't have
 their own discriminator specified.
 
-See [target discriminator](./targets/README.md#discriminator) for details.
+See [target discriminator](./targets/#discriminator) for details.
 
 ### targets
 


### PR DESCRIPTION
# Description

update link to `target discriminator` target page

