### PR TITLE
fix: Honor ignore-conflicts even if force-apply is active for a field

### DIFF
--- a/pkg/diff/managed_fields_test.go
+++ b/pkg/diff/managed_fields_test.go
@@ -164,6 +164,42 @@ func TestResolveFieldManagerConflicts(t *testing.T) {
 			lost:   buildLost("d1"),
 			anns:   buildAnnotations("kluctl.io/ignore-conflicts-field-123", "data.d3"),
 		},
+		{
+			name:   "force-apply-object-ignore-conflicts",
+			remote: buildConfigMap(fieldInfo{"d1", "v1", "c1"}, fieldInfo{"d2", "v2", "m1"}, fieldInfo{"d3", "v3", "c1"}),
+			local:  buildConfigMap(fieldInfo{"d1", "x", "m1"}, fieldInfo{"d2", "x", "m1"}, fieldInfo{"d3", "x", "m1"}),
+			status: buildConflicts("d1", "d3"),
+			result: buildConfigMap(fieldInfo{"d2", "x", "m1"}),
+			lost:   buildLost(),
+			anns:   buildAnnotations("kluctl.io/force-apply", "true", "kluctl.io/ignore-conflicts", "true"),
+		},
+		{
+			name:   "force-apply-object-ignore-conflicts-field",
+			remote: buildConfigMap(fieldInfo{"d1", "v1", "c1"}, fieldInfo{"d2", "v2", "m1"}, fieldInfo{"d3", "v3", "c1"}),
+			local:  buildConfigMap(fieldInfo{"d1", "x", "m1"}, fieldInfo{"d2", "x", "m1"}, fieldInfo{"d3", "x", "m1"}),
+			status: buildConflicts("d1", "d3"),
+			result: buildConfigMap(fieldInfo{"d2", "x", "m1"}, fieldInfo{"d3", "x", "m1"}),
+			lost:   buildLost(),
+			anns:   buildAnnotations("kluctl.io/force-apply", "true", "kluctl.io/ignore-conflicts-field", "data.d1"),
+		},
+		{
+			name:   "force-apply-field-ignore-conflicts",
+			remote: buildConfigMap(fieldInfo{"d1", "v1", "c1"}, fieldInfo{"d2", "v2", "m1"}, fieldInfo{"d3", "v3", "c1"}),
+			local:  buildConfigMap(fieldInfo{"d1", "x", "m1"}, fieldInfo{"d2", "x", "m1"}, fieldInfo{"d3", "x", "m1"}),
+			status: buildConflicts("d1", "d3"),
+			result: buildConfigMap(fieldInfo{"d2", "x", "m1"}),
+			lost:   buildLost(),
+			anns:   buildAnnotations("kluctl.io/force-apply-field", "data.d1", "kluctl.io/ignore-conflicts", "true"),
+		},
+		{
+			name:   "force-apply-field-ignore-conflicts-field",
+			remote: buildConfigMap(fieldInfo{"d1", "v1", "c1"}, fieldInfo{"d2", "v2", "m1"}, fieldInfo{"d3", "v3", "c1"}),
+			local:  buildConfigMap(fieldInfo{"d1", "x", "m1"}, fieldInfo{"d2", "x", "m1"}, fieldInfo{"d3", "x", "m1"}),
+			status: buildConflicts("d1", "d3"),
+			result: buildConfigMap(fieldInfo{"d1", "x", "m1"}, fieldInfo{"d2", "x", "m1"}),
+			lost:   buildLost(),
+			anns:   buildAnnotations("kluctl.io/force-apply-field", "data.d1", "kluctl.io/ignore-conflicts-field", "data.d3"),
+		},
 	}
 
 	for _, tc := range tests {
@@ -185,8 +221,8 @@ func TestResolveFieldManagerConflicts(t *testing.T) {
 
 			r, l, err := ResolveFieldManagerConflicts(tc.local, tc.remote, tc.status)
 			assert.NoError(t, err)
-			assert.Equal(t, r, tc.result)
-			assert.Equal(t, l, tc.lost)
+			assert.Equal(t, tc.result, r)
+			assert.Equal(t, tc.lost, l)
 		})
 	}
 }


### PR DESCRIPTION
# Description

When an object has `kluctl.io/force-apply: true` and `kluctl.io/ignore-conflics-field: my.field` set at the same time, the `ignore-conflict` directive should have higher priority.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
