### PR TITLE
fix: Fix .git-credentials checking/loading/matching

### DIFF
--- a/pkg/git/auth/git_credentials_file.go
+++ b/pkg/git/auth/git_credentials_file.go
@@ -46,7 +46,7 @@ func (a *GitCredentialsFileAuthProvider) BuildAuth(ctx context.Context, gitUrl g
 
 func (a *GitCredentialsFileAuthProvider) tryBuildAuth(gitUrl git_url.GitUrl, gitCredentialsPath string) *AuthMethodAndCA {
 	st, err := os.Stat(gitCredentialsPath)
-	if err != nil || !st.Mode().IsDir() {
+	if err != nil || st.Mode().IsDir() {
 		return nil
 	}
 


### PR DESCRIPTION
# Description

A user in Slack reported that his .git-credentials file was not honoured anymore. This was due to a regression in the file existence check. This PR fixes this. It also fixes matching of credentials with different usernames.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
