### PR TITLE
feat: Introduce command results written into the target cluster

### DIFF
--- a/cmd/kluctl/args/cobra_types.go
+++ b/cmd/kluctl/args/cobra_types.go
@@ -5,27 +5,27 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 )
 
-type existingPathType string
+type ExistingPathType string
 
-func (s *existingPathType) Set(val string) error {
+func (s *ExistingPathType) Set(val string) error {
 	if val != "-" {
 		val = utils.ExpandPath(val)
 	}
 	if !utils.Exists(val) {
 		return fmt.Errorf("%s does not exist", val)
 	}
-	*s = existingPathType(val)
+	*s = ExistingPathType(val)
 	return nil
 }
-func (s *existingPathType) Type() string {
+func (s *ExistingPathType) Type() string {
 	return "existingpath"
 }
 
-func (s *existingPathType) String() string { return string(*s) }
+func (s *ExistingPathType) String() string { return string(*s) }
 
-type existingFileType string
+type ExistingFileType string
 
-func (s *existingFileType) Set(val string) error {
+func (s *ExistingFileType) Set(val string) error {
 	if val != "-" {
 		val = utils.ExpandPath(val)
 	}
@@ -35,18 +35,18 @@ func (s *existingFileType) Set(val string) error {
 	if utils.IsDirectory(val) {
 		return fmt.Errorf("%s exists but is a directory", val)
 	}
-	*s = existingFileType(val)
+	*s = ExistingFileType(val)
 	return nil
 }
-func (s *existingFileType) Type() string {
+func (s *ExistingFileType) Type() string {
 	return "existingfile"
 }
 
-func (s *existingFileType) String() string { return string(*s) }
+func (s *ExistingFileType) String() string { return string(*s) }
 
-type existingDirType string
+type ExistingDirType string
 
-func (s *existingDirType) Set(val string) error {
+func (s *ExistingDirType) Set(val string) error {
 	if val != "-" {
 		val = utils.ExpandPath(val)
 	}
@@ -56,11 +56,11 @@ func (s *existingDirType) Set(val string) error {
 	if !utils.IsDirectory(val) {
 		return fmt.Errorf("%s exists but is not a directory", val)
 	}
-	*s = existingDirType(val)
+	*s = ExistingDirType(val)
 	return nil
 }
-func (s *existingDirType) Type() string {
+func (s *ExistingDirType) Type() string {
 	return "existingdir"
 }
 
-func (s *existingDirType) String() string { return string(*s) }
+func (s *ExistingDirType) String() string { return string(*s) }

--- a/cmd/kluctl/args/images.go
+++ b/cmd/kluctl/args/images.go
@@ -9,7 +9,7 @@ import (
 
 type ImageFlags struct {
 	FixedImage      []string         `group:"images" short:"F" help:"Pin an image to a given version. Expects '--fixed-image=image<:namespace:deployment:container>=result'"`
-	FixedImagesFile existingFileType `group:"images" help:"Use .yaml file to pin image versions. See output of list-images sub-command or read the documentation for details about the output format" exts:"yml,yaml"`
+	FixedImagesFile ExistingFileType `group:"images" help:"Use .yaml file to pin image versions. See output of list-images sub-command or read the documentation for details about the output format" exts:"yml,yaml"`
 }
 
 func (args *ImageFlags) LoadFixedImagesFromArgs() ([]types.FixedImage, error) {

--- a/cmd/kluctl/args/project.go
+++ b/cmd/kluctl/args/project.go
@@ -46,4 +46,5 @@ type CommandResultFlags struct {
 	NoWriteCommandResult    bool   `group:"results" help:"Disable writing of command results into the cluster."`
 	ForceWriteCommandResult bool   `group:"results" help:"Force writing of command results, even if the command is run in dry-run mode."`
 	CommandResultNamespace  string `group:"results" help:"Override the namespace to be used when writing command results." default:"kluctl-results"`
+	KeepCommandResultsCount int    `group:"results" help:"Configure how many old command results to keep." default:"10"`
 }

--- a/cmd/kluctl/args/project.go
+++ b/cmd/kluctl/args/project.go
@@ -6,7 +6,7 @@ import (
 )
 
 type ProjectDir struct {
-	ProjectDir existingDirType `group:"project" help:"Specify the project directory. Defaults to the current working directory."`
+	ProjectDir ExistingDirType `group:"project" help:"Specify the project directory. Defaults to the current working directory."`
 }
 
 func (a ProjectDir) GetProjectDir() (string, error) {
@@ -23,7 +23,7 @@ func (a ProjectDir) GetProjectDir() (string, error) {
 type ProjectFlags struct {
 	ProjectDir
 
-	ProjectConfig existingFileType `group:"project" short:"c" help:"Location of the .kluctl.yaml config file. Defaults to $PROJECT/.kluctl.yaml" exts:"yml,yaml"`
+	ProjectConfig ExistingFileType `group:"project" short:"c" help:"Location of the .kluctl.yaml config file. Defaults to $PROJECT/.kluctl.yaml" exts:"yml,yaml"`
 
 	Timeout                time.Duration `group:"project" help:"Specify timeout for all operations, including loading of the project, all external api calls and waiting for readiness." default:"10m"`
 	GitCacheUpdateInterval time.Duration `group:"project" help:"Specify the time to wait between git cache updates. Defaults to not wait at all and always updating caches."`

--- a/cmd/kluctl/args/project.go
+++ b/cmd/kluctl/args/project.go
@@ -43,6 +43,6 @@ type TargetFlags struct {
 }
 
 type CommandResultFlags struct {
-	WriteCommandResult     bool   `group:"results" help:"Enable experimental writing of command results into the cluster. Command results will be written into ConfigMaps in the kluctl-results namespace."`
+	NoWriteCommandResult   bool   `group:"results" help:"Disable writing of command results into the cluster."`
 	CommandResultNamespace string `group:"results" help:"Override the namespace to be used when writing command results." default:"kluctl-results"`
 }

--- a/cmd/kluctl/args/project.go
+++ b/cmd/kluctl/args/project.go
@@ -43,6 +43,7 @@ type TargetFlags struct {
 }
 
 type CommandResultFlags struct {
-	NoWriteCommandResult   bool   `group:"results" help:"Disable writing of command results into the cluster."`
-	CommandResultNamespace string `group:"results" help:"Override the namespace to be used when writing command results." default:"kluctl-results"`
+	NoWriteCommandResult    bool   `group:"results" help:"Disable writing of command results into the cluster."`
+	ForceWriteCommandResult bool   `group:"results" help:"Force writing of command results, even if the command is run in dry-run mode."`
+	CommandResultNamespace  string `group:"results" help:"Override the namespace to be used when writing command results." default:"kluctl-results"`
 }

--- a/cmd/kluctl/args/project.go
+++ b/cmd/kluctl/args/project.go
@@ -41,3 +41,8 @@ type TargetFlags struct {
 	TargetNameOverride string `group:"project" short:"T" help:"Overrides the target name. If -t is used at the same time, then the target will be looked up based on -t <name> and then renamed to the value of -T. If no target is specified via -t, then the no-name target is renamed to the value of -T."`
 	Context            string `group:"project" help:"Overrides the context name specified in the target. If the selected target does not specify a context or the no-name target is used, --context will override the currently active context."`
 }
+
+type CommandResultFlags struct {
+	WriteCommandResult     bool   `group:"results" help:"Enable experimental writing of command results into the cluster. Command results will be written into ConfigMaps in the kluctl-results namespace."`
+	CommandResultNamespace string `group:"results" help:"Override the namespace to be used when writing command results." default:"kluctl-results"`
+}

--- a/cmd/kluctl/commands/cmd_delete.go
+++ b/cmd/kluctl/commands/cmd_delete.go
@@ -8,8 +8,8 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/status"
-	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 )
 
 type deleteCmd struct {
@@ -72,7 +72,7 @@ func (cmd *deleteCmd) Run(ctx context.Context) error {
 	})
 }
 
-func confirmedDeleteObjects(ctx context.Context, k *k8s.K8sCluster, refs []k8s2.ObjectRef, dryRun bool, forceYes bool) (*types.CommandResult, error) {
+func confirmedDeleteObjects(ctx context.Context, k *k8s.K8sCluster, refs []k8s2.ObjectRef, dryRun bool, forceYes bool) (*result.CommandResult, error) {
 	if len(refs) != 0 {
 		_, _ = getStderr(ctx).WriteString("The following objects will be deleted:\n")
 		for _, ref := range refs {

--- a/cmd/kluctl/commands/cmd_delete.go
+++ b/cmd/kluctl/commands/cmd_delete.go
@@ -64,7 +64,7 @@ func (cmd *deleteCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, true)
+		err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, !cmd.DryRun || cmd.ForceWriteCommandResult)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_delete.go
+++ b/cmd/kluctl/commands/cmd_delete.go
@@ -43,6 +43,7 @@ func (cmd *deleteCmd) Run(ctx context.Context) error {
 		helmCredentials:      cmd.HelmCredentials,
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
+		needsResultStore:     true,
 	}
 	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
@@ -62,7 +63,7 @@ func (cmd *deleteCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(ctx, cmd.OutputFormatFlags, result)
+		err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, true)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_delete.go
+++ b/cmd/kluctl/commands/cmd_delete.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
 	"github.com/kluctl/kluctl/v2/pkg/status"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"time"
 )
 
 type deleteCmd struct {
@@ -43,6 +44,7 @@ func (cmd *deleteCmd) Run(ctx context.Context) error {
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 	}
+	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
 		discriminator := cmdCtx.targetCtx.Target.Discriminator
 		if cmd.Discriminator != "" {
@@ -56,7 +58,7 @@ func (cmd *deleteCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = addCommandInfo(result, "delete", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, &cmd.DryRunFlags, nil, nil, nil, false)
+		err = addCommandInfo(result, startTime, "delete", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, &cmd.DryRunFlags, nil, nil, nil, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_delete.go
+++ b/cmd/kluctl/commands/cmd_delete.go
@@ -21,6 +21,7 @@ type deleteCmd struct {
 	args.DryRunFlags
 	args.OutputFormatFlags
 	args.RenderOutputDirFlags
+	args.CommandResultFlags
 
 	Discriminator string `group:"misc" help:"Override the discriminator used to find objects for deletion."`
 }
@@ -43,7 +44,7 @@ func (cmd *deleteCmd) Run(ctx context.Context) error {
 		helmCredentials:      cmd.HelmCredentials,
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
-		needsResultStore:     true,
+		commandResultFlags:   &cmd.CommandResultFlags,
 	}
 	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {

--- a/cmd/kluctl/commands/cmd_delete.go
+++ b/cmd/kluctl/commands/cmd_delete.go
@@ -61,6 +61,10 @@ func (cmd *deleteCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		err = addCommandInfo(result, "delete", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, &cmd.DryRunFlags, nil, nil, nil, false)
+		if err != nil {
+			return err
+		}
 		err = outputCommandResult(ctx, cmd.OutputFormatFlags, result)
 		if err != nil {
 			return err

--- a/cmd/kluctl/commands/cmd_deploy.go
+++ b/cmd/kluctl/commands/cmd_deploy.go
@@ -25,6 +25,7 @@ type deployCmd struct {
 	args.HookFlags
 	args.OutputFormatFlags
 	args.RenderOutputDirFlags
+	args.CommandResultFlags
 
 	NoWait bool `group:"misc" help:"Don't wait for objects readiness'"`
 }
@@ -46,7 +47,7 @@ func (cmd *deployCmd) Run(ctx context.Context) error {
 		helmCredentials:      cmd.HelmCredentials,
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
-		needsResultStore:     true,
+		commandResultFlags:   &cmd.CommandResultFlags,
 	}
 	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {

--- a/cmd/kluctl/commands/cmd_deploy.go
+++ b/cmd/kluctl/commands/cmd_deploy.go
@@ -74,6 +74,10 @@ func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
 	if err != nil {
 		return err
 	}
+	err = addCommandInfo(result, "deploy", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, &cmd.DryRunFlags, &cmd.ForceApplyFlags, &cmd.ReplaceOnErrorFlags, &cmd.AbortOnErrorFlags, cmd.NoWait)
+	if err != nil {
+		return err
+	}
 	err = outputCommandResult(cmdCtx.ctx, cmd.OutputFormatFlags, result)
 	if err != nil {
 		return err

--- a/cmd/kluctl/commands/cmd_deploy.go
+++ b/cmd/kluctl/commands/cmd_deploy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
 	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/types/result"
+	"time"
 )
 
 type deployCmd struct {
@@ -46,12 +47,13 @@ func (cmd *deployCmd) Run(ctx context.Context) error {
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 	}
+	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
-		return cmd.runCmdDeploy(cmdCtx)
+		return cmd.runCmdDeploy(cmdCtx, startTime)
 	})
 }
 
-func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
+func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx, startTime time.Time) error {
 	status.Trace(cmdCtx.ctx, "enter runCmdDeploy")
 	defer status.Trace(cmdCtx.ctx, "leave runCmdDeploy")
 
@@ -74,7 +76,7 @@ func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
 	if err != nil {
 		return err
 	}
-	err = addCommandInfo(result, "deploy", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, &cmd.DryRunFlags, &cmd.ForceApplyFlags, &cmd.ReplaceOnErrorFlags, &cmd.AbortOnErrorFlags, cmd.NoWait)
+	err = addCommandInfo(result, startTime, "deploy", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, &cmd.DryRunFlags, &cmd.ForceApplyFlags, &cmd.ReplaceOnErrorFlags, &cmd.AbortOnErrorFlags, cmd.NoWait)
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/cmd_deploy.go
+++ b/cmd/kluctl/commands/cmd_deploy.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
 	"github.com/kluctl/kluctl/v2/pkg/status"
-	"github.com/kluctl/kluctl/v2/pkg/types"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 )
 
 type deployCmd struct {
@@ -63,7 +63,7 @@ func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
 	cmd2.ReadinessTimeout = cmd.ReadinessTimeout
 	cmd2.NoWait = cmd.NoWait
 
-	cb := func(diffResult *types.CommandResult) error {
+	cb := func(diffResult *result.CommandResult) error {
 		return cmd.diffResultCb(cmdCtx.ctx, diffResult)
 	}
 	if cmd.Yes || cmd.DryRun {
@@ -84,7 +84,7 @@ func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
 	return nil
 }
 
-func (cmd *deployCmd) diffResultCb(ctx context.Context, diffResult *types.CommandResult) error {
+func (cmd *deployCmd) diffResultCb(ctx context.Context, diffResult *result.CommandResult) error {
 	flags := cmd.OutputFormatFlags
 	flags.OutputFormat = nil // use default output format
 

--- a/cmd/kluctl/commands/cmd_deploy.go
+++ b/cmd/kluctl/commands/cmd_deploy.go
@@ -82,7 +82,7 @@ func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx, startTime time.Time) erro
 	if err != nil {
 		return err
 	}
-	err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, true)
+	err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, !cmd.DryRun || cmd.ForceWriteCommandResult)
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/cmd_diff.go
+++ b/cmd/kluctl/commands/cmd_diff.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
+	"time"
 )
 
 type diffCmd struct {
@@ -38,6 +39,7 @@ func (cmd *diffCmd) Run(ctx context.Context) error {
 		helmCredentials:      cmd.HelmCredentials,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 	}
+	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
 		cmd2 := commands.NewDiffCommand(cmdCtx.targetCtx.Target.Discriminator, cmdCtx.targetCtx.DeploymentCollection)
 		cmd2.ForceApply = cmd.ForceApply
@@ -50,7 +52,7 @@ func (cmd *diffCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = addCommandInfo(result, "diff", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, nil, &cmd.ForceApplyFlags, &cmd.ReplaceOnErrorFlags, nil, false)
+		err = addCommandInfo(result, startTime, "diff", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, nil, &cmd.ForceApplyFlags, &cmd.ReplaceOnErrorFlags, nil, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_diff.go
+++ b/cmd/kluctl/commands/cmd_diff.go
@@ -20,6 +20,7 @@ type diffCmd struct {
 	args.IgnoreFlags
 	args.OutputFormatFlags
 	args.RenderOutputDirFlags
+	args.CommandResultFlags
 }
 
 func (cmd *diffCmd) Help() string {
@@ -38,6 +39,7 @@ func (cmd *diffCmd) Run(ctx context.Context) error {
 		inclusionFlags:       cmd.InclusionFlags,
 		helmCredentials:      cmd.HelmCredentials,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
+		commandResultFlags:   &cmd.CommandResultFlags,
 	}
 	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
@@ -56,7 +58,7 @@ func (cmd *diffCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, false)
+		err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, true)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_diff.go
+++ b/cmd/kluctl/commands/cmd_diff.go
@@ -20,7 +20,6 @@ type diffCmd struct {
 	args.IgnoreFlags
 	args.OutputFormatFlags
 	args.RenderOutputDirFlags
-	args.CommandResultFlags
 }
 
 func (cmd *diffCmd) Help() string {
@@ -39,7 +38,6 @@ func (cmd *diffCmd) Run(ctx context.Context) error {
 		inclusionFlags:       cmd.InclusionFlags,
 		helmCredentials:      cmd.HelmCredentials,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
-		commandResultFlags:   &cmd.CommandResultFlags,
 	}
 	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
@@ -58,7 +56,7 @@ func (cmd *diffCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, true)
+		err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_diff.go
+++ b/cmd/kluctl/commands/cmd_diff.go
@@ -50,6 +50,10 @@ func (cmd *diffCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		err = addCommandInfo(result, "diff", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, nil, &cmd.ForceApplyFlags, &cmd.ReplaceOnErrorFlags, nil, false)
+		if err != nil {
+			return err
+		}
 		err = outputCommandResult(ctx, cmd.OutputFormatFlags, result)
 		if err != nil {
 			return err

--- a/cmd/kluctl/commands/cmd_diff.go
+++ b/cmd/kluctl/commands/cmd_diff.go
@@ -56,7 +56,7 @@ func (cmd *diffCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(ctx, cmd.OutputFormatFlags, result)
+		err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_flux_reconcile.go
+++ b/cmd/kluctl/commands/cmd_flux_reconcile.go
@@ -36,7 +36,7 @@ func (cmd *fluxReconcileCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	ref := k8s2.ObjectRef{GVK: args.KluctlDeploymentGVK, Name: kd, Namespace: ns}
+	ref := k8s2.NewObjectRef(args.KluctlDeploymentGVK.Group, args.KluctlDeploymentGVK.Version, args.KluctlDeploymentGVK.Kind, kd, ns)
 	patch := []k8s.JsonPatch{{
 		Op:   "replace",
 		Path: "/metadata/annotations",
@@ -59,7 +59,7 @@ func (cmd *fluxReconcileCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		ref2 := k8s2.ObjectRef{GVK: args.GitRepositoryGVK, Name: sourceName, Namespace: sourceNamespace}
+		ref2 := k8s2.NewObjectRef(args.GitRepositoryGVK.Group, args.GitRepositoryGVK.Version, args.GitRepositoryGVK.Kind, sourceName, sourceNamespace)
 
 		s := status.Start(ctx, "Annotating Source %s in %s namespace", sourceName, sourceNamespace)
 		defer s.Failed()

--- a/cmd/kluctl/commands/cmd_flux_resume.go
+++ b/cmd/kluctl/commands/cmd_flux_resume.go
@@ -27,7 +27,7 @@ func (cmd *fluxResumeCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	ref := k8s2.ObjectRef{GVK: args.KluctlDeploymentGVK, Name: kd, Namespace: ns}
+	ref := k8s2.NewObjectRef(args.KluctlDeploymentGVK.Group, args.KluctlDeploymentGVK.Version, args.KluctlDeploymentGVK.Kind, kd, ns)
 
 	patch := []k8s.JsonPatch{{
 		Op:    "replace",

--- a/cmd/kluctl/commands/cmd_flux_suspend.go
+++ b/cmd/kluctl/commands/cmd_flux_suspend.go
@@ -26,7 +26,7 @@ func (cmd *fluxSuspendCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	ref := k8s2.ObjectRef{GVK: args.KluctlDeploymentGVK, Name: kd, Namespace: ns}
+	ref := k8s2.NewObjectRef(args.KluctlDeploymentGVK.Group, args.KluctlDeploymentGVK.Version, args.KluctlDeploymentGVK.Kind, kd, ns)
 	patch := []k8s.JsonPatch{{
 		Op:    "replace",
 		Path:  "/spec/suspend",

--- a/cmd/kluctl/commands/cmd_poke_images.go
+++ b/cmd/kluctl/commands/cmd_poke_images.go
@@ -51,6 +51,10 @@ func (cmd *pokeImagesCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		err = addCommandInfo(result, "poke-images", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, &cmd.DryRunFlags, nil, nil, nil, false)
+		if err != nil {
+			return err
+		}
 		err = outputCommandResult(ctx, cmd.OutputFormatFlags, result)
 		if err != nil {
 			return err

--- a/cmd/kluctl/commands/cmd_poke_images.go
+++ b/cmd/kluctl/commands/cmd_poke_images.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
 	"github.com/kluctl/kluctl/v2/pkg/status"
+	"time"
 )
 
 type pokeImagesCmd struct {
@@ -38,6 +39,7 @@ func (cmd *pokeImagesCmd) Run(ctx context.Context) error {
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 	}
+	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
 		if !cmd.Yes && !cmd.DryRun {
 			if !status.AskForConfirmation(ctx, fmt.Sprintf("Do you really want to poke images to the context/cluster %s?", cmdCtx.targetCtx.ClusterContext)) {
@@ -51,7 +53,7 @@ func (cmd *pokeImagesCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = addCommandInfo(result, "poke-images", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, &cmd.DryRunFlags, nil, nil, nil, false)
+		err = addCommandInfo(result, startTime, "poke-images", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, &cmd.DryRunFlags, nil, nil, nil, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_poke_images.go
+++ b/cmd/kluctl/commands/cmd_poke_images.go
@@ -38,6 +38,7 @@ func (cmd *pokeImagesCmd) Run(ctx context.Context) error {
 		helmCredentials:      cmd.HelmCredentials,
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
+		needsResultStore:     true,
 	}
 	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
@@ -57,7 +58,7 @@ func (cmd *pokeImagesCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(ctx, cmd.OutputFormatFlags, result)
+		err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, true)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_poke_images.go
+++ b/cmd/kluctl/commands/cmd_poke_images.go
@@ -20,6 +20,7 @@ type pokeImagesCmd struct {
 	args.DryRunFlags
 	args.OutputFormatFlags
 	args.RenderOutputDirFlags
+	args.CommandResultFlags
 }
 
 func (cmd *pokeImagesCmd) Help() string {
@@ -38,7 +39,7 @@ func (cmd *pokeImagesCmd) Run(ctx context.Context) error {
 		helmCredentials:      cmd.HelmCredentials,
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
-		needsResultStore:     true,
+		commandResultFlags:   &cmd.CommandResultFlags,
 	}
 	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {

--- a/cmd/kluctl/commands/cmd_poke_images.go
+++ b/cmd/kluctl/commands/cmd_poke_images.go
@@ -59,7 +59,7 @@ func (cmd *pokeImagesCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, true)
+		err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, !cmd.DryRun || cmd.ForceWriteCommandResult)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_prune.go
+++ b/cmd/kluctl/commands/cmd_prune.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"time"
 )
 
 type pruneCmd struct {
@@ -40,12 +41,13 @@ func (cmd *pruneCmd) Run(ctx context.Context) error {
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 	}
+	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
-		return cmd.runCmdPrune(cmdCtx)
+		return cmd.runCmdPrune(cmdCtx, startTime)
 	})
 }
 
-func (cmd *pruneCmd) runCmdPrune(cmdCtx *commandCtx) error {
+func (cmd *pruneCmd) runCmdPrune(cmdCtx *commandCtx, startTime time.Time) error {
 	cmd2 := commands.NewPruneCommand(cmdCtx.targetCtx.Target.Discriminator, cmdCtx.targetCtx.DeploymentCollection)
 	result, err := cmd2.Run(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K, func(refs []k8s2.ObjectRef) error {
 		return confirmDeletion(cmdCtx.ctx, refs, cmd.DryRun, cmd.Yes)
@@ -53,7 +55,7 @@ func (cmd *pruneCmd) runCmdPrune(cmdCtx *commandCtx) error {
 	if err != nil {
 		return err
 	}
-	err = addCommandInfo(result, "prune", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, &cmd.DryRunFlags, nil, nil, nil, false)
+	err = addCommandInfo(result, startTime, "prune", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, &cmd.DryRunFlags, nil, nil, nil, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/cmd_prune.go
+++ b/cmd/kluctl/commands/cmd_prune.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
+	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
 )
 
 type pruneCmd struct {
@@ -46,11 +47,9 @@ func (cmd *pruneCmd) Run(ctx context.Context) error {
 
 func (cmd *pruneCmd) runCmdPrune(cmdCtx *commandCtx) error {
 	cmd2 := commands.NewPruneCommand(cmdCtx.targetCtx.Target.Discriminator, cmdCtx.targetCtx.DeploymentCollection)
-	objects, err := cmd2.Run(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K)
-	if err != nil {
-		return err
-	}
-	result, err := confirmedDeleteObjects(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K, objects, cmd.DryRun, cmd.Yes)
+	result, err := cmd2.Run(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K, func(refs []k8s2.ObjectRef) error {
+		return confirmDeletion(cmdCtx.ctx, refs, cmd.DryRun, cmd.Yes)
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/cmd_prune.go
+++ b/cmd/kluctl/commands/cmd_prune.go
@@ -20,6 +20,7 @@ type pruneCmd struct {
 	args.DryRunFlags
 	args.OutputFormatFlags
 	args.RenderOutputDirFlags
+	args.CommandResultFlags
 }
 
 func (cmd *pruneCmd) Help() string {
@@ -40,7 +41,7 @@ func (cmd *pruneCmd) Run(ctx context.Context) error {
 		helmCredentials:      cmd.HelmCredentials,
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
-		needsResultStore:     true,
+		commandResultFlags:   &cmd.CommandResultFlags,
 	}
 	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {

--- a/cmd/kluctl/commands/cmd_prune.go
+++ b/cmd/kluctl/commands/cmd_prune.go
@@ -40,6 +40,7 @@ func (cmd *pruneCmd) Run(ctx context.Context) error {
 		helmCredentials:      cmd.HelmCredentials,
 		dryRunArgs:           &cmd.DryRunFlags,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
+		needsResultStore:     true,
 	}
 	startTime := time.Now()
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
@@ -59,7 +60,7 @@ func (cmd *pruneCmd) runCmdPrune(cmdCtx *commandCtx, startTime time.Time) error 
 	if err != nil {
 		return err
 	}
-	err = outputCommandResult(cmdCtx.ctx, cmd.OutputFormatFlags, result)
+	err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, true)
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/cmd_prune.go
+++ b/cmd/kluctl/commands/cmd_prune.go
@@ -54,6 +54,10 @@ func (cmd *pruneCmd) runCmdPrune(cmdCtx *commandCtx) error {
 	if err != nil {
 		return err
 	}
+	err = addCommandInfo(result, "prune", cmdCtx, &cmd.TargetFlags, &cmd.ImageFlags, &cmd.InclusionFlags, &cmd.DryRunFlags, nil, nil, nil, false)
+	if err != nil {
+		return err
+	}
 	err = outputCommandResult(cmdCtx.ctx, cmd.OutputFormatFlags, result)
 	if err != nil {
 		return err

--- a/cmd/kluctl/commands/cmd_prune.go
+++ b/cmd/kluctl/commands/cmd_prune.go
@@ -61,7 +61,7 @@ func (cmd *pruneCmd) runCmdPrune(cmdCtx *commandCtx, startTime time.Time) error 
 	if err != nil {
 		return err
 	}
-	err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, true)
+	err = outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, !cmd.DryRun || cmd.ForceWriteCommandResult)
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/cmd_validate.go
+++ b/cmd/kluctl/commands/cmd_validate.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/deployment/commands"
+	k8s2 "github.com/kluctl/kluctl/v2/pkg/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
+	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	"time"
 )
 
@@ -16,6 +19,8 @@ type validateCmd struct {
 	args.HelmCredentials
 	args.OutputFlags
 	args.RenderOutputDirFlags
+
+	CommandResult args.ExistingFileType `group:"misc" help:"Specify a command result to use instead of loading a project. This will also perform drift detection."`
 
 	Wait             time.Duration `group:"misc" help:"Wait for the given amount of time until the deployment validates"`
 	Sleep            time.Duration `group:"misc" help:"Sleep duration between validation attempts" default:"5s"`
@@ -37,43 +42,76 @@ func (cmd *validateCmd) Run(ctx context.Context) error {
 		helmCredentials:      cmd.HelmCredentials,
 		renderOutputDirFlags: cmd.RenderOutputDirFlags,
 	}
-	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
-		startTime := time.Now()
-		cmd2 := commands.NewValidateCommand(cmdCtx.ctx, cmdCtx.targetCtx.Target.Discriminator, cmdCtx.targetCtx.DeploymentCollection)
-		for true {
-			result, err := cmd2.Run(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K)
-			if err != nil {
-				return err
-			}
-			failed := len(result.Errors) != 0 || (cmd.WarningsAsErrors && len(result.Warnings) != 0)
 
-			err = outputValidateResult(ctx, cmd.Output, result)
-			if err != nil {
-				return err
-			}
-
-			if !failed {
-				_, _ = getStderr(ctx).WriteString("Validation succeeded\n")
-				return nil
-			}
-
-			if cmd.Wait <= 0 || time.Now().Sub(startTime) > cmd.Wait {
-				return fmt.Errorf("Validation failed")
-			}
-
-			time.Sleep(cmd.Sleep)
-
-			// Need to force re-requesting these objects
-			for _, e := range result.Results {
-				cmd2.ForgetRemoteObject(e.Ref)
-			}
-			for _, e := range result.Warnings {
-				cmd2.ForgetRemoteObject(e.Ref)
-			}
-			for _, e := range result.Errors {
-				cmd2.ForgetRemoteObject(e.Ref)
-			}
+	if cmd.CommandResult.String() != "" {
+		var ccr result.CompactedCommandResult
+		err := yaml.ReadYamlFile(cmd.CommandResult.String(), &ccr)
+		if err != nil {
+			return err
 		}
-		return nil
-	})
+		commandResult := ccr.ToNonCompacted()
+
+		var k8sContext *string
+		if cmd.Context != "" {
+			k8sContext = &cmd.Context
+		} else if commandResult.Command.Target != nil {
+			k8sContext = commandResult.Command.Target.Context
+		}
+		clientFactory, err := k8s2.NewClientFactoryFromDefaultConfig(ctx, k8sContext)
+		if err != nil {
+			return err
+		}
+		k, err := k8s2.NewK8sCluster(ctx, clientFactory, true)
+		if err != nil {
+			return err
+		}
+
+		cmd2 := commands.NewValidateCommand(ctx, "", nil, commandResult)
+		return cmd.doValidate(ctx, k, cmd2)
+
+	} else {
+		return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
+			cmd2 := commands.NewValidateCommand(cmdCtx.ctx, cmdCtx.targetCtx.Target.Discriminator, cmdCtx.targetCtx.DeploymentCollection, nil)
+			return cmd.doValidate(cmdCtx.ctx, cmdCtx.targetCtx.SharedContext.K, cmd2)
+		})
+	}
+}
+
+func (cmd *validateCmd) doValidate(ctx context.Context, k *k8s2.K8sCluster, cmd2 *commands.ValidateCommand) error {
+	startTime := time.Now()
+	for true {
+		result, err := cmd2.Run(ctx, k)
+		if err != nil {
+			return err
+		}
+		failed := len(result.Errors) != 0 || (cmd.WarningsAsErrors && len(result.Warnings) != 0)
+
+		err = outputValidateResult(ctx, cmd.Output, result)
+		if err != nil {
+			return err
+		}
+
+		if !failed {
+			_, _ = getStderr(ctx).WriteString("Validation succeeded\n")
+			return nil
+		}
+
+		if cmd.Wait <= 0 || time.Now().Sub(startTime) > cmd.Wait {
+			return fmt.Errorf("Validation failed")
+		}
+
+		time.Sleep(cmd.Sleep)
+
+		// Need to force re-requesting these objects
+		for _, e := range result.Results {
+			cmd2.ForgetRemoteObject(e.Ref)
+		}
+		for _, e := range result.Warnings {
+			cmd2.ForgetRemoteObject(e.Ref)
+		}
+		for _, e := range result.Errors {
+			cmd2.ForgetRemoteObject(e.Ref)
+		}
+	}
+	return nil
 }

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -174,6 +174,23 @@ func formatValidateResultText(vr *result.ValidateResult) string {
 		buf.WriteString("Results:\n")
 		prettyValidationResults(buf, vr.Results)
 	}
+
+	if len(vr.Drift) != 0 {
+		if buf.Len() != 0 {
+			buf.WriteString("\n")
+		}
+		buf.WriteString("Drift:\n")
+		for i, o := range vr.Drift {
+			if len(o.Changes) == 0 {
+				continue
+			}
+			if i != 0 {
+				buf.WriteString("\n")
+			}
+			prettyChanges(buf, o.Ref, o.Changes)
+		}
+	}
+
 	return buf.String()
 }
 

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -90,7 +90,7 @@ func prettyErrors(buf io.StringWriter, errors []result.DeploymentError) {
 		if s := e.Ref.String(); s != "" {
 			prefix = fmt.Sprintf("%s: ", s)
 		}
-		_, _ = buf.WriteString(fmt.Sprintf("  %s%s\n", prefix, e.Error))
+		_, _ = buf.WriteString(fmt.Sprintf("  %s%s\n", prefix, e.Message))
 	}
 }
 

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -7,8 +7,8 @@ import (
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/diff"
 	"github.com/kluctl/kluctl/v2/pkg/status"
-	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	"io"
@@ -16,7 +16,7 @@ import (
 	"strings"
 )
 
-func formatCommandResultText(cr *types.CommandResult, short bool) string {
+func formatCommandResultText(cr *result.CommandResult, short bool) string {
 	buf := bytes.NewBuffer(nil)
 
 	if len(cr.Warnings) != 0 {
@@ -84,7 +84,7 @@ func prettyObjectRefs(buf io.StringWriter, refs []k8s.ObjectRef) {
 	}
 }
 
-func prettyErrors(buf io.StringWriter, errors []types.DeploymentError) {
+func prettyErrors(buf io.StringWriter, errors []result.DeploymentError) {
 	for _, e := range errors {
 		prefix := ""
 		if s := e.Ref.String(); s != "" {
@@ -94,7 +94,7 @@ func prettyErrors(buf io.StringWriter, errors []types.DeploymentError) {
 	}
 }
 
-func prettyChanges(buf io.StringWriter, ref k8s.ObjectRef, changes []types.Change) {
+func prettyChanges(buf io.StringWriter, ref k8s.ObjectRef, changes []result.Change) {
 	_, _ = buf.WriteString(fmt.Sprintf("Diff for object %s\n", ref.String()))
 
 	var t utils.PrettyTable
@@ -107,7 +107,7 @@ func prettyChanges(buf io.StringWriter, ref k8s.ObjectRef, changes []types.Chang
 	_, _ = buf.WriteString(s)
 }
 
-func formatCommandResultYaml(cr *types.CommandResult) (string, error) {
+func formatCommandResultYaml(cr *result.CommandResult) (string, error) {
 	b, err := yaml.WriteYamlString(cr)
 	if err != nil {
 		return "", err
@@ -115,7 +115,7 @@ func formatCommandResultYaml(cr *types.CommandResult) (string, error) {
 	return b, nil
 }
 
-func formatCommandResult(cr *types.CommandResult, format string, short bool) (string, error) {
+func formatCommandResult(cr *result.CommandResult, format string, short bool) (string, error) {
 	switch format {
 	case "text":
 		return formatCommandResultText(cr, short), nil
@@ -126,7 +126,7 @@ func formatCommandResult(cr *types.CommandResult, format string, short bool) (st
 	}
 }
 
-func prettyValidationResults(buf io.StringWriter, results []types.ValidateResultEntry) {
+func prettyValidationResults(buf io.StringWriter, results []result.ValidateResultEntry) {
 	var t utils.PrettyTable
 	t.AddRow("Object", "Message")
 
@@ -137,7 +137,7 @@ func prettyValidationResults(buf io.StringWriter, results []types.ValidateResult
 	_, _ = buf.WriteString(s)
 }
 
-func formatValidateResultText(vr *types.ValidateResult) string {
+func formatValidateResultText(vr *result.ValidateResult) string {
 	buf := bytes.NewBuffer(nil)
 
 	if len(vr.Warnings) != 0 {
@@ -163,7 +163,7 @@ func formatValidateResultText(vr *types.ValidateResult) string {
 	return buf.String()
 }
 
-func formatValidateResultYaml(vr *types.ValidateResult) (string, error) {
+func formatValidateResultYaml(vr *result.ValidateResult) (string, error) {
 	b, err := yaml.WriteYamlString(vr)
 	if err != nil {
 		return "", err
@@ -171,7 +171,7 @@ func formatValidateResultYaml(vr *types.ValidateResult) (string, error) {
 	return string(b), nil
 }
 
-func formatValidateResult(vr *types.ValidateResult, format string) (string, error) {
+func formatValidateResult(vr *result.ValidateResult, format string) (string, error) {
 	switch format {
 	case "text":
 		return formatValidateResultText(vr), nil
@@ -206,7 +206,7 @@ func outputHelper(ctx context.Context, output []string, cb func(format string) (
 	return nil
 }
 
-func outputCommandResult(ctx context.Context, flags args.OutputFormatFlags, cr *types.CommandResult) error {
+func outputCommandResult(ctx context.Context, flags args.OutputFormatFlags, cr *result.CommandResult) error {
 	status.Flush(ctx)
 
 	if !flags.NoObfuscate {
@@ -224,7 +224,7 @@ func outputCommandResult(ctx context.Context, flags args.OutputFormatFlags, cr *
 	})
 }
 
-func outputValidateResult(ctx context.Context, output []string, vr *types.ValidateResult) error {
+func outputValidateResult(ctx context.Context, output []string, vr *result.ValidateResult) error {
 	status.Flush(ctx)
 
 	return outputHelper(ctx, output, func(format string) (string, error) {

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -252,7 +252,7 @@ func outputCommandResult(ctx *commandCtx, flags args.OutputFormatFlags, cr *resu
 	if writeToResultStore && ctx.resultStore != nil {
 		s := status.Start(ctx.ctx, "Writing command result")
 		defer s.Failed()
-		resultStoreErr = ctx.resultStore.WriteCommandResult(ctx.ctx, cr)
+		resultStoreErr = ctx.resultStore.WriteCommandResult(cr)
 		if resultStoreErr != nil {
 			s.FailedWithMessage("Failed to write result to result store: %s", resultStoreErr.Error())
 		} else {

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -212,7 +212,19 @@ func outputCommandResult(ctx context.Context, flags args.OutputFormatFlags, cr *
 	if !flags.NoObfuscate {
 		var obfuscator diff.Obfuscator
 		for _, c := range cr.ChangedObjects {
-			err := obfuscator.Obfuscate(c.Ref, c.Changes)
+			err := obfuscator.ObfuscateChanges(c.Ref, c.Changes)
+			if err != nil {
+				return err
+			}
+		}
+		for _, n := range cr.NewObjects {
+			err := obfuscator.ObfuscateObject(n.Object)
+			if err != nil {
+				return err
+			}
+		}
+		for _, h := range cr.HookObjects {
+			err := obfuscator.ObfuscateObject(h.Object)
 			if err != nil {
 				return err
 			}

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -26,11 +26,7 @@ func formatCommandResultText(cr *result.CommandResult, short bool) string {
 
 	if len(cr.NewObjects) != 0 {
 		buf.WriteString("\nNew objects:\n")
-		var refs []k8s.ObjectRef
-		for _, o := range cr.NewObjects {
-			refs = append(refs, o.GetK8sRef())
-		}
-		prettyObjectRefs(buf, refs)
+		prettyObjectRefs(buf, cr.NewObjects)
 	}
 	if len(cr.ChangedObjects) != 0 {
 		buf.WriteString("\nChanged objects:\n")
@@ -57,10 +53,10 @@ func formatCommandResultText(cr *result.CommandResult, short bool) string {
 		prettyObjectRefs(buf, cr.DeletedObjects)
 	}
 
-	if len(cr.HookObjects) != 0 {
+	if len(cr.AppliedHookObjects) != 0 {
 		buf.WriteString("\nApplied hooks:\n")
 		var refs []k8s.ObjectRef
-		for _, o := range cr.HookObjects {
+		for _, o := range cr.AppliedHookObjects {
 			refs = append(refs, o.GetK8sRef())
 		}
 		prettyObjectRefs(buf, refs)

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -28,7 +28,7 @@ func formatCommandResultText(cr *result.CommandResult, short bool) string {
 		buf.WriteString("\nNew objects:\n")
 		var refs []k8s.ObjectRef
 		for _, o := range cr.NewObjects {
-			refs = append(refs, o.Ref)
+			refs = append(refs, o.GetK8sRef())
 		}
 		prettyObjectRefs(buf, refs)
 	}
@@ -61,7 +61,7 @@ func formatCommandResultText(cr *result.CommandResult, short bool) string {
 		buf.WriteString("\nApplied hooks:\n")
 		var refs []k8s.ObjectRef
 		for _, o := range cr.HookObjects {
-			refs = append(refs, o.Ref)
+			refs = append(refs, o.GetK8sRef())
 		}
 		prettyObjectRefs(buf, refs)
 	}

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -122,11 +122,7 @@ func prettyChanges(buf io.StringWriter, ref k8s.ObjectRef, changes []result.Chan
 }
 
 func formatCommandResultYaml(cr *result.CommandResult) (string, error) {
-	compactedCr := *cr
-	compactedCr.CompactedObjects = compactedCr.Objects
-	compactedCr.Objects = nil
-
-	b, err := yaml.WriteYamlString(compactedCr)
+	b, err := yaml.WriteYamlString(cr.ToCompacted())
 	if err != nil {
 		return "", err
 	}

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -211,23 +211,9 @@ func outputCommandResult(ctx context.Context, flags args.OutputFormatFlags, cr *
 
 	if !flags.NoObfuscate {
 		var obfuscator diff.Obfuscator
-		for _, c := range cr.ChangedObjects {
-			err := obfuscator.ObfuscateChanges(c.Ref, c.Changes)
-			if err != nil {
-				return err
-			}
-		}
-		for _, n := range cr.NewObjects {
-			err := obfuscator.ObfuscateObject(n.Object)
-			if err != nil {
-				return err
-			}
-		}
-		for _, h := range cr.HookObjects {
-			err := obfuscator.ObfuscateObject(h.Object)
-			if err != nil {
-				return err
-			}
+		err := obfuscator.ObfuscateResult(cr)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/cmd/kluctl/commands/root.go
+++ b/cmd/kluctl/commands/root.go
@@ -78,6 +78,7 @@ var flagGroups = []groupInfo{
 	{group: "inclusion", title: "Inclusion/Exclusion arguments:", description: "Control inclusion/exclusion."},
 	{group: "misc", title: "Misc arguments:", description: "Command specific arguments."},
 	{group: "flux", title: "Flux arguments:", description: "EXPERIMENTAL: Subcommands for interaction with flux-kluctl-controller"},
+	{group: "results", title: "Command Results:", description: "Configure how command results are stored."},
 }
 
 var origStderr = os.Stderr

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -246,6 +246,7 @@ func addCommandInfo(r *result.CommandResult, command string, ctx *commandCtx, ta
 		r.Command.AbortOnError = abortOnErrorFlags.AbortOnError
 	}
 	r.Deployment = &ctx.targetCtx.DeploymentProject.Config
+	r.RenderedObjects = ctx.targetCtx.DeploymentCollection.LocalObjects()
 	return nil
 }
 

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	git2 "github.com/go-git/go-git/v5"
-	"github.com/google/uuid"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"os"
@@ -214,7 +213,6 @@ func addCommandInfo(r *result.CommandResult, startTime time.Time, command string
 	imageFlags *args.ImageFlags, inclusionFlags *args.InclusionFlags,
 	dryRunFlags *args.DryRunFlags, forceApplyFlags *args.ForceApplyFlags, replaceOnErrorFlags *args.ReplaceOnErrorFlags, abortOnErrorFlags *args.AbortOnErrorFlags, noWait bool) error {
 	r.Command = result.CommandInfo{
-		Id:        uuid.New().String(),
 		Initiator: result.CommandInititiator_CommandLine,
 		StartTime: types.FromTime(startTime),
 		EndTime:   types.FromTime(time.Now()),

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -130,12 +130,12 @@ type projectTargetCommandArgs struct {
 	helmCredentials      args.HelmCredentials
 	dryRunArgs           *args.DryRunFlags
 	renderOutputDirFlags args.RenderOutputDirFlags
+	commandResultFlags   *args.CommandResultFlags
 
 	forSeal           bool
 	forCompletion     bool
 	offlineKubernetes bool
 	kubernetesVersion string
-	needsResultStore  bool
 }
 
 type commandCtx struct {
@@ -204,8 +204,8 @@ func withProjectTargetCommandContext(ctx context.Context, args projectTargetComm
 	}
 
 	var resultStore results.ResultStore
-	if args.needsResultStore {
-		resultStore, err = results.NewResultStoreSecrets(targetCtx.SharedContext.K, "kluctl-results")
+	if args.commandResultFlags != nil && args.commandResultFlags.WriteCommandResult {
+		resultStore, err = results.NewResultStoreSecrets(targetCtx.SharedContext.K, args.commandResultFlags.CommandResultNamespace)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -3,9 +3,11 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/deployment"
@@ -205,11 +207,13 @@ func withProjectTargetCommandContext(ctx context.Context, args projectTargetComm
 	return cb(cmdCtx)
 }
 
-func addCommandInfo(r *result.CommandResult, command string, ctx *commandCtx, targetFlags *args.TargetFlags,
+func addCommandInfo(r *result.CommandResult, startTime time.Time, command string, ctx *commandCtx, targetFlags *args.TargetFlags,
 	imageFlags *args.ImageFlags, inclusionFlags *args.InclusionFlags,
 	dryRunFlags *args.DryRunFlags, forceApplyFlags *args.ForceApplyFlags, replaceOnErrorFlags *args.ReplaceOnErrorFlags, abortOnErrorFlags *args.AbortOnErrorFlags, noWait bool) error {
 	r.Command = &result.CommandInfo{
 		Initiator: result.CommandInititiator_CommandLine,
+		StartTime: types.FromTime(startTime),
+		EndTime:   types.FromTime(time.Now()),
 		Command:   command,
 		Target:    ctx.targetCtx.Target,
 		Args:      ctx.targetCtx.KluctlProject.LoadArgs.ExternalArgs,

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -246,7 +246,6 @@ func addCommandInfo(r *result.CommandResult, command string, ctx *commandCtx, ta
 		r.Command.AbortOnError = abortOnErrorFlags.AbortOnError
 	}
 	r.Deployment = &ctx.targetCtx.DeploymentProject.Config
-	r.RenderedObjects = ctx.targetCtx.DeploymentCollection.LocalObjects()
 	return nil
 }
 

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -205,7 +205,7 @@ func withProjectTargetCommandContext(ctx context.Context, args projectTargetComm
 	}
 
 	var resultStore results.ResultStore
-	if args.commandResultFlags != nil && args.commandResultFlags.WriteCommandResult {
+	if args.commandResultFlags != nil && !args.commandResultFlags.NoWriteCommandResult {
 		rc, err := targetCtx.SharedContext.K.ToRESTConfig()
 		if err != nil {
 			return err

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -284,9 +284,7 @@ func addCommandInfo(r *result.CommandResult, startTime time.Time, command string
 		r.Target.TargetName = ctx.targetCtx.Target.Name
 		r.Target.Discriminator = ctx.targetCtx.Target.Discriminator
 	}
-	if r.ClusterInfo != nil {
-		r.Target.ClusterId = r.ClusterInfo.ClusterId
-	}
+	r.Target.ClusterId = r.ClusterInfo.ClusterId
 
 	return nil
 }
@@ -372,7 +370,7 @@ func addClusterInfo(r *result.CommandResult, ctx *commandCtx) error {
 	if clusterId == "" {
 		return fmt.Errorf("kube-system namespace has no uid")
 	}
-	r.ClusterInfo = &result.ClusterInfo{
+	r.ClusterInfo = result.ClusterInfo{
 		ClusterId: clusterId,
 	}
 	return nil

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -210,7 +210,7 @@ func withProjectTargetCommandContext(ctx context.Context, args projectTargetComm
 		if err != nil {
 			return err
 		}
-		resultStore, err = results.NewResultStoreSecrets(ctx, rc, args.commandResultFlags.CommandResultNamespace)
+		resultStore, err = results.NewResultStoreSecrets(ctx, rc, args.commandResultFlags.CommandResultNamespace, args.commandResultFlags.KeepCommandResultsCount)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -206,7 +206,11 @@ func withProjectTargetCommandContext(ctx context.Context, args projectTargetComm
 
 	var resultStore results.ResultStore
 	if args.commandResultFlags != nil && args.commandResultFlags.WriteCommandResult {
-		resultStore, err = results.NewResultStoreSecrets(targetCtx.SharedContext.K, args.commandResultFlags.CommandResultNamespace)
+		rc, err := targetCtx.SharedContext.K.ToRESTConfig()
+		if err != nil {
+			return err
+		}
+		resultStore, err = results.NewResultStoreSecrets(ctx, rc, args.commandResultFlags.CommandResultNamespace)
 		if err != nil {
 			return err
 		}
@@ -274,6 +278,14 @@ func addCommandInfo(r *result.CommandResult, startTime time.Time, command string
 	err = addClusterInfo(r, ctx)
 	if err != nil {
 		return err
+	}
+
+	if ctx.targetCtx.Target != nil {
+		r.Target.TargetName = ctx.targetCtx.Target.Name
+		r.Target.Discriminator = ctx.targetCtx.Target.Discriminator
+	}
+	if r.ClusterInfo != nil {
+		r.Target.ClusterId = r.ClusterInfo.ClusterId
 	}
 
 	return nil

--- a/docs/reference/commands/common-arguments.md
+++ b/docs/reference/commands/common-arguments.md
@@ -124,3 +124,20 @@ Inclusion/Exclusion arguments:
 
 ```
 <!-- END SECTION -->
+
+## Command Results arguments
+
+These arguments control how command results are stored.
+
+<!-- BEGIN SECTION "deploy" "Command Results" true -->
+```
+Command Results:
+  Configure how command results are stored.
+
+      --command-result-namespace string   Override the namespace to be used when writing command results. (default
+                                          "kluctl-results")
+      --write-command-result              Enable experimental writing of command results into the cluster. Command
+                                          results will be written into ConfigMaps in the kluctl-results namespace.
+
+```
+<!-- END SECTION -->

--- a/docs/reference/commands/common-arguments.md
+++ b/docs/reference/commands/common-arguments.md
@@ -136,8 +136,8 @@ Command Results:
 
       --command-result-namespace string   Override the namespace to be used when writing command results. (default
                                           "kluctl-results")
-      --write-command-result              Enable experimental writing of command results into the cluster. Command
-                                          results will be written into ConfigMaps in the kluctl-results namespace.
+      --force-write-command-result        Force writing of command results, even if the command is run in dry-run mode.
+      --no-write-command-result           Disable writing of command results into the cluster.
 
 ```
 <!-- END SECTION -->

--- a/docs/reference/commands/common-arguments.md
+++ b/docs/reference/commands/common-arguments.md
@@ -137,6 +137,7 @@ Command Results:
       --command-result-namespace string   Override the namespace to be used when writing command results. (default
                                           "kluctl-results")
       --force-write-command-result        Force writing of command results, even if the command is run in dry-run mode.
+      --keep-command-results-count int    Configure how many old command results to keep. (default 10)
       --no-write-command-result           Disable writing of command results into the cluster.
 
 ```

--- a/docs/reference/commands/validate.md
+++ b/docs/reference/commands/validate.md
@@ -31,6 +31,8 @@ In addition, the following arguments are available:
 Misc arguments:
   Command specific arguments.
 
+      --command-result existingfile                 Specify a command result to use instead of loading a project.
+                                                    This will also perform drift detection.
       --helm-insecure-skip-tls-verify stringArray   Controls skipping of TLS verification. Must be in the form
                                                     --helm-insecure-skip-tls-verify=<credentialsId>, where
                                                     <credentialsId> must match the id specified in the helm-chart.yaml.

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -25,12 +25,16 @@ func createNamespace(t *testing.T, k *test_utils.EnvTestCluster, namespace strin
 	}
 }
 
-func assertConfigMapExists(t *testing.T, k *test_utils.EnvTestCluster, namespace string, name string) *uo.UnstructuredObject {
-	x, err := k.Get(v1.SchemeGroupVersion.WithResource("configmaps"), namespace, name)
+func assertObjectExists(t *testing.T, k *test_utils.EnvTestCluster, gvr schema.GroupVersionResource, namespace string, name string) *uo.UnstructuredObject {
+	x, err := k.Get(gvr, namespace, name)
 	if err != nil {
 		t.Fatalf("unexpected error '%v' while getting ConfigMap %s/%s", err, namespace, name)
 	}
 	return x
+}
+
+func assertConfigMapExists(t *testing.T, k *test_utils.EnvTestCluster, namespace string, name string) *uo.UnstructuredObject {
+	return assertObjectExists(t, k, v1.SchemeGroupVersion.WithResource("configmaps"), namespace, name)
 }
 
 func assertConfigMapNotExists(t *testing.T, k *test_utils.EnvTestCluster, namespace string, name string) {

--- a/e2e/validate_test.go
+++ b/e2e/validate_test.go
@@ -1,0 +1,183 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	test_utils "github.com/kluctl/kluctl/v2/e2e/test-utils"
+	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
+	"github.com/kluctl/kluctl/v2/pkg/yaml"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"path/filepath"
+	"testing"
+)
+
+func buildDeployment(name string, namespace string, ready bool) *uo.UnstructuredObject {
+	deployment := uo.FromStringMust(fmt.Sprintf(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+`, name, namespace))
+	if ready {
+		deployment.Merge(uo.FromStringMust(`
+status:
+  availableReplicas: 1
+  conditions:
+  - lastTransitionTime: "2023-03-29T19:23:12Z"
+    lastUpdateTime: "2023-03-29T19:23:12Z"
+    message: Deployment has minimum availability.
+    reason: MinimumReplicasAvailable
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2023-03-29T19:22:30Z"
+    lastUpdateTime: "2023-03-29T19:23:12Z"
+    message: ReplicaSet "argocd-redis-8f7689686" has successfully progressed.
+    reason: NewReplicaSetAvailable
+    status: "True"
+    type: Progressing
+  observedGeneration: 1
+  readyReplicas: 1
+  replicas: 1
+`))
+	}
+	return deployment
+}
+
+func prepareValidateTest(t *testing.T, k *test_utils.EnvTestCluster) *test_utils.TestProject {
+	p := test_utils.NewTestProject(t)
+
+	createNamespace(t, k, p.TestSlug())
+
+	p.UpdateTarget("test", nil)
+
+	p.AddKustomizeDeployment("d1", []test_utils.KustomizeResource{
+		{fmt.Sprintf("configmap-%s.yml", "d1"), "", buildDeployment("d1", p.TestSlug(), false)},
+	}, nil)
+
+	return p
+}
+
+func assertValidate(t *testing.T, p *test_utils.TestProject, commandResult *string, succeed bool) (string, string) {
+	args := []string{"validate"}
+	if commandResult != nil {
+		args = append(args, "--command-result", *commandResult)
+	} else {
+		args = append(args, "-t", "test")
+	}
+	stdout, stderr, err := p.Kluctl(args...)
+
+	if succeed {
+		assert.NoError(t, err)
+		assert.NotContains(t, stdout, fmt.Sprintf("%s/Deployment/d1: readyReplicas field not in status or empty", p.TestSlug()))
+		assert.NotContains(t, stderr, "Validation failed")
+	} else {
+		assert.Error(t, err)
+		assert.Contains(t, stdout, fmt.Sprintf("%s/Deployment/d1: readyReplicas field not in status or empty", p.TestSlug()))
+		assert.Contains(t, stderr, "Validation failed")
+	}
+
+	return stdout, stderr
+}
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	k := defaultCluster1
+
+	p := prepareValidateTest(t, k)
+
+	p.KluctlMust("deploy", "--yes", "-t", "test")
+	assertObjectExists(t, k, appsv1.SchemeGroupVersion.WithResource("deployments"), p.TestSlug(), "d1")
+
+	assertValidate(t, p, nil, false)
+
+	readyDeployment := buildDeployment("d1", p.TestSlug(), true)
+
+	_, err := k.DynamicClient.Resource(appsv1.SchemeGroupVersion.WithResource("deployments")).Namespace(p.TestSlug()).
+		Patch(context.Background(), "d1", types.ApplyPatchType, []byte(yaml.WriteJsonStringMust(readyDeployment)), metav1.PatchOptions{
+			FieldManager: "test",
+		}, "status")
+	assert.NoError(t, err)
+
+	assertValidate(t, p, nil, true)
+}
+
+func TestValidateCommandResult(t *testing.T) {
+	t.Parallel()
+
+	k := defaultCluster1
+
+	p := prepareValidateTest(t, k)
+
+	resultPath := filepath.Join(t.TempDir(), "result.yaml")
+
+	p.KluctlMust("deploy", "--yes", "-t", "test", "-oyaml="+resultPath)
+	assertObjectExists(t, k, appsv1.SchemeGroupVersion.WithResource("deployments"), p.TestSlug(), "d1")
+
+	assertValidate(t, p, &resultPath, false)
+
+	readyDeployment := buildDeployment("d1", p.TestSlug(), true)
+
+	_, err := k.DynamicClient.Resource(appsv1.SchemeGroupVersion.WithResource("deployments")).Namespace(p.TestSlug()).
+		Patch(context.Background(), "d1", types.ApplyPatchType, []byte(yaml.WriteJsonStringMust(readyDeployment)), metav1.PatchOptions{
+			FieldManager: "test",
+		}, "status")
+	assert.NoError(t, err)
+
+	assertValidate(t, p, &resultPath, true)
+}
+
+func TestValidateDrift(t *testing.T) {
+	t.Parallel()
+
+	k := defaultCluster1
+
+	p := prepareValidateTest(t, k)
+
+	resultPath := filepath.Join(t.TempDir(), "result.yaml")
+
+	p.KluctlMust("deploy", "--yes", "-t", "test", "-oyaml="+resultPath)
+	assertObjectExists(t, k, appsv1.SchemeGroupVersion.WithResource("deployments"), p.TestSlug(), "d1")
+
+	stdout, _ := assertValidate(t, p, &resultPath, false)
+	assert.NotContains(t, stdout, "Drift:")
+
+	changedDeployment := buildDeployment("d1", p.TestSlug(), false)
+	changedDeployment.Merge(uo.FromStringMust(`
+spec:
+  replicas: 2
+`))
+
+	b := true
+	_, err := k.DynamicClient.Resource(appsv1.SchemeGroupVersion.WithResource("deployments")).Namespace(p.TestSlug()).
+		Patch(context.Background(), "d1", types.ApplyPatchType, []byte(yaml.WriteJsonStringMust(changedDeployment)), metav1.PatchOptions{
+			FieldManager: "test",
+			Force:        &b,
+		})
+	assert.NoError(t, err)
+
+	stdout, _ = assertValidate(t, p, &resultPath, false)
+	assert.Contains(t, stdout, "Drift:")
+	assert.Contains(t, stdout, "spec.replicas")
+}

--- a/go.mod
+++ b/go.mod
@@ -58,10 +58,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.7
 	github.com/go-git/go-git/v5 v5.6.1
 	github.com/go-logr/logr v1.2.4
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/huandu/xstrings v1.4.0
 	github.com/onsi/gomega v1.27.6
 	github.com/otiai10/copy v1.11.0
+	github.com/sergi/go-diff v1.2.0
 	go.mozilla.org/sops/v3 v3.7.4-0.20220901181616-9124783930b1
 	sigs.k8s.io/controller-runtime v0.14.5
 	sigs.k8s.io/kustomize/api v0.13.2
@@ -149,7 +151,6 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
@@ -207,7 +208,6 @@ require (
 	github.com/rubenv/sql-migrate v1.3.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/spf13/afero v1.9.3 // indirect

--- a/pkg/deployment/commands/delete.go
+++ b/pkg/deployment/commands/delete.go
@@ -3,25 +3,29 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/kluctl/kluctl/v2/pkg/deployment"
 	utils2 "github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 )
 
 type DeleteCommand struct {
+	c             *deployment.DeploymentCollection
 	discriminator string
 	inclusion     *utils.Inclusion
 }
 
-func NewDeleteCommand(discriminator string, inclusion *utils.Inclusion) *DeleteCommand {
+func NewDeleteCommand(discriminator string, c *deployment.DeploymentCollection, inclusion *utils.Inclusion) *DeleteCommand {
 	return &DeleteCommand{
 		discriminator: discriminator,
+		c:             c,
 		inclusion:     inclusion,
 	}
 }
 
-func (cmd *DeleteCommand) Run(ctx context.Context, k *k8s.K8sCluster) ([]k8s2.ObjectRef, error) {
+func (cmd *DeleteCommand) Run(ctx context.Context, k *k8s.K8sCluster, confirmCb func(refs []k8s2.ObjectRef) error) (*result.CommandResult, error) {
 	if cmd.discriminator == "" {
 		return nil, fmt.Errorf("deletion without a discriminator is not supported")
 	}
@@ -33,5 +37,26 @@ func (cmd *DeleteCommand) Run(ctx context.Context, k *k8s.K8sCluster) ([]k8s2.Ob
 		return nil, err
 	}
 
-	return utils2.FindObjectsForDelete(k, ru.GetFilteredRemoteObjects(cmd.inclusion), cmd.inclusion.HasType("tags"), nil)
+	deleteRefs, err := utils2.FindObjectsForDelete(k, ru.GetFilteredRemoteObjects(cmd.inclusion), cmd.inclusion.HasType("tags"), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if confirmCb != nil {
+		err = confirmCb(deleteRefs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	deleted, err := utils2.DeleteObjects(ctx, k, deleteRefs, dew, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result.CommandResult{
+		DeletedObjects: deleted,
+		Errors:         dew.GetErrorsList(),
+		Warnings:       dew.GetWarningsList(),
+	}, nil
 }

--- a/pkg/deployment/commands/delete.go
+++ b/pkg/deployment/commands/delete.go
@@ -55,10 +55,8 @@ func (cmd *DeleteCommand) Run(ctx context.Context, k *k8s.K8sCluster, confirmCb 
 	}
 
 	return &result.CommandResult{
-		RenderedObjects: cmd.c.LocalObjects(),
-		RemoteObjects:   ru.GetFilteredRemoteObjects(nil),
-		DeletedObjects:  deleted,
-		Errors:          dew.GetErrorsList(),
-		Warnings:        dew.GetWarningsList(),
+		Objects:  collectObjects(cmd.c, ru, nil, nil, nil, deleted),
+		Errors:   dew.GetErrorsList(),
+		Warnings: dew.GetWarningsList(),
 	}, nil
 }

--- a/pkg/deployment/commands/delete.go
+++ b/pkg/deployment/commands/delete.go
@@ -55,8 +55,10 @@ func (cmd *DeleteCommand) Run(ctx context.Context, k *k8s.K8sCluster, confirmCb 
 	}
 
 	return &result.CommandResult{
-		DeletedObjects: deleted,
-		Errors:         dew.GetErrorsList(),
-		Warnings:       dew.GetWarningsList(),
+		RenderedObjects: cmd.c.LocalObjects(),
+		RemoteObjects:   ru.GetFilteredRemoteObjects(nil),
+		DeletedObjects:  deleted,
+		Errors:          dew.GetErrorsList(),
+		Warnings:        dew.GetWarningsList(),
 	}, nil
 }

--- a/pkg/deployment/commands/delete.go
+++ b/pkg/deployment/commands/delete.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/kluctl/kluctl/v2/pkg/deployment"
 	utils2 "github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
@@ -55,6 +56,7 @@ func (cmd *DeleteCommand) Run(ctx context.Context, k *k8s.K8sCluster, confirmCb 
 	}
 
 	return &result.CommandResult{
+		Id:       uuid.New().String(),
 		Objects:  collectObjects(cmd.c, ru, nil, nil, nil, deleted),
 		Errors:   dew.GetErrorsList(),
 		Warnings: dew.GetWarningsList(),

--- a/pkg/deployment/commands/deploy.go
+++ b/pkg/deployment/commands/deploy.go
@@ -7,8 +7,8 @@ import (
 	utils2 "github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/status"
-	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"time"
 )
 
@@ -31,7 +31,7 @@ func NewDeployCommand(discriminator string, c *deployment.DeploymentCollection) 
 	}
 }
 
-func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResultCb func(diffResult *types.CommandResult) error) (*types.CommandResult, error) {
+func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResultCb func(diffResult *result.CommandResult) error) (*result.CommandResult, error) {
 	dew := utils2.NewDeploymentErrorsAndWarnings()
 
 	if cmd.discriminator == "" {
@@ -64,7 +64,7 @@ func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResult
 		du.Diff()
 
 		orphanObjects, err := FindOrphanObjects(k, ru, cmd.c)
-		diffResult := &types.CommandResult{
+		diffResult := &result.CommandResult{
 			NewObjects:     au.GetNewObjects(),
 			ChangedObjects: du.ChangedObjects,
 			DeletedObjects: au.GetDeletedObjects(),
@@ -98,7 +98,7 @@ func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResult
 	if err != nil {
 		return nil, err
 	}
-	return &types.CommandResult{
+	return &result.CommandResult{
 		NewObjects:     au.GetNewObjects(),
 		ChangedObjects: du.ChangedObjects,
 		DeletedObjects: au.GetDeletedObjects(),

--- a/pkg/deployment/commands/deploy.go
+++ b/pkg/deployment/commands/deploy.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/kluctl/kluctl/v2/pkg/deployment"
 	utils2 "github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
@@ -65,6 +66,7 @@ func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResult
 
 		orphanObjects, err := FindOrphanObjects(k, ru, cmd.c)
 		diffResult := &result.CommandResult{
+			Id:         uuid.New().String(),
 			Objects:    collectObjects(cmd.c, ru, au, du, orphanObjects, nil),
 			Errors:     dew.GetErrorsList(),
 			Warnings:   dew.GetWarningsList(),
@@ -95,6 +97,7 @@ func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResult
 		return nil, err
 	}
 	return &result.CommandResult{
+		Id:         uuid.New().String(),
 		Objects:    collectObjects(cmd.c, ru, au, du, orphanObjects, nil),
 		Errors:     dew.GetErrorsList(),
 		Warnings:   dew.GetWarningsList(),

--- a/pkg/deployment/commands/deploy.go
+++ b/pkg/deployment/commands/deploy.go
@@ -65,14 +65,17 @@ func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResult
 
 		orphanObjects, err := FindOrphanObjects(k, ru, cmd.c)
 		diffResult := &result.CommandResult{
-			NewObjects:     au.GetNewObjects(),
-			ChangedObjects: du.ChangedObjects,
-			DeletedObjects: au.GetDeletedObjects(),
-			HookObjects:    au.GetAppliedHookObjects(),
-			OrphanObjects:  orphanObjects,
-			Errors:         dew.GetErrorsList(),
-			Warnings:       dew.GetWarningsList(),
-			SeenImages:     cmd.c.Images.SeenImages(false),
+			RenderedObjects:    cmd.c.LocalObjects(),
+			RemoteObjects:      ru.GetFilteredRemoteObjects(nil),
+			AppliedObjects:     au.GetAppliedObjects(),
+			AppliedHookObjects: au.GetAppliedHookObjects(),
+			NewObjects:         au.GetNewObjectRefs(),
+			ChangedObjects:     du.ChangedObjects,
+			DeletedObjects:     au.GetDeletedObjects(),
+			OrphanObjects:      orphanObjects,
+			Errors:             dew.GetErrorsList(),
+			Warnings:           dew.GetWarningsList(),
+			SeenImages:         cmd.c.Images.SeenImages(false),
 		}
 
 		err = diffResultCb(diffResult)
@@ -99,13 +102,16 @@ func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResult
 		return nil, err
 	}
 	return &result.CommandResult{
-		NewObjects:     au.GetNewObjects(),
-		ChangedObjects: du.ChangedObjects,
-		DeletedObjects: au.GetDeletedObjects(),
-		HookObjects:    au.GetAppliedHookObjects(),
-		OrphanObjects:  orphanObjects,
-		Errors:         dew.GetErrorsList(),
-		Warnings:       dew.GetWarningsList(),
-		SeenImages:     cmd.c.Images.SeenImages(false),
+		RenderedObjects:    cmd.c.LocalObjects(),
+		RemoteObjects:      ru.GetFilteredRemoteObjects(nil),
+		AppliedObjects:     au.GetAppliedObjects(),
+		AppliedHookObjects: au.GetAppliedHookObjects(),
+		NewObjects:         au.GetNewObjectRefs(),
+		ChangedObjects:     du.ChangedObjects,
+		DeletedObjects:     au.GetDeletedObjects(),
+		OrphanObjects:      orphanObjects,
+		Errors:             dew.GetErrorsList(),
+		Warnings:           dew.GetWarningsList(),
+		SeenImages:         cmd.c.Images.SeenImages(false),
 	}, nil
 }

--- a/pkg/deployment/commands/deploy.go
+++ b/pkg/deployment/commands/deploy.go
@@ -65,17 +65,10 @@ func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResult
 
 		orphanObjects, err := FindOrphanObjects(k, ru, cmd.c)
 		diffResult := &result.CommandResult{
-			RenderedObjects:    cmd.c.LocalObjects(),
-			RemoteObjects:      ru.GetFilteredRemoteObjects(nil),
-			AppliedObjects:     au.GetAppliedObjects(),
-			AppliedHookObjects: au.GetAppliedHookObjects(),
-			NewObjects:         au.GetNewObjectRefs(),
-			ChangedObjects:     du.ChangedObjects,
-			DeletedObjects:     au.GetDeletedObjects(),
-			OrphanObjects:      orphanObjects,
-			Errors:             dew.GetErrorsList(),
-			Warnings:           dew.GetWarningsList(),
-			SeenImages:         cmd.c.Images.SeenImages(false),
+			Objects:    collectObjects(cmd.c, ru, au, du, orphanObjects, nil),
+			Errors:     dew.GetErrorsList(),
+			Warnings:   dew.GetWarningsList(),
+			SeenImages: cmd.c.Images.SeenImages(false),
 		}
 
 		err = diffResultCb(diffResult)
@@ -102,16 +95,9 @@ func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResult
 		return nil, err
 	}
 	return &result.CommandResult{
-		RenderedObjects:    cmd.c.LocalObjects(),
-		RemoteObjects:      ru.GetFilteredRemoteObjects(nil),
-		AppliedObjects:     au.GetAppliedObjects(),
-		AppliedHookObjects: au.GetAppliedHookObjects(),
-		NewObjects:         au.GetNewObjectRefs(),
-		ChangedObjects:     du.ChangedObjects,
-		DeletedObjects:     au.GetDeletedObjects(),
-		OrphanObjects:      orphanObjects,
-		Errors:             dew.GetErrorsList(),
-		Warnings:           dew.GetWarningsList(),
-		SeenImages:         cmd.c.Images.SeenImages(false),
+		Objects:    collectObjects(cmd.c, ru, au, du, orphanObjects, nil),
+		Errors:     dew.GetErrorsList(),
+		Warnings:   dew.GetWarningsList(),
+		SeenImages: cmd.c.Images.SeenImages(false),
 	}, nil
 }

--- a/pkg/deployment/commands/deploy.go
+++ b/pkg/deployment/commands/deploy.go
@@ -58,11 +58,11 @@ func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResult
 	}
 
 	if diffResultCb != nil {
-		au := utils2.NewApplyDeploymentsUtil(ctx, dew, cmd.c.Deployments, ru, k, o)
-		au.ApplyDeployments()
+		au := utils2.NewApplyDeploymentsUtil(ctx, dew, ru, k, o)
+		au.ApplyDeployments(cmd.c.Deployments)
 
-		du := utils2.NewDiffUtil(dew, cmd.c.Deployments, ru, au.GetAppliedObjectsMap())
-		du.Diff()
+		du := utils2.NewDiffUtil(dew, ru, au.GetAppliedObjectsMap())
+		du.DiffDeploymentItems(cmd.c.Deployments)
 
 		orphanObjects, err := FindOrphanObjects(k, ru, cmd.c)
 		diffResult := &result.CommandResult{
@@ -86,11 +86,11 @@ func (cmd *DeployCommand) Run(ctx context.Context, k *k8s.K8sCluster, diffResult
 	o.DryRun = k.DryRun
 	o.AbortOnError = cmd.AbortOnError
 
-	au := utils2.NewApplyDeploymentsUtil(ctx, dew, cmd.c.Deployments, ru, k, o)
-	au.ApplyDeployments()
+	au := utils2.NewApplyDeploymentsUtil(ctx, dew, ru, k, o)
+	au.ApplyDeployments(cmd.c.Deployments)
 
-	du := utils2.NewDiffUtil(dew, cmd.c.Deployments, ru, au.GetAppliedObjectsMap())
-	du.Diff()
+	du := utils2.NewDiffUtil(dew, ru, au.GetAppliedObjectsMap())
+	du.DiffDeploymentItems(cmd.c.Deployments)
 
 	orphanObjects, err := FindOrphanObjects(k, ru, cmd.c)
 	if err != nil {

--- a/pkg/deployment/commands/diff.go
+++ b/pkg/deployment/commands/diff.go
@@ -7,8 +7,8 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/status"
-	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 )
 
 type DiffCommand struct {
@@ -30,7 +30,7 @@ func NewDiffCommand(discriminator string, c *deployment.DeploymentCollection) *D
 	}
 }
 
-func (cmd *DiffCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*types.CommandResult, error) {
+func (cmd *DiffCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result.CommandResult, error) {
 	dew := utils.NewDeploymentErrorsAndWarnings()
 
 	if cmd.discriminator == "" {
@@ -65,7 +65,7 @@ func (cmd *DiffCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*types.Comm
 	if err != nil {
 		return nil, err
 	}
-	return &types.CommandResult{
+	return &result.CommandResult{
 		NewObjects:     au.GetNewObjects(),
 		ChangedObjects: du.ChangedObjects,
 		DeletedObjects: au.GetDeletedObjects(),

--- a/pkg/deployment/commands/diff.go
+++ b/pkg/deployment/commands/diff.go
@@ -53,14 +53,14 @@ func (cmd *DiffCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result.Com
 		AbortOnError:        false,
 		ReadinessTimeout:    0,
 	}
-	au := utils.NewApplyDeploymentsUtil(ctx, dew, cmd.c.Deployments, ru, k, o)
-	au.ApplyDeployments()
+	au := utils.NewApplyDeploymentsUtil(ctx, dew, ru, k, o)
+	au.ApplyDeployments(cmd.c.Deployments)
 
-	du := utils.NewDiffUtil(dew, cmd.c.Deployments, ru, au.GetAppliedObjectsMap())
+	du := utils.NewDiffUtil(dew, ru, au.GetAppliedObjectsMap())
 	du.IgnoreTags = cmd.IgnoreTags
 	du.IgnoreLabels = cmd.IgnoreLabels
 	du.IgnoreAnnotations = cmd.IgnoreAnnotations
-	du.Diff()
+	du.DiffDeploymentItems(cmd.c.Deployments)
 
 	orphanObjects, err := FindOrphanObjects(k, ru, cmd.c)
 	if err != nil {

--- a/pkg/deployment/commands/diff.go
+++ b/pkg/deployment/commands/diff.go
@@ -66,13 +66,16 @@ func (cmd *DiffCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result.Com
 		return nil, err
 	}
 	return &result.CommandResult{
-		NewObjects:     au.GetNewObjects(),
-		ChangedObjects: du.ChangedObjects,
-		DeletedObjects: au.GetDeletedObjects(),
-		HookObjects:    au.GetAppliedHookObjects(),
-		OrphanObjects:  orphanObjects,
-		Errors:         dew.GetErrorsList(),
-		Warnings:       dew.GetWarningsList(),
-		SeenImages:     cmd.c.Images.SeenImages(false),
+		RenderedObjects:    cmd.c.LocalObjects(),
+		RemoteObjects:      ru.GetFilteredRemoteObjects(nil),
+		AppliedObjects:     au.GetAppliedObjects(),
+		AppliedHookObjects: au.GetAppliedHookObjects(),
+		NewObjects:         au.GetNewObjectRefs(),
+		ChangedObjects:     du.ChangedObjects,
+		DeletedObjects:     au.GetDeletedObjects(),
+		OrphanObjects:      orphanObjects,
+		Errors:             dew.GetErrorsList(),
+		Warnings:           dew.GetWarningsList(),
+		SeenImages:         cmd.c.Images.SeenImages(false),
 	}, nil
 }

--- a/pkg/deployment/commands/diff.go
+++ b/pkg/deployment/commands/diff.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/kluctl/kluctl/v2/pkg/deployment"
 	"github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
@@ -66,6 +67,7 @@ func (cmd *DiffCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result.Com
 		return nil, err
 	}
 	return &result.CommandResult{
+		Id:         uuid.New().String(),
 		Objects:    collectObjects(cmd.c, ru, au, du, orphanObjects, nil),
 		Errors:     dew.GetErrorsList(),
 		Warnings:   dew.GetWarningsList(),

--- a/pkg/deployment/commands/diff.go
+++ b/pkg/deployment/commands/diff.go
@@ -66,16 +66,9 @@ func (cmd *DiffCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result.Com
 		return nil, err
 	}
 	return &result.CommandResult{
-		RenderedObjects:    cmd.c.LocalObjects(),
-		RemoteObjects:      ru.GetFilteredRemoteObjects(nil),
-		AppliedObjects:     au.GetAppliedObjects(),
-		AppliedHookObjects: au.GetAppliedHookObjects(),
-		NewObjects:         au.GetNewObjectRefs(),
-		ChangedObjects:     du.ChangedObjects,
-		DeletedObjects:     au.GetDeletedObjects(),
-		OrphanObjects:      orphanObjects,
-		Errors:             dew.GetErrorsList(),
-		Warnings:           dew.GetWarningsList(),
-		SeenImages:         cmd.c.Images.SeenImages(false),
+		Objects:    collectObjects(cmd.c, ru, au, du, orphanObjects, nil),
+		Errors:     dew.GetErrorsList(),
+		Warnings:   dew.GetWarningsList(),
+		SeenImages: cmd.c.Images.SeenImages(false),
 	}, nil
 }

--- a/pkg/deployment/commands/poke_images.go
+++ b/pkg/deployment/commands/poke_images.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"sync"
 )
@@ -22,7 +23,7 @@ func NewPokeImagesCommand(c *deployment.DeploymentCollection) *PokeImagesCommand
 	}
 }
 
-func (cmd *PokeImagesCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*types.CommandResult, error) {
+func (cmd *PokeImagesCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result.CommandResult, error) {
 	var wg sync.WaitGroup
 
 	dew := utils2.NewDeploymentErrorsAndWarnings()
@@ -94,7 +95,7 @@ func (cmd *PokeImagesCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*type
 	du := utils2.NewDiffUtil(dew, cmd.c.Deployments, ru, ad.GetAppliedObjectsMap())
 	du.Diff()
 
-	return &types.CommandResult{
+	return &result.CommandResult{
 		NewObjects:     nil,
 		ChangedObjects: du.ChangedObjects,
 		Errors:         dew.GetErrorsList(),

--- a/pkg/deployment/commands/poke_images.go
+++ b/pkg/deployment/commands/poke_images.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/kluctl/kluctl/v2/pkg/deployment"
 	utils2 "github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
@@ -101,6 +102,7 @@ func (cmd *PokeImagesCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*resu
 	}
 
 	return &result.CommandResult{
+		Id:         uuid.New().String(),
 		Objects:    collectObjects(cmd.c, ru, au, du, orphanObjects, nil),
 		Errors:     dew.GetErrorsList(),
 		Warnings:   dew.GetWarningsList(),

--- a/pkg/deployment/commands/poke_images.go
+++ b/pkg/deployment/commands/poke_images.go
@@ -101,16 +101,9 @@ func (cmd *PokeImagesCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*resu
 	}
 
 	return &result.CommandResult{
-		RenderedObjects:    cmd.c.LocalObjects(),
-		RemoteObjects:      ru.GetFilteredRemoteObjects(nil),
-		AppliedObjects:     au.GetAppliedObjects(),
-		AppliedHookObjects: au.GetAppliedHookObjects(),
-		NewObjects:         au.GetNewObjectRefs(),
-		ChangedObjects:     du.ChangedObjects,
-		DeletedObjects:     au.GetDeletedObjects(),
-		OrphanObjects:      orphanObjects,
-		Errors:             dew.GetErrorsList(),
-		Warnings:           dew.GetWarningsList(),
-		SeenImages:         cmd.c.Images.SeenImages(false),
+		Objects:    collectObjects(cmd.c, ru, au, du, orphanObjects, nil),
+		Errors:     dew.GetErrorsList(),
+		Warnings:   dew.GetWarningsList(),
+		SeenImages: cmd.c.Images.SeenImages(false),
 	}, nil
 }

--- a/pkg/deployment/commands/poke_images.go
+++ b/pkg/deployment/commands/poke_images.go
@@ -72,7 +72,7 @@ func (cmd *PokeImagesCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*resu
 		return o, nil
 	}
 
-	au := utils2.NewApplyDeploymentsUtil(ctx, dew, cmd.c.Deployments, ru, k, &utils2.ApplyUtilOptions{})
+	au := utils2.NewApplyDeploymentsUtil(ctx, dew, ru, k, &utils2.ApplyUtilOptions{})
 
 	for ref, containers := range containersAndImages {
 		ref := ref
@@ -93,8 +93,8 @@ func (cmd *PokeImagesCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*resu
 	}
 	wg.Wait()
 
-	du := utils2.NewDiffUtil(dew, cmd.c.Deployments, ru, au.GetAppliedObjectsMap())
-	du.Diff()
+	du := utils2.NewDiffUtil(dew, ru, au.GetAppliedObjectsMap())
+	du.DiffDeploymentItems(cmd.c.Deployments)
 
 	orphanObjects, err := FindOrphanObjects(k, ru, cmd.c)
 	if err != nil {

--- a/pkg/deployment/commands/prune.go
+++ b/pkg/deployment/commands/prune.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/kluctl/kluctl/v2/pkg/deployment"
 	utils2 "github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
@@ -53,6 +54,7 @@ func (cmd *PruneCommand) Run(ctx context.Context, k *k8s.K8sCluster, confirmCb f
 	}
 
 	return &result.CommandResult{
+		Id:       uuid.New().String(),
 		Objects:  collectObjects(cmd.c, ru, nil, nil, nil, deleted),
 		Warnings: dew.GetWarningsList(),
 	}, nil

--- a/pkg/deployment/commands/prune.go
+++ b/pkg/deployment/commands/prune.go
@@ -53,9 +53,11 @@ func (cmd *PruneCommand) Run(ctx context.Context, k *k8s.K8sCluster, confirmCb f
 	}
 
 	return &result.CommandResult{
-		DeletedObjects: deleted,
-		Errors:         dew.GetErrorsList(),
-		Warnings:       dew.GetWarningsList(),
+		RenderedObjects: cmd.c.LocalObjects(),
+		RemoteObjects:   ru.GetFilteredRemoteObjects(nil),
+		DeletedObjects:  deleted,
+		Errors:          dew.GetErrorsList(),
+		Warnings:        dew.GetWarningsList(),
 	}, nil
 }
 

--- a/pkg/deployment/commands/prune.go
+++ b/pkg/deployment/commands/prune.go
@@ -53,11 +53,8 @@ func (cmd *PruneCommand) Run(ctx context.Context, k *k8s.K8sCluster, confirmCb f
 	}
 
 	return &result.CommandResult{
-		RenderedObjects: cmd.c.LocalObjects(),
-		RemoteObjects:   ru.GetFilteredRemoteObjects(nil),
-		DeletedObjects:  deleted,
-		Errors:          dew.GetErrorsList(),
-		Warnings:        dew.GetWarningsList(),
+		Objects:  collectObjects(cmd.c, ru, nil, nil, nil, deleted),
+		Warnings: dew.GetWarningsList(),
 	}, nil
 }
 

--- a/pkg/deployment/commands/prune.go
+++ b/pkg/deployment/commands/prune.go
@@ -7,6 +7,7 @@ import (
 	utils2 "github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 )
 
 type PruneCommand struct {
@@ -21,7 +22,7 @@ func NewPruneCommand(discriminator string, c *deployment.DeploymentCollection) *
 	}
 }
 
-func (cmd *PruneCommand) Run(ctx context.Context, k *k8s.K8sCluster) ([]k8s2.ObjectRef, error) {
+func (cmd *PruneCommand) Run(ctx context.Context, k *k8s.K8sCluster, confirmCb func(refs []k8s2.ObjectRef) error) (*result.CommandResult, error) {
 	if cmd.discriminator == "" {
 		return nil, fmt.Errorf("pruning without a discriminator is not supported")
 	}
@@ -34,7 +35,28 @@ func (cmd *PruneCommand) Run(ctx context.Context, k *k8s.K8sCluster) ([]k8s2.Obj
 		return nil, err
 	}
 
-	return FindOrphanObjects(k, ru, cmd.c)
+	deleteRefs, err := FindOrphanObjects(k, ru, cmd.c)
+	if err != nil {
+		return nil, err
+	}
+
+	if confirmCb != nil {
+		err = confirmCb(deleteRefs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	deleted, err := utils2.DeleteObjects(ctx, k, deleteRefs, dew, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result.CommandResult{
+		DeletedObjects: deleted,
+		Errors:         dew.GetErrorsList(),
+		Warnings:       dew.GetWarningsList(),
+	}, nil
 }
 
 func FindOrphanObjects(k *k8s.K8sCluster, ru *utils2.RemoteObjectUtils, c *deployment.DeploymentCollection) ([]k8s2.ObjectRef, error) {

--- a/pkg/deployment/commands/utils.go
+++ b/pkg/deployment/commands/utils.go
@@ -1,0 +1,87 @@
+package commands
+
+import (
+	"github.com/kluctl/kluctl/v2/pkg/deployment"
+	"github.com/kluctl/kluctl/v2/pkg/deployment/utils"
+	"github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
+	"sort"
+)
+
+func collectObjects(c *deployment.DeploymentCollection, ru *utils.RemoteObjectUtils, au *utils.ApplyDeploymentsUtil, du *utils.DiffUtil, orphans []k8s.ObjectRef, deleted []k8s.ObjectRef) []result.ResultObject {
+	m := map[k8s.ObjectRef]*result.ResultObject{}
+
+	getOrCreate := func(ref k8s.ObjectRef) *result.ResultObject {
+		x, ok := m[ref]
+		if !ok {
+			x = &result.ResultObject{}
+			x.Ref = ref
+			m[ref] = x
+		}
+		return x
+	}
+
+	if c != nil {
+		for _, x := range c.LocalObjects() {
+			o := getOrCreate(x.GetK8sRef())
+			o.Rendered = x
+		}
+	}
+	if ru != nil {
+		for _, x := range ru.GetFilteredRemoteObjects(nil) {
+			o := getOrCreate(x.GetK8sRef())
+			o.Remote = x
+		}
+	}
+
+	if au != nil {
+		for _, x := range au.GetAppliedObjects() {
+			o := getOrCreate(x.GetK8sRef())
+			o.Applied = x
+		}
+
+		for _, x := range au.GetAppliedHookObjects() {
+			o := getOrCreate(x.GetK8sRef())
+			o.Hook = true
+		}
+		for _, x := range au.GetNewObjectRefs() {
+			o := getOrCreate(x)
+			o.New = true
+		}
+		for _, x := range au.GetDeletedObjects() {
+			o := getOrCreate(x)
+			o.Deleted = true
+		}
+	}
+	if du != nil {
+		for _, x := range du.ChangedObjects {
+			o := getOrCreate(x.Ref)
+			o.Changes = x.Changes
+		}
+	}
+	for _, x := range orphans {
+		o := getOrCreate(x)
+		o.Orphan = true
+	}
+	for _, x := range deleted {
+		o := getOrCreate(x)
+		o.Deleted = true
+	}
+
+	for ref, o := range m {
+		if o.Rendered == nil && o.Applied == nil && !o.Deleted && !o.Orphan {
+			// exclude all objects that are clearly not under our control, but got retrieved anyway because some
+			// controller passed through the discriminator labels
+			delete(m, ref)
+		}
+	}
+
+	ret := make([]result.ResultObject, 0, len(m))
+	for _, o := range m {
+		ret = append(ret, *o)
+	}
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Ref.GroupVersionKind().String() < ret[j].Ref.GroupVersionKind().String()
+	})
+	return ret
+}

--- a/pkg/deployment/commands/validate.go
+++ b/pkg/deployment/commands/validate.go
@@ -53,7 +53,7 @@ func (cmd *ValidateCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result
 
 			remoteObject := cmd.ru.GetRemoteObject(ref)
 			if remoteObject == nil {
-				r.Errors = append(r.Errors, result.DeploymentError{Ref: ref, Error: "object not found"})
+				r.Errors = append(r.Errors, result.DeploymentError{Ref: ref, Message: "object not found"})
 				continue
 			}
 			r := validation.ValidateObject(k, remoteObject, true, false)

--- a/pkg/deployment/commands/validate.go
+++ b/pkg/deployment/commands/validate.go
@@ -5,8 +5,8 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/deployment"
 	utils2 "github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
-	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/kluctl/kluctl/v2/pkg/validation"
 )
 
@@ -28,9 +28,9 @@ func NewValidateCommand(ctx context.Context, discriminator string, c *deployment
 	return cmd
 }
 
-func (cmd *ValidateCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*types.ValidateResult, error) {
-	var result types.ValidateResult
-	result.Ready = true
+func (cmd *ValidateCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result.ValidateResult, error) {
+	var r result.ValidateResult
+	r.Ready = true
 
 	cmd.dew.Init()
 
@@ -53,23 +53,23 @@ func (cmd *ValidateCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*types.
 
 			remoteObject := cmd.ru.GetRemoteObject(ref)
 			if remoteObject == nil {
-				result.Errors = append(result.Errors, types.DeploymentError{Ref: ref, Error: "object not found"})
+				r.Errors = append(r.Errors, result.DeploymentError{Ref: ref, Error: "object not found"})
 				continue
 			}
 			r := validation.ValidateObject(k, remoteObject, true, false)
 			if !r.Ready {
-				result.Ready = false
+				r.Ready = false
 			}
-			result.Errors = append(result.Errors, r.Errors...)
-			result.Warnings = append(result.Warnings, r.Warnings...)
-			result.Results = append(result.Results, r.Results...)
+			r.Errors = append(r.Errors, r.Errors...)
+			r.Warnings = append(r.Warnings, r.Warnings...)
+			r.Results = append(r.Results, r.Results...)
 		}
 	}
 
-	result.Warnings = append(result.Warnings, cmd.dew.GetWarningsList()...)
-	result.Errors = append(result.Errors, cmd.dew.GetErrorsList()...)
+	r.Warnings = append(r.Warnings, cmd.dew.GetWarningsList()...)
+	r.Errors = append(r.Errors, cmd.dew.GetErrorsList()...)
 
-	return &result, nil
+	return &r, nil
 }
 
 func (cmd *ValidateCommand) ForgetRemoteObject(ref k8s2.ObjectRef) {

--- a/pkg/deployment/commands/validate.go
+++ b/pkg/deployment/commands/validate.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"github.com/google/uuid"
 	"github.com/kluctl/kluctl/v2/pkg/deployment"
 	utils2 "github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
@@ -29,8 +30,10 @@ func NewValidateCommand(ctx context.Context, discriminator string, c *deployment
 }
 
 func (cmd *ValidateCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result.ValidateResult, error) {
-	var r result.ValidateResult
-	r.Ready = true
+	r := result.ValidateResult{
+		Id:    uuid.New().String(),
+		Ready: true,
+	}
 
 	cmd.dew.Init()
 

--- a/pkg/deployment/commands/validate.go
+++ b/pkg/deployment/commands/validate.go
@@ -30,7 +30,7 @@ func NewValidateCommand(ctx context.Context, discriminator string, c *deployment
 }
 
 func (cmd *ValidateCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result.ValidateResult, error) {
-	r := result.ValidateResult{
+	ret := result.ValidateResult{
 		Id:    uuid.New().String(),
 		Ready: true,
 	}
@@ -56,23 +56,23 @@ func (cmd *ValidateCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result
 
 			remoteObject := cmd.ru.GetRemoteObject(ref)
 			if remoteObject == nil {
-				r.Errors = append(r.Errors, result.DeploymentError{Ref: ref, Message: "object not found"})
+				ret.Errors = append(ret.Errors, result.DeploymentError{Ref: ref, Message: "object not found"})
 				continue
 			}
 			r := validation.ValidateObject(k, remoteObject, true, false)
 			if !r.Ready {
-				r.Ready = false
+				ret.Ready = false
 			}
-			r.Errors = append(r.Errors, r.Errors...)
-			r.Warnings = append(r.Warnings, r.Warnings...)
-			r.Results = append(r.Results, r.Results...)
+			ret.Errors = append(ret.Errors, r.Errors...)
+			ret.Warnings = append(ret.Warnings, r.Warnings...)
+			ret.Results = append(ret.Results, r.Results...)
 		}
 	}
 
-	r.Warnings = append(r.Warnings, cmd.dew.GetWarningsList()...)
-	r.Errors = append(r.Errors, cmd.dew.GetErrorsList()...)
+	ret.Warnings = append(ret.Warnings, cmd.dew.GetWarningsList()...)
+	ret.Errors = append(ret.Errors, cmd.dew.GetErrorsList()...)
 
-	return &r, nil
+	return &ret, nil
 }
 
 func (cmd *ValidateCommand) ForgetRemoteObject(ref k8s2.ObjectRef) {

--- a/pkg/deployment/commands/validate.go
+++ b/pkg/deployment/commands/validate.go
@@ -59,6 +59,9 @@ func (cmd *ValidateCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result
 	} else if cmd.r != nil {
 		for _, o := range cmd.r.Objects {
 			refs = append(refs, o.Ref)
+			if o.Hook {
+				continue
+			}
 			if o.Rendered != nil {
 				renderedObjects = append(renderedObjects, o.Rendered)
 			}

--- a/pkg/deployment/commands/validate.go
+++ b/pkg/deployment/commands/validate.go
@@ -2,26 +2,30 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"github.com/google/uuid"
 	"github.com/kluctl/kluctl/v2/pkg/deployment"
 	utils2 "github.com/kluctl/kluctl/v2/pkg/deployment/utils"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/types/result"
+	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/kluctl/kluctl/v2/pkg/validation"
 )
 
 type ValidateCommand struct {
 	c             *deployment.DeploymentCollection
+	r             *result.CommandResult
 	discriminator string
 
 	dew *utils2.DeploymentErrorsAndWarnings
 	ru  *utils2.RemoteObjectUtils
 }
 
-func NewValidateCommand(ctx context.Context, discriminator string, c *deployment.DeploymentCollection) *ValidateCommand {
+func NewValidateCommand(ctx context.Context, discriminator string, c *deployment.DeploymentCollection, r *result.CommandResult) *ValidateCommand {
 	cmd := &ValidateCommand{
 		c:             c,
+		r:             r,
 		discriminator: discriminator,
 		dew:           utils2.NewDeploymentErrorsAndWarnings(),
 	}
@@ -37,40 +41,80 @@ func (cmd *ValidateCommand) Run(ctx context.Context, k *k8s.K8sCluster) (*result
 
 	cmd.dew.Init()
 
-	err := cmd.ru.UpdateRemoteObjects(k, &cmd.discriminator, cmd.c.LocalObjectRefs(), true)
+	var refs []k8s2.ObjectRef
+	var renderedObjects []*uo.UnstructuredObject
+	appliedObjects := map[k8s2.ObjectRef]*uo.UnstructuredObject{}
+	var discriminator string
+
+	if cmd.c != nil && cmd.r != nil {
+		return nil, fmt.Errorf("passing both deployment collection and command result is not allowed")
+	} else if cmd.c != nil {
+		for _, d := range cmd.c.Deployments {
+			for _, o := range d.Objects {
+				ref := o.GetK8sRef()
+				refs = append(refs, ref)
+				renderedObjects = append(renderedObjects, o)
+			}
+		}
+	} else if cmd.r != nil {
+		for _, o := range cmd.r.Objects {
+			refs = append(refs, o.Ref)
+			if o.Rendered != nil {
+				renderedObjects = append(renderedObjects, o.Rendered)
+			}
+			if o.Applied != nil {
+				appliedObjects[o.Ref] = o.Applied
+			}
+		}
+		discriminator = cmd.r.Target.Discriminator
+	} else {
+		return nil, fmt.Errorf("either deployment collection or command result must be passed")
+	}
+
+	if discriminator == "" {
+		discriminator = cmd.discriminator
+	}
+
+	err := cmd.ru.UpdateRemoteObjects(k, &cmd.discriminator, refs, true)
 	if err != nil {
 		return nil, err
 	}
 
-	ad := utils2.NewApplyDeploymentsUtil(ctx, cmd.dew, cmd.c.Deployments, cmd.ru, k, &utils2.ApplyUtilOptions{})
-	for _, d := range cmd.c.Deployments {
+	ad := utils2.NewApplyDeploymentsUtil(ctx, cmd.dew, cmd.ru, k, &utils2.ApplyUtilOptions{})
+	for _, o := range renderedObjects {
 		au := ad.NewApplyUtil(ctx, nil)
 		h := utils2.NewHooksUtil(au)
-		for _, o := range d.Objects {
-			hook := h.GetHook(o)
-			if hook != nil && !hook.IsPersistent() {
-				continue
-			}
-
-			ref := o.GetK8sRef()
-
-			remoteObject := cmd.ru.GetRemoteObject(ref)
-			if remoteObject == nil {
-				ret.Errors = append(ret.Errors, result.DeploymentError{Ref: ref, Message: "object not found"})
-				continue
-			}
-			r := validation.ValidateObject(k, remoteObject, true, false)
-			if !r.Ready {
-				ret.Ready = false
-			}
-			ret.Errors = append(ret.Errors, r.Errors...)
-			ret.Warnings = append(ret.Warnings, r.Warnings...)
-			ret.Results = append(ret.Results, r.Results...)
+		hook := h.GetHook(o)
+		if hook != nil && !hook.IsPersistent() {
+			continue
 		}
+
+		ref := o.GetK8sRef()
+
+		remoteObject := cmd.ru.GetRemoteObject(ref)
+		if remoteObject == nil {
+			ret.Errors = append(ret.Errors, result.DeploymentError{Ref: ref, Message: "object not found"})
+			continue
+		}
+		r := validation.ValidateObject(k, remoteObject, true, false)
+		if !r.Ready {
+			ret.Ready = false
+		}
+		ret.Errors = append(ret.Errors, r.Errors...)
+		ret.Warnings = append(ret.Warnings, r.Warnings...)
+		ret.Results = append(ret.Results, r.Results...)
 	}
+
+	du := utils2.NewDiffUtil(cmd.dew, cmd.ru, appliedObjects)
+	du.Swapped = true
+	du.DiffObjects(renderedObjects)
 
 	ret.Warnings = append(ret.Warnings, cmd.dew.GetWarningsList()...)
 	ret.Errors = append(ret.Errors, cmd.dew.GetErrorsList()...)
+
+	if len(du.ChangedObjects) != 0 {
+		ret.Drift = du.ChangedObjects
+	}
 
 	return &ret, nil
 }

--- a/pkg/deployment/deployment_collection.go
+++ b/pkg/deployment/deployment_collection.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
+	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"path/filepath"
 	"sync"
 )
@@ -227,11 +228,19 @@ func (c *DeploymentCollection) buildKustomizeObjects() error {
 	return g.ErrorOrNil()
 }
 
-func (c *DeploymentCollection) LocalObjectsByRef() map[k8s2.ObjectRef]bool {
-	ret := make(map[k8s2.ObjectRef]bool)
+func (c *DeploymentCollection) LocalObjects() []*uo.UnstructuredObject {
+	var ret []*uo.UnstructuredObject
+	for _, d := range c.Deployments {
+		ret = append(ret, d.Objects...)
+	}
+	return ret
+}
+
+func (c *DeploymentCollection) LocalObjectsByRef() map[k8s2.ObjectRef]*uo.UnstructuredObject {
+	ret := make(map[k8s2.ObjectRef]*uo.UnstructuredObject)
 	for _, d := range c.Deployments {
 		for _, o := range d.Objects {
-			ret[o.GetK8sRef()] = true
+			ret[o.GetK8sRef()] = o
 		}
 	}
 	return ret

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -535,7 +535,7 @@ func (di *DeploymentItem) buildKustomize() error {
 		}
 		o := uo.FromMap(y)
 		di.Objects = append(di.Objects, o)
-		di.Config.RenderedObjects = append(di.Config.RenderedObjects, o)
+		di.Config.RenderedObjects = append(di.Config.RenderedObjects, o.GetK8sRef())
 	}
 
 	return nil

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -225,6 +225,8 @@ func (di *DeploymentItem) renderHelmCharts() error {
 			}
 		}
 
+		di.Config.RenderedHelmChartConfig = hr.Config
+
 		return hr.Render(di.ctx.Ctx, di.ctx.K, di.ctx.K8sVersion, di.ctx.SopsDecrypter)
 	})
 	if err != nil {
@@ -533,6 +535,7 @@ func (di *DeploymentItem) buildKustomize() error {
 		}
 		o := uo.FromMap(y)
 		di.Objects = append(di.Objects, o)
+		di.Config.RenderedObjects = append(di.Config.RenderedObjects, o)
 	}
 
 	return nil

--- a/pkg/deployment/deployment_project.go
+++ b/pkg/deployment/deployment_project.go
@@ -108,6 +108,18 @@ func (p *DeploymentProject) generateSingleKustomizeProject() error {
 }
 
 func (p *DeploymentProject) processConfig() error {
+	for _, item := range p.Config.Deployments {
+		if len(item.RenderedObjects) != 0 {
+			return fmt.Errorf("renderedObjects is not allowed here")
+		}
+		if item.RenderedHelmChartConfig != nil {
+			return fmt.Errorf("renderedHelmChartConfig is not allowed here")
+		}
+		if item.RenderedInclude != nil {
+			return fmt.Errorf("renderedInclude is not allowed here")
+		}
+	}
+
 	err := p.loadVarsList(p.VarsCtx, p.Config.Vars)
 	if err != nil {
 		return fmt.Errorf("failed to load deployment.yml vars: %w", err)
@@ -228,6 +240,7 @@ func (p *DeploymentProject) loadIncludes() error {
 		} else {
 			continue
 		}
+		inc.RenderedInclude = &newProject.Config
 		newProject.parentProjectInclude = inc
 		p.includes[i] = newProject
 	}

--- a/pkg/deployment/deployment_project.go
+++ b/pkg/deployment/deployment_project.go
@@ -3,7 +3,6 @@ package deployment
 import (
 	"fmt"
 	securejoin "github.com/cyphar/filepath-securejoin"
-	"github.com/kluctl/kluctl/v2/pkg/kluctl_jinja2"
 	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
@@ -57,8 +56,8 @@ func NewDeploymentProject(ctx SharedContext, varsCtx *vars.VarsCtx, source Sourc
 		return nil, fmt.Errorf("failed to load deployment config for %s: %w", dir, err)
 	}
 
-	if !kluctl_jinja2.IsConditionalTrue(dp.Config.When) {
-		return dp, nil
+	if x, err := dp.CheckWhenTrue(); !x || err != nil {
+		return dp, err
 	}
 
 	err = dp.loadIncludes()
@@ -143,11 +142,6 @@ func (p *DeploymentProject) processConfig() error {
 		return err
 	}
 
-	err = p.renderConditionals()
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -176,38 +170,12 @@ func (p *DeploymentProject) checkDeploymentDirs() error {
 	return nil
 }
 
-func (p *DeploymentProject) renderConditionals() error {
+func (p *DeploymentProject) CheckWhenTrue() (bool, error) {
 	if p.parentProject == nil && p.Config.When != "" {
-		return fmt.Errorf("the root deployment project can not contain 'when'")
+		return false, fmt.Errorf("the root deployment project can not contain 'when'")
 	}
 
-	vars, err := p.VarsCtx.Vars.ToMap()
-	if err != nil {
-		return err
-	}
-	r, err := kluctl_jinja2.RenderConditional(p.VarsCtx.J2, vars, p.Config.When)
-	if err != nil {
-		return err
-	}
-	p.Config.When = r
-
-	if !kluctl_jinja2.IsConditionalTrue(p.Config.When) {
-		// No need to render individual deployment item conditionals
-		return nil
-	}
-
-	conditionals := make([]string, 0, len(p.Config.Deployments))
-	for _, di := range p.Config.Deployments {
-		conditionals = append(conditionals, di.When)
-	}
-	rendered, err := kluctl_jinja2.RenderConditionals(p.VarsCtx.J2, vars, conditionals)
-	if err != nil {
-		return err
-	}
-	for i, r := range rendered {
-		p.Config.Deployments[i].When = r
-	}
-	return nil
+	return p.VarsCtx.CheckConditional(p.Config.When)
 }
 
 func (p *DeploymentProject) loadIncludes() error {
@@ -215,7 +183,11 @@ func (p *DeploymentProject) loadIncludes() error {
 		var err error
 		var newProject *DeploymentProject
 
-		if !kluctl_jinja2.IsConditionalTrue(inc.When) {
+		whenTrue, err := p.VarsCtx.CheckConditional(inc.When)
+		if err != nil {
+			return err
+		}
+		if !whenTrue {
 			continue
 		}
 

--- a/pkg/deployment/images.go
+++ b/pkg/deployment/images.go
@@ -205,7 +205,7 @@ func (images *Images) ResolvePlaceholders(ctx context.Context, k *k8s.K8sCluster
 	}
 
 	ref := o.GetK8sRef()
-	deployment := fmt.Sprintf("%s/%s", ref.GVK.Kind, ref.Name)
+	deployment := fmt.Sprintf("%s/%s", ref.Kind, ref.Name)
 
 	var remoteObject *uo.UnstructuredObject
 	triedRemoteObject := false

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -492,7 +492,7 @@ func (a *ApplyUtil) WaitReadiness(ref k8s2.ObjectRef, timeout time.Duration) boo
 			a.HandleError(ref, err)
 			return false
 		case <-a.ctx.Done():
-			err := fmt.Errorf("failed waiting for readiness of %s: %w", ref.String(), err)
+			err := fmt.Errorf("context cancelled while waiting for readiness of %s", ref.String())
 			status.Warning(a.ctx, "%s (%ds elapsed)", err.Error(), elapsed)
 			a.HandleError(ref, err)
 			return false

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -61,11 +61,10 @@ type ApplyUtil struct {
 type ApplyDeploymentsUtil struct {
 	ctx context.Context
 
-	dew         *DeploymentErrorsAndWarnings
-	deployments []*deployment.DeploymentItem
-	ru          *RemoteObjectUtils
-	k           *k8s.K8sCluster
-	o           *ApplyUtilOptions
+	dew *DeploymentErrorsAndWarnings
+	ru  *RemoteObjectUtils
+	k   *k8s.K8sCluster
+	o   *ApplyUtilOptions
 
 	abortSignal atomic.Value
 
@@ -79,14 +78,13 @@ type ApplyDeploymentsUtil struct {
 	results      []*ApplyUtil
 }
 
-func NewApplyDeploymentsUtil(ctx context.Context, dew *DeploymentErrorsAndWarnings, deployments []*deployment.DeploymentItem, ru *RemoteObjectUtils, k *k8s.K8sCluster, o *ApplyUtilOptions) *ApplyDeploymentsUtil {
+func NewApplyDeploymentsUtil(ctx context.Context, dew *DeploymentErrorsAndWarnings, ru *RemoteObjectUtils, k *k8s.K8sCluster, o *ApplyUtilOptions) *ApplyDeploymentsUtil {
 	ret := &ApplyDeploymentsUtil{
-		ctx:         ctx,
-		dew:         dew,
-		deployments: deployments,
-		ru:          ru,
-		k:           k,
-		o:           o,
+		ctx: ctx,
+		dew: dew,
+		ru:  ru,
+		k:   k,
+		o:   o,
 	}
 	ret.abortSignal.Store(false)
 	return ret
@@ -642,7 +640,7 @@ func (a *ApplyDeploymentsUtil) buildProgressName(d *deployment.DeploymentItem) *
 	return nil
 }
 
-func (a *ApplyDeploymentsUtil) ApplyDeployments() {
+func (a *ApplyDeploymentsUtil) ApplyDeployments(deployments []*deployment.DeploymentItem) {
 	s := status.Start(a.ctx, "Running server-side apply for all objects")
 	defer s.Failed()
 
@@ -650,7 +648,7 @@ func (a *ApplyDeploymentsUtil) ApplyDeployments() {
 	sem := semaphore.NewWeighted(8)
 
 	maxNameLen := 0
-	for _, d := range a.deployments {
+	for _, d := range deployments {
 		name := a.buildProgressName(d)
 		if name != nil {
 			if len(*name) > maxNameLen {
@@ -659,7 +657,7 @@ func (a *ApplyDeploymentsUtil) ApplyDeployments() {
 		}
 	}
 
-	for _, d_ := range a.deployments {
+	for _, d_ := range deployments {
 		d := d_
 		if a.abortSignal.Load().(bool) {
 			break

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/status"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
-	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/kluctl/kluctl/v2/pkg/validation"
@@ -754,29 +753,26 @@ func (a *ApplyUtil) ReplaceObject(ref k8s2.ObjectRef, firstVersion *uo.Unstructu
 	a.HandleError(ref, fmt.Errorf("unexpected end of loop"))
 }
 
-func (ad *ApplyDeploymentsUtil) collectObjects(f func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject) []*result.RefAndObject {
+func (ad *ApplyDeploymentsUtil) collectObjects(f func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject) []*uo.UnstructuredObject {
 	ad.resultsMutex.Lock()
 	defer ad.resultsMutex.Unlock()
 
-	var ret []*result.RefAndObject
+	var ret []*uo.UnstructuredObject
 	for _, a := range ad.results {
 		for _, o := range f(a) {
-			ret = append(ret, &result.RefAndObject{
-				Ref:    o.GetK8sRef(),
-				Object: o,
-			})
+			ret = append(ret, o)
 		}
 	}
 	return ret
 }
 
-func (ad *ApplyDeploymentsUtil) GetNewObjects() []*result.RefAndObject {
+func (ad *ApplyDeploymentsUtil) GetNewObjects() []*uo.UnstructuredObject {
 	return ad.collectObjects(func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject {
 		return au.newObjects
 	})
 }
 
-func (ad *ApplyDeploymentsUtil) GetAppliedObjects() []*result.RefAndObject {
+func (ad *ApplyDeploymentsUtil) GetAppliedObjects() []*uo.UnstructuredObject {
 	return ad.collectObjects(func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject {
 		return au.appliedObjects
 	})
@@ -784,13 +780,13 @@ func (ad *ApplyDeploymentsUtil) GetAppliedObjects() []*result.RefAndObject {
 
 func (ad *ApplyDeploymentsUtil) GetAppliedObjectsMap() map[k8s2.ObjectRef]*uo.UnstructuredObject {
 	ret := make(map[k8s2.ObjectRef]*uo.UnstructuredObject)
-	for _, ro := range ad.GetAppliedObjects() {
-		ret[ro.Ref] = ro.Object
+	for _, o := range ad.GetAppliedObjects() {
+		ret[o.GetK8sRef()] = o
 	}
 	return ret
 }
 
-func (ad *ApplyDeploymentsUtil) GetAppliedHookObjects() []*result.RefAndObject {
+func (ad *ApplyDeploymentsUtil) GetAppliedHookObjects() []*uo.UnstructuredObject {
 	return ad.collectObjects(func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject {
 		return au.appliedHookObjects
 	})

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -461,7 +461,7 @@ func (a *ApplyUtil) WaitReadiness(ref k8s2.ObjectRef, timeout time.Duration) boo
 				status.Warning(a.ctx, "Cancelled waiting for %s due to errors (%ds elapsed)", ref.String(), elapsed)
 			}
 			for _, e := range v.Errors {
-				a.HandleError(ref, fmt.Errorf(e.Error))
+				a.HandleError(ref, fmt.Errorf(e.Message))
 			}
 			return false
 		}

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -382,10 +382,10 @@ func (a *ApplyUtil) ApplyObject(x *uo.UnstructuredObject, replaced bool, hook bo
 			return
 		}
 	}
-	if r != nil && ref.GVK.GroupKind().String() == "Namespace" {
+	if r != nil && ref.GroupKind().String() == "Namespace" {
 		a.allNamespaces.Store(ref.Name, r)
 	}
-	if r != nil && ref.GVK.GroupKind().String() == "CustomResourceDefinition.apiextensions.k8s.io" {
+	if r != nil && ref.GroupKind().String() == "CustomResourceDefinition.apiextensions.k8s.io" {
 		a.handleObservedCRD(r)
 	}
 	a.handleApiWarnings(ref, apiWarnings)
@@ -506,7 +506,9 @@ func (a *ApplyUtil) applyDeploymentItem(d *deployment.DeploymentItem) {
 	for _, x := range d.Config.DeleteObjects {
 		for _, gvk := range a.k.Resources.GetFilteredGVKs(k8s.BuildGVKFilter(x.Group, nil, x.Kind)) {
 			ref := k8s2.ObjectRef{
-				GVK:       gvk,
+				Group:     gvk.Group,
+				Version:   gvk.Version,
+				Kind:      gvk.Kind,
 				Name:      x.Name,
 				Namespace: x.Namespace,
 			}

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -8,8 +8,8 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/diff"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/status"
-	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/kluctl/kluctl/v2/pkg/validation"
@@ -754,14 +754,14 @@ func (a *ApplyUtil) ReplaceObject(ref k8s2.ObjectRef, firstVersion *uo.Unstructu
 	a.HandleError(ref, fmt.Errorf("unexpected end of loop"))
 }
 
-func (ad *ApplyDeploymentsUtil) collectObjects(f func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject) []*types.RefAndObject {
+func (ad *ApplyDeploymentsUtil) collectObjects(f func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject) []*result.RefAndObject {
 	ad.resultsMutex.Lock()
 	defer ad.resultsMutex.Unlock()
 
-	var ret []*types.RefAndObject
+	var ret []*result.RefAndObject
 	for _, a := range ad.results {
 		for _, o := range f(a) {
-			ret = append(ret, &types.RefAndObject{
+			ret = append(ret, &result.RefAndObject{
 				Ref:    o.GetK8sRef(),
 				Object: o,
 			})
@@ -770,13 +770,13 @@ func (ad *ApplyDeploymentsUtil) collectObjects(f func(au *ApplyUtil) map[k8s2.Ob
 	return ret
 }
 
-func (ad *ApplyDeploymentsUtil) GetNewObjects() []*types.RefAndObject {
+func (ad *ApplyDeploymentsUtil) GetNewObjects() []*result.RefAndObject {
 	return ad.collectObjects(func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject {
 		return au.newObjects
 	})
 }
 
-func (ad *ApplyDeploymentsUtil) GetAppliedObjects() []*types.RefAndObject {
+func (ad *ApplyDeploymentsUtil) GetAppliedObjects() []*result.RefAndObject {
 	return ad.collectObjects(func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject {
 		return au.appliedObjects
 	})
@@ -790,7 +790,7 @@ func (ad *ApplyDeploymentsUtil) GetAppliedObjectsMap() map[k8s2.ObjectRef]*uo.Un
 	return ret
 }
 
-func (ad *ApplyDeploymentsUtil) GetAppliedHookObjects() []*types.RefAndObject {
+func (ad *ApplyDeploymentsUtil) GetAppliedHookObjects() []*result.RefAndObject {
 	return ad.collectObjects(func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject {
 		return au.appliedHookObjects
 	})

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -768,8 +768,21 @@ func (ad *ApplyDeploymentsUtil) collectObjects(f func(au *ApplyUtil) map[k8s2.Ob
 	return ret
 }
 
-func (ad *ApplyDeploymentsUtil) GetNewObjects() []*uo.UnstructuredObject {
-	return ad.collectObjects(func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject {
+func (ad *ApplyDeploymentsUtil) collectObjectRefs(f func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject) []k8s2.ObjectRef {
+	ad.resultsMutex.Lock()
+	defer ad.resultsMutex.Unlock()
+
+	var ret []k8s2.ObjectRef
+	for _, a := range ad.results {
+		for _, o := range f(a) {
+			ret = append(ret, o.GetK8sRef())
+		}
+	}
+	return ret
+}
+
+func (ad *ApplyDeploymentsUtil) GetNewObjectRefs() []k8s2.ObjectRef {
+	return ad.collectObjectRefs(func(au *ApplyUtil) map[k8s2.ObjectRef]*uo.UnstructuredObject {
 		return au.newObjects
 	})
 }

--- a/pkg/deployment/utils/delete_utils.go
+++ b/pkg/deployment/utils/delete_utils.go
@@ -175,14 +175,14 @@ func DeleteObjects(ctx context.Context, k *k8s.K8sCluster, refs []k8s2.ObjectRef
 			ret.DeletedObjects = append(ret.DeletedObjects, ref)
 		} else {
 			ret.Errors = append(ret.Errors, result.DeploymentError{
-				Ref:   ref,
-				Error: err.Error(),
+				Ref:     ref,
+				Message: err.Error(),
 			})
 		}
 		for _, w := range apiWarnings {
 			ret.Warnings = append(ret.Warnings, result.DeploymentError{
-				Ref:   ref,
-				Error: w.Text,
+				Ref:     ref,
+				Message: w.Text,
 			})
 		}
 	}

--- a/pkg/deployment/utils/delete_utils.go
+++ b/pkg/deployment/utils/delete_utils.go
@@ -42,7 +42,7 @@ var deleteOrder = [][]string{
 
 func objectRefForExclusion(k *k8s.K8sCluster, ref k8s2.ObjectRef) k8s2.ObjectRef {
 	ref = k.Resources.FixNamespaceInRef(ref)
-	ref.GVK.Version = ""
+	ref.Version = ""
 	return ref
 }
 
@@ -84,7 +84,7 @@ func filterObjectsForDelete(k *k8s.K8sCluster, objects []*uo.UnstructuredObject,
 
 	for _, o := range objects {
 		ref := o.GetK8sRef()
-		if _, ok := filteredResources[ref.GVK.GroupKind()]; !ok {
+		if _, ok := filteredResources[ref.GroupKind()]; !ok {
 			continue
 		}
 
@@ -189,7 +189,7 @@ func DeleteObjects(ctx context.Context, k *k8s.K8sCluster, refs []k8s2.ObjectRef
 
 	for _, ref_ := range refs {
 		ref := ref_
-		if ref.GVK.GroupVersion().String() == "v1" && ref.GVK.Kind == "Namespace" {
+		if ref.GroupVersion().String() == "v1" && ref.Kind == "Namespace" {
 			namespaceNames[ref.Name] = true
 			g.Run(func() {
 				apiWarnings, err := k.DeleteSingleObject(ref, k8s.DeleteOptions{NoWait: !doWait, IgnoreNotFoundError: true})
@@ -201,7 +201,7 @@ func DeleteObjects(ctx context.Context, k *k8s.K8sCluster, refs []k8s2.ObjectRef
 
 	for _, ref_ := range refs {
 		ref := ref_
-		if ref.GVK.GroupVersion().String() == "v1" && ref.GVK.Kind == "Namespace" {
+		if ref.GroupVersion().String() == "v1" && ref.Kind == "Namespace" {
 			continue
 		}
 		if _, ok := namespaceNames[ref.Namespace]; ok {

--- a/pkg/deployment/utils/delete_utils.go
+++ b/pkg/deployment/utils/delete_utils.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"context"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
-	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -160,10 +160,10 @@ func FindObjectsForDelete(k *k8s.K8sCluster, allClusterObjects []*uo.Unstructure
 	return ret, nil
 }
 
-func DeleteObjects(ctx context.Context, k *k8s.K8sCluster, refs []k8s2.ObjectRef, doWait bool) (*types.CommandResult, error) {
+func DeleteObjects(ctx context.Context, k *k8s.K8sCluster, refs []k8s2.ObjectRef, doWait bool) (*result.CommandResult, error) {
 	g := utils.NewGoHelper(ctx, 8)
 
-	var ret types.CommandResult
+	var ret result.CommandResult
 	namespaceNames := make(map[string]bool)
 	var mutex sync.Mutex
 
@@ -174,13 +174,13 @@ func DeleteObjects(ctx context.Context, k *k8s.K8sCluster, refs []k8s2.ObjectRef
 		if err == nil {
 			ret.DeletedObjects = append(ret.DeletedObjects, ref)
 		} else {
-			ret.Errors = append(ret.Errors, types.DeploymentError{
+			ret.Errors = append(ret.Errors, result.DeploymentError{
 				Ref:   ref,
 				Error: err.Error(),
 			})
 		}
 		for _, w := range apiWarnings {
-			ret.Warnings = append(ret.Warnings, types.DeploymentError{
+			ret.Warnings = append(ret.Warnings, result.DeploymentError{
 				Ref:   ref,
 				Error: w.Text,
 			})

--- a/pkg/deployment/utils/diff_utils.go
+++ b/pkg/deployment/utils/diff_utils.go
@@ -100,10 +100,8 @@ func (u *diffUtil) diffObject(lo *uo.UnstructuredObject, diffRef k8s2.ObjectRef,
 		u.mutex.Lock()
 		defer u.mutex.Unlock()
 		u.ChangedObjects = append(u.ChangedObjects, &result.ChangedObject{
-			Ref:       diffRef,
-			NewObject: ao,
-			OldObject: ro,
-			Changes:   changes,
+			Ref:     diffRef,
+			Changes: changes,
 		})
 	}
 }

--- a/pkg/deployment/utils/diff_utils.go
+++ b/pkg/deployment/utils/diff_utils.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/diff"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"sort"
 	"sync"
@@ -22,7 +23,7 @@ type diffUtil struct {
 	IgnoreAnnotations bool
 
 	remoteDiffObjects map[k8s2.ObjectRef]*uo.UnstructuredObject
-	ChangedObjects    []*types.ChangedObject
+	ChangedObjects    []*result.ChangedObject
 	mutex             sync.Mutex
 }
 
@@ -98,7 +99,7 @@ func (u *diffUtil) diffObject(lo *uo.UnstructuredObject, diffRef k8s2.ObjectRef,
 
 		u.mutex.Lock()
 		defer u.mutex.Unlock()
-		u.ChangedObjects = append(u.ChangedObjects, &types.ChangedObject{
+		u.ChangedObjects = append(u.ChangedObjects, &result.ChangedObject{
 			Ref:       diffRef,
 			NewObject: ao,
 			OldObject: ro,

--- a/pkg/deployment/utils/diff_utils.go
+++ b/pkg/deployment/utils/diff_utils.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-type diffUtil struct {
+type DiffUtil struct {
 	dew            *DeploymentErrorsAndWarnings
 	deployments    []*deployment.DeploymentItem
 	appliedObjects map[k8s2.ObjectRef]*uo.UnstructuredObject
@@ -27,8 +27,8 @@ type diffUtil struct {
 	mutex             sync.Mutex
 }
 
-func NewDiffUtil(dew *DeploymentErrorsAndWarnings, deployments []*deployment.DeploymentItem, ru *RemoteObjectUtils, appliedObjects map[k8s2.ObjectRef]*uo.UnstructuredObject) *diffUtil {
-	return &diffUtil{
+func NewDiffUtil(dew *DeploymentErrorsAndWarnings, deployments []*deployment.DeploymentItem, ru *RemoteObjectUtils, appliedObjects map[k8s2.ObjectRef]*uo.UnstructuredObject) *DiffUtil {
+	return &DiffUtil{
 		dew:            dew,
 		deployments:    deployments,
 		ru:             ru,
@@ -36,7 +36,7 @@ func NewDiffUtil(dew *DeploymentErrorsAndWarnings, deployments []*deployment.Dep
 	}
 }
 
-func (u *diffUtil) Diff() {
+func (u *DiffUtil) Diff() {
 	var wg sync.WaitGroup
 
 	u.calcRemoteObjectsForDiff()
@@ -67,7 +67,7 @@ func (u *diffUtil) Diff() {
 	})
 }
 
-func (u *diffUtil) diffObject(lo *uo.UnstructuredObject, diffRef k8s2.ObjectRef, ao *uo.UnstructuredObject, ro *uo.UnstructuredObject, ignoreForDiffs []*types.IgnoreForDiffItemConfig) {
+func (u *DiffUtil) diffObject(lo *uo.UnstructuredObject, diffRef k8s2.ObjectRef, ao *uo.UnstructuredObject, ro *uo.UnstructuredObject, ignoreForDiffs []*types.IgnoreForDiffItemConfig) {
 	if ao != nil && ro == nil {
 		// new?
 		return
@@ -106,7 +106,7 @@ func (u *diffUtil) diffObject(lo *uo.UnstructuredObject, diffRef k8s2.ObjectRef,
 	}
 }
 
-func (u *diffUtil) calcRemoteObjectsForDiff() {
+func (u *DiffUtil) calcRemoteObjectsForDiff() {
 	u.remoteDiffObjects = make(map[k8s2.ObjectRef]*uo.UnstructuredObject)
 	for _, o := range u.ru.remoteObjects {
 		diffName := o.GetK8sAnnotation("kluctl.io/diff-name")
@@ -126,7 +126,7 @@ func (u *diffUtil) calcRemoteObjectsForDiff() {
 	}
 }
 
-func (u *diffUtil) getRemoteObjectForDiff(localObject *uo.UnstructuredObject) (k8s2.ObjectRef, *uo.UnstructuredObject) {
+func (u *DiffUtil) getRemoteObjectForDiff(localObject *uo.UnstructuredObject) (k8s2.ObjectRef, *uo.UnstructuredObject) {
 	ref := localObject.GetK8sRef()
 	diffName := localObject.GetK8sAnnotation("kluctl.io/diff-name")
 	if diffName != nil {

--- a/pkg/deployment/utils/diff_utils_test.go
+++ b/pkg/deployment/utils/diff_utils_test.go
@@ -64,7 +64,6 @@ func TestDiff(t *testing.T) {
 			ao:   []*uo.UnstructuredObject{newTestConfigMap("test", map[string]interface{}{"d1": "v2"})},
 			a: func(t *testing.T, dtc *diffTestConfig) {
 				assert.Len(t, dtc.du.ChangedObjects, 1)
-				assert.Equal(t, dtc.du.ChangedObjects[0].NewObject, dtc.ao[0])
 				assert.Equal(t, []result.Change{
 					result.Change{Type: "update", JsonPath: "data.d1", OldValue: "v1", NewValue: "v2", UnifiedDiff: "-v1\n+v2"},
 				}, dtc.du.ChangedObjects[0].Changes)
@@ -77,7 +76,6 @@ func TestDiff(t *testing.T) {
 			ao:   []*uo.UnstructuredObject{newTestConfigMap("test", map[string]interface{}{"d1": "v1", "d2": "v2"})},
 			a: func(t *testing.T, dtc *diffTestConfig) {
 				assert.Len(t, dtc.du.ChangedObjects, 1)
-				assert.Equal(t, dtc.du.ChangedObjects[0].NewObject, dtc.ao[0])
 				assert.Equal(t, []result.Change{
 					result.Change{Type: "insert", JsonPath: "data.d2", OldValue: interface{}(nil), NewValue: "v2", UnifiedDiff: "+v2"},
 				}, dtc.du.ChangedObjects[0].Changes)
@@ -90,7 +88,6 @@ func TestDiff(t *testing.T) {
 			ao:   []*uo.UnstructuredObject{newTestConfigMap("test", map[string]interface{}{"d1": "v1"})},
 			a: func(t *testing.T, dtc *diffTestConfig) {
 				assert.Len(t, dtc.du.ChangedObjects, 1)
-				assert.Equal(t, dtc.du.ChangedObjects[0].NewObject, dtc.ao[0])
 				assert.Equal(t, []result.Change{
 					result.Change{Type: "delete", JsonPath: "data.d2", OldValue: "v2", NewValue: interface{}(nil), UnifiedDiff: "-v2"},
 				}, dtc.du.ChangedObjects[0].Changes)
@@ -103,7 +100,6 @@ func TestDiff(t *testing.T) {
 			ao:   []*uo.UnstructuredObject{newTestConfigMap("test", map[string]interface{}{"d2": "v2"})},
 			a: func(t *testing.T, dtc *diffTestConfig) {
 				assert.Len(t, dtc.du.ChangedObjects, 1)
-				assert.Equal(t, dtc.du.ChangedObjects[0].NewObject, dtc.ao[0])
 				assert.Equal(t, []result.Change{
 					result.Change{Type: "delete", JsonPath: "data.d1", OldValue: "v1", NewValue: interface{}(nil), UnifiedDiff: "-v1"},
 					result.Change{Type: "insert", JsonPath: "data.d2", OldValue: interface{}(nil), NewValue: "v2", UnifiedDiff: "+v2"},
@@ -117,7 +113,6 @@ func TestDiff(t *testing.T) {
 			ao:   []*uo.UnstructuredObject{newTestConfigMap("test", map[string]interface{}{"d1": "v12", "d3": "v3"})},
 			a: func(t *testing.T, dtc *diffTestConfig) {
 				assert.Len(t, dtc.du.ChangedObjects, 1)
-				assert.Equal(t, dtc.du.ChangedObjects[0].NewObject, dtc.ao[0])
 				assert.Equal(t, []result.Change{
 					result.Change{Type: "update", JsonPath: "data.d1", OldValue: "v1", NewValue: "v12", UnifiedDiff: "-v1\n+v12"},
 					result.Change{Type: "delete", JsonPath: "data.d2", OldValue: "v2", NewValue: interface{}(nil), UnifiedDiff: "-v2"},

--- a/pkg/deployment/utils/diff_utils_test.go
+++ b/pkg/deployment/utils/diff_utils_test.go
@@ -19,7 +19,7 @@ type diffTestConfig struct {
 
 	dew *DeploymentErrorsAndWarnings
 	ru  *RemoteObjectUtils
-	du  *diffUtil
+	du  *DiffUtil
 }
 
 func (dtc *diffTestConfig) newRemoteObjects(dew *DeploymentErrorsAndWarnings) *RemoteObjectUtils {

--- a/pkg/deployment/utils/diff_utils_test.go
+++ b/pkg/deployment/utils/diff_utils_test.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"context"
 	"github.com/kluctl/kluctl/v2/pkg/deployment"
-	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -65,8 +65,8 @@ func TestDiff(t *testing.T) {
 			a: func(t *testing.T, dtc *diffTestConfig) {
 				assert.Len(t, dtc.du.ChangedObjects, 1)
 				assert.Equal(t, dtc.du.ChangedObjects[0].NewObject, dtc.ao[0])
-				assert.Equal(t, []types.Change{
-					types.Change{Type: "update", JsonPath: "data.d1", OldValue: "v1", NewValue: "v2", UnifiedDiff: "-v1\n+v2"},
+				assert.Equal(t, []result.Change{
+					result.Change{Type: "update", JsonPath: "data.d1", OldValue: "v1", NewValue: "v2", UnifiedDiff: "-v1\n+v2"},
 				}, dtc.du.ChangedObjects[0].Changes)
 			},
 		},
@@ -78,8 +78,8 @@ func TestDiff(t *testing.T) {
 			a: func(t *testing.T, dtc *diffTestConfig) {
 				assert.Len(t, dtc.du.ChangedObjects, 1)
 				assert.Equal(t, dtc.du.ChangedObjects[0].NewObject, dtc.ao[0])
-				assert.Equal(t, []types.Change{
-					types.Change{Type: "insert", JsonPath: "data.d2", OldValue: interface{}(nil), NewValue: "v2", UnifiedDiff: "+v2"},
+				assert.Equal(t, []result.Change{
+					result.Change{Type: "insert", JsonPath: "data.d2", OldValue: interface{}(nil), NewValue: "v2", UnifiedDiff: "+v2"},
 				}, dtc.du.ChangedObjects[0].Changes)
 			},
 		},
@@ -91,8 +91,8 @@ func TestDiff(t *testing.T) {
 			a: func(t *testing.T, dtc *diffTestConfig) {
 				assert.Len(t, dtc.du.ChangedObjects, 1)
 				assert.Equal(t, dtc.du.ChangedObjects[0].NewObject, dtc.ao[0])
-				assert.Equal(t, []types.Change{
-					types.Change{Type: "delete", JsonPath: "data.d2", OldValue: "v2", NewValue: interface{}(nil), UnifiedDiff: "-v2"},
+				assert.Equal(t, []result.Change{
+					result.Change{Type: "delete", JsonPath: "data.d2", OldValue: "v2", NewValue: interface{}(nil), UnifiedDiff: "-v2"},
 				}, dtc.du.ChangedObjects[0].Changes)
 			},
 		},
@@ -104,9 +104,9 @@ func TestDiff(t *testing.T) {
 			a: func(t *testing.T, dtc *diffTestConfig) {
 				assert.Len(t, dtc.du.ChangedObjects, 1)
 				assert.Equal(t, dtc.du.ChangedObjects[0].NewObject, dtc.ao[0])
-				assert.Equal(t, []types.Change{
-					types.Change{Type: "delete", JsonPath: "data.d1", OldValue: "v1", NewValue: interface{}(nil), UnifiedDiff: "-v1"},
-					types.Change{Type: "insert", JsonPath: "data.d2", OldValue: interface{}(nil), NewValue: "v2", UnifiedDiff: "+v2"},
+				assert.Equal(t, []result.Change{
+					result.Change{Type: "delete", JsonPath: "data.d1", OldValue: "v1", NewValue: interface{}(nil), UnifiedDiff: "-v1"},
+					result.Change{Type: "insert", JsonPath: "data.d2", OldValue: interface{}(nil), NewValue: "v2", UnifiedDiff: "+v2"},
 				}, dtc.du.ChangedObjects[0].Changes)
 			},
 		},
@@ -118,10 +118,10 @@ func TestDiff(t *testing.T) {
 			a: func(t *testing.T, dtc *diffTestConfig) {
 				assert.Len(t, dtc.du.ChangedObjects, 1)
 				assert.Equal(t, dtc.du.ChangedObjects[0].NewObject, dtc.ao[0])
-				assert.Equal(t, []types.Change{
-					types.Change{Type: "update", JsonPath: "data.d1", OldValue: "v1", NewValue: "v12", UnifiedDiff: "-v1\n+v12"},
-					types.Change{Type: "delete", JsonPath: "data.d2", OldValue: "v2", NewValue: interface{}(nil), UnifiedDiff: "-v2"},
-					types.Change{Type: "insert", JsonPath: "data.d3", OldValue: interface{}(nil), NewValue: "v3", UnifiedDiff: "+v3"},
+				assert.Equal(t, []result.Change{
+					result.Change{Type: "update", JsonPath: "data.d1", OldValue: "v1", NewValue: "v12", UnifiedDiff: "-v1\n+v12"},
+					result.Change{Type: "delete", JsonPath: "data.d2", OldValue: "v2", NewValue: interface{}(nil), UnifiedDiff: "-v2"},
+					result.Change{Type: "insert", JsonPath: "data.d3", OldValue: interface{}(nil), NewValue: "v3", UnifiedDiff: "+v3"},
 				}, dtc.du.ChangedObjects[0].Changes)
 			},
 		},

--- a/pkg/deployment/utils/diff_utils_test.go
+++ b/pkg/deployment/utils/diff_utils_test.go
@@ -126,8 +126,8 @@ func TestDiff(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			test.dew = NewDeploymentErrorsAndWarnings()
 			test.ru = test.newRemoteObjects(test.dew)
-			test.du = NewDiffUtil(test.dew, test.newDeploymentItems(), test.ru, test.appliedObjectsMap())
-			test.du.Diff()
+			test.du = NewDiffUtil(test.dew, test.ru, test.appliedObjectsMap())
+			test.du.DiffDeploymentItems(test.newDeploymentItems())
 			test.a(t, test)
 		})
 	}

--- a/pkg/deployment/utils/errors_holder.go
+++ b/pkg/deployment/utils/errors_holder.go
@@ -31,8 +31,8 @@ func (dew *DeploymentErrorsAndWarnings) Init() {
 
 func (dew *DeploymentErrorsAndWarnings) AddWarning(ref k8s.ObjectRef, warning error) {
 	de := result.DeploymentError{
-		Ref:   ref,
-		Error: warning.Error(),
+		Ref:     ref,
+		Message: warning.Error(),
 	}
 	dew.mutex.Lock()
 	defer dew.mutex.Unlock()
@@ -46,8 +46,8 @@ func (dew *DeploymentErrorsAndWarnings) AddWarning(ref k8s.ObjectRef, warning er
 
 func (dew *DeploymentErrorsAndWarnings) AddError(ref k8s.ObjectRef, err error) {
 	de := result.DeploymentError{
-		Ref:   ref,
-		Error: err.Error(),
+		Ref:     ref,
+		Message: err.Error(),
 	}
 	dew.mutex.Lock()
 	defer dew.mutex.Unlock()
@@ -99,7 +99,7 @@ func (dew *DeploymentErrorsAndWarnings) GetWarningsList() []result.DeploymentErr
 func (dew *DeploymentErrorsAndWarnings) getPlainErrorsList() []error {
 	var ret []error
 	for _, e := range dew.GetErrorsList() {
-		ret = append(ret, errors.New(e.Error))
+		ret = append(ret, errors.New(e.Message))
 	}
 	return ret
 }

--- a/pkg/deployment/utils/errors_holder.go
+++ b/pkg/deployment/utils/errors_holder.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"github.com/hashicorp/go-multierror"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/k8s"
-	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"sync"
 )
 
 type DeploymentErrorsAndWarnings struct {
-	errors   map[k8s.ObjectRef]map[types.DeploymentError]bool
-	warnings map[k8s.ObjectRef]map[types.DeploymentError]bool
+	errors   map[k8s.ObjectRef]map[result.DeploymentError]bool
+	warnings map[k8s.ObjectRef]map[result.DeploymentError]bool
 	mutex    sync.Mutex
 }
 
@@ -25,12 +25,12 @@ func NewDeploymentErrorsAndWarnings() *DeploymentErrorsAndWarnings {
 func (dew *DeploymentErrorsAndWarnings) Init() {
 	dew.mutex.Lock()
 	defer dew.mutex.Unlock()
-	dew.warnings = map[k8s.ObjectRef]map[types.DeploymentError]bool{}
-	dew.errors = map[k8s.ObjectRef]map[types.DeploymentError]bool{}
+	dew.warnings = map[k8s.ObjectRef]map[result.DeploymentError]bool{}
+	dew.errors = map[k8s.ObjectRef]map[result.DeploymentError]bool{}
 }
 
 func (dew *DeploymentErrorsAndWarnings) AddWarning(ref k8s.ObjectRef, warning error) {
-	de := types.DeploymentError{
+	de := result.DeploymentError{
 		Ref:   ref,
 		Error: warning.Error(),
 	}
@@ -38,14 +38,14 @@ func (dew *DeploymentErrorsAndWarnings) AddWarning(ref k8s.ObjectRef, warning er
 	defer dew.mutex.Unlock()
 	m, ok := dew.warnings[ref]
 	if !ok {
-		m = make(map[types.DeploymentError]bool)
+		m = make(map[result.DeploymentError]bool)
 		dew.warnings[ref] = m
 	}
 	m[de] = true
 }
 
 func (dew *DeploymentErrorsAndWarnings) AddError(ref k8s.ObjectRef, err error) {
-	de := types.DeploymentError{
+	de := result.DeploymentError{
 		Ref:   ref,
 		Error: err.Error(),
 	}
@@ -53,7 +53,7 @@ func (dew *DeploymentErrorsAndWarnings) AddError(ref k8s.ObjectRef, err error) {
 	defer dew.mutex.Unlock()
 	m, ok := dew.errors[ref]
 	if !ok {
-		m = make(map[types.DeploymentError]bool)
+		m = make(map[result.DeploymentError]bool)
 		dew.errors[ref] = m
 	}
 	m[de] = true
@@ -72,10 +72,10 @@ func (dew *DeploymentErrorsAndWarnings) HadError(ref k8s.ObjectRef) bool {
 	return ok
 }
 
-func (dew *DeploymentErrorsAndWarnings) GetErrorsList() []types.DeploymentError {
+func (dew *DeploymentErrorsAndWarnings) GetErrorsList() []result.DeploymentError {
 	dew.mutex.Lock()
 	defer dew.mutex.Unlock()
-	var ret []types.DeploymentError
+	var ret []result.DeploymentError
 	for _, m := range dew.errors {
 		for e := range m {
 			ret = append(ret, e)
@@ -84,10 +84,10 @@ func (dew *DeploymentErrorsAndWarnings) GetErrorsList() []types.DeploymentError 
 	return ret
 }
 
-func (dew *DeploymentErrorsAndWarnings) GetWarningsList() []types.DeploymentError {
+func (dew *DeploymentErrorsAndWarnings) GetWarningsList() []result.DeploymentError {
 	dew.mutex.Lock()
 	defer dew.mutex.Unlock()
-	var ret []types.DeploymentError
+	var ret []result.DeploymentError
 	for _, m := range dew.warnings {
 		for e := range m {
 			ret = append(ret, e)

--- a/pkg/deployment/utils/remote_objects_utils.go
+++ b/pkg/deployment/utils/remote_objects_utils.go
@@ -69,7 +69,11 @@ func (u *RemoteObjectUtils) getAllByDiscriminator(k *k8s.K8sCluster, discriminat
 		gvk := gvk
 		g.Run(func() {
 			l, apiWarnings, err := k.ListObjects(gvk, "", labels)
-			u.dew.AddApiWarnings(k8s2.ObjectRef{GVK: gvk}, apiWarnings)
+			u.dew.AddApiWarnings(k8s2.ObjectRef{
+				Group:   gvk.Group,
+				Version: gvk.Version,
+				Kind:    gvk.Kind,
+			}, apiWarnings)
 			mutex.Lock()
 			defer mutex.Unlock()
 			if err != nil {
@@ -81,7 +85,11 @@ func (u *RemoteObjectUtils) getAllByDiscriminator(k *k8s.K8sCluster, discriminat
 					permissionErrCount += 1
 					return
 				}
-				u.dew.AddWarning(k8s2.ObjectRef{GVK: gvk}, err)
+				u.dew.AddWarning(k8s2.ObjectRef{
+					Group:   gvk.Group,
+					Version: gvk.Version,
+					Kind:    gvk.Kind,
+				}, err)
 				return
 			}
 			for _, o := range l {
@@ -175,7 +183,7 @@ func (u *RemoteObjectUtils) UpdateRemoteObjects(k *k8s.K8sCluster, discriminator
 	if onlyUsedGKs {
 		usedGKs = map[schema.GroupKind]bool{}
 		for _, ref := range refs {
-			usedGKs[ref.GVK.GroupKind()] = true
+			usedGKs[ref.GroupKind()] = true
 		}
 	}
 

--- a/pkg/deployment/utils/remote_objects_utils_test.go
+++ b/pkg/deployment/utils/remote_objects_utils_test.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"context"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
-	"github.com/kluctl/kluctl/v2/pkg/types"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -42,7 +42,7 @@ func TestRemoteObjectUtils_PermissionErrors(t *testing.T) {
 		k8s2.NewObjectRef("", "v1", "Secret", "secret", "default"),
 	}, false)
 	assert.NoError(t, err)
-	assert.Equal(t, []types.DeploymentError{{
+	assert.Equal(t, []result.DeploymentError{{
 		Error: "at least one permission error was encountered while gathering objects by discriminator labels. This might result in orphan object detection to not work properly"},
 	}, dew.GetWarningsList())
 	assert.Empty(t, dew.GetErrorsList())

--- a/pkg/deployment/utils/remote_objects_utils_test.go
+++ b/pkg/deployment/utils/remote_objects_utils_test.go
@@ -43,7 +43,7 @@ func TestRemoteObjectUtils_PermissionErrors(t *testing.T) {
 	}, false)
 	assert.NoError(t, err)
 	assert.Equal(t, []result.DeploymentError{{
-		Error: "at least one permission error was encountered while gathering objects by discriminator labels. This might result in orphan object detection to not work properly"},
+		Message: "at least one permission error was encountered while gathering objects by discriminator labels. This might result in orphan object detection to not work properly"},
 	}, dew.GetWarningsList())
 	assert.Empty(t, dew.GetErrorsList())
 }

--- a/pkg/diff/normalize.go
+++ b/pkg/diff/normalize.go
@@ -117,6 +117,18 @@ func normalizeMisc(o *uo.UnstructuredObject) {
 	_ = o.RemoveNestedField("status")
 }
 
+func normalizeFloats(o *uo.UnstructuredObject) {
+	_ = o.NewIterator().IterateLeafs(func(it *uo.ObjectIterator) error {
+		if f, ok := it.Value().(float64); ok {
+			i := int64(f)
+			if f == float64(i) {
+				_ = it.SetValue(i)
+			}
+		}
+		return nil
+	})
+}
+
 var ignoreDiffFieldAnnotationRegex = regexp.MustCompile(`^kluctl.io/ignore-diff-field(-\d*)?$`)
 var ignoreDiffFieldRegexAnnotationRegex = regexp.MustCompile(`^kluctl.io/ignore-diff-field-regex(-\d*)?$`)
 
@@ -127,6 +139,7 @@ func NormalizeObject(o_ *uo.UnstructuredObject, ignoreForDiffs []*types.IgnoreFo
 	ns := o_.GetK8sNamespace()
 
 	o := o_.Clone()
+	normalizeFloats(o)
 	normalizeMetadata(o)
 	normalizeMisc(o)
 

--- a/pkg/diff/obfuscate.go
+++ b/pkg/diff/obfuscate.go
@@ -39,7 +39,7 @@ func (o *Obfuscator) ObfuscateResult(r *result.CommandResult) error {
 }
 
 func (o *Obfuscator) ObfuscateChanges(ref k8s.ObjectRef, changes []result.Change) error {
-	if ref.GVK.GroupKind() == secretGk {
+	if ref.GroupKind() == secretGk {
 		err := o.obfuscateSecretChanges(ref, changes)
 		if err != nil {
 			return err
@@ -50,7 +50,7 @@ func (o *Obfuscator) ObfuscateChanges(ref k8s.ObjectRef, changes []result.Change
 
 func (o *Obfuscator) ObfuscateObject(x *uo.UnstructuredObject) error {
 	ref := x.GetK8sRef()
-	if ref.GVK.GroupKind() == secretGk {
+	if ref.GroupKind() == secretGk {
 		err := o.obfuscateSecret(x)
 		if err != nil {
 			return err

--- a/pkg/diff/obfuscate.go
+++ b/pkg/diff/obfuscate.go
@@ -16,6 +16,28 @@ var secretGk = schema.GroupKind{Group: "", Kind: "Secret"}
 type Obfuscator struct {
 }
 
+func (o *Obfuscator) ObfuscateResult(r *result.CommandResult) error {
+	for _, c := range r.ChangedObjects {
+		err := o.ObfuscateChanges(c.Ref, c.Changes)
+		if err != nil {
+			return err
+		}
+	}
+	for _, n := range r.NewObjects {
+		err := o.ObfuscateObject(n.Object)
+		if err != nil {
+			return err
+		}
+	}
+	for _, h := range r.HookObjects {
+		err := o.ObfuscateObject(h.Object)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (o *Obfuscator) ObfuscateChanges(ref k8s.ObjectRef, changes []result.Change) error {
 	if ref.GVK.GroupKind() == secretGk {
 		err := o.obfuscateSecretChanges(ref, changes)

--- a/pkg/diff/obfuscate.go
+++ b/pkg/diff/obfuscate.go
@@ -24,13 +24,13 @@ func (o *Obfuscator) ObfuscateResult(r *result.CommandResult) error {
 		}
 	}
 	for _, n := range r.NewObjects {
-		err := o.ObfuscateObject(n.Object)
+		err := o.ObfuscateObject(n)
 		if err != nil {
 			return err
 		}
 	}
 	for _, h := range r.HookObjects {
-		err := o.ObfuscateObject(h.Object)
+		err := o.ObfuscateObject(h)
 		if err != nil {
 			return err
 		}

--- a/pkg/diff/obfuscate.go
+++ b/pkg/diff/obfuscate.go
@@ -2,8 +2,8 @@ package diff
 
 import (
 	"fmt"
-	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/ohler55/ojg/jp"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"strings"
@@ -14,7 +14,7 @@ var secretGvk = schema.GroupKind{Group: "", Kind: "Secret"}
 type Obfuscator struct {
 }
 
-func (o *Obfuscator) Obfuscate(ref k8s.ObjectRef, changes []types.Change) error {
+func (o *Obfuscator) Obfuscate(ref k8s.ObjectRef, changes []result.Change) error {
 	if ref.GVK.GroupKind() == secretGvk {
 		err := o.obfuscateSecret(ref, changes)
 		if err != nil {
@@ -24,7 +24,7 @@ func (o *Obfuscator) Obfuscate(ref k8s.ObjectRef, changes []types.Change) error 
 	return nil
 }
 
-func (o *Obfuscator) obfuscateSecret(ref k8s.ObjectRef, changes []types.Change) error {
+func (o *Obfuscator) obfuscateSecret(ref k8s.ObjectRef, changes []result.Change) error {
 	replaceValues := func(x any, v string) any {
 		if x == nil {
 			return nil

--- a/pkg/diff/obfuscate.go
+++ b/pkg/diff/obfuscate.go
@@ -119,7 +119,7 @@ func (o *Obfuscator) obfuscateSecretChanges(ref k8s.ObjectRef, changes []result.
 
 func (o *Obfuscator) obfuscateSecret(x *uo.UnstructuredObject) error {
 	data, ok, _ := x.GetNestedField("data")
-	if ok {
+	if ok && data != nil {
 		if m, ok := data.(map[string]any); ok {
 			for k, _ := range m {
 				m[k] = base64.StdEncoding.EncodeToString([]byte("*****"))
@@ -129,7 +129,7 @@ func (o *Obfuscator) obfuscateSecret(x *uo.UnstructuredObject) error {
 		}
 	}
 	data, ok, _ = x.GetNestedField("stringData")
-	if ok {
+	if ok && data != nil {
 		if m, ok := data.(map[string]any); ok {
 			for k, _ := range m {
 				m[k] = "*****"

--- a/pkg/diff/obfuscate.go
+++ b/pkg/diff/obfuscate.go
@@ -23,14 +23,26 @@ func (o *Obfuscator) ObfuscateResult(r *result.CommandResult) error {
 			return err
 		}
 	}
-	for _, n := range r.NewObjects {
+	for _, n := range r.RenderedObjects {
 		err := o.ObfuscateObject(n)
 		if err != nil {
 			return err
 		}
 	}
-	for _, h := range r.HookObjects {
-		err := o.ObfuscateObject(h)
+	for _, n := range r.RemoteObjects {
+		err := o.ObfuscateObject(n)
+		if err != nil {
+			return err
+		}
+	}
+	for _, n := range r.AppliedObjects {
+		err := o.ObfuscateObject(n)
+		if err != nil {
+			return err
+		}
+	}
+	for _, n := range r.AppliedHookObjects {
+		err := o.ObfuscateObject(n)
 		if err != nil {
 			return err
 		}

--- a/pkg/diff/obfuscate.go
+++ b/pkg/diff/obfuscate.go
@@ -17,32 +17,20 @@ type Obfuscator struct {
 }
 
 func (o *Obfuscator) ObfuscateResult(r *result.CommandResult) error {
-	for _, c := range r.ChangedObjects {
-		err := o.ObfuscateChanges(c.Ref, c.Changes)
+	for _, x := range r.Objects {
+		err := o.ObfuscateObject(x.Rendered)
 		if err != nil {
 			return err
 		}
-	}
-	for _, n := range r.RenderedObjects {
-		err := o.ObfuscateObject(n)
+		err = o.ObfuscateObject(x.Remote)
 		if err != nil {
 			return err
 		}
-	}
-	for _, n := range r.RemoteObjects {
-		err := o.ObfuscateObject(n)
+		err = o.ObfuscateObject(x.Applied)
 		if err != nil {
 			return err
 		}
-	}
-	for _, n := range r.AppliedObjects {
-		err := o.ObfuscateObject(n)
-		if err != nil {
-			return err
-		}
-	}
-	for _, n := range r.AppliedHookObjects {
-		err := o.ObfuscateObject(n)
+		err = o.ObfuscateChanges(x.Ref, x.Changes)
 		if err != nil {
 			return err
 		}
@@ -61,6 +49,9 @@ func (o *Obfuscator) ObfuscateChanges(ref k8s.ObjectRef, changes []result.Change
 }
 
 func (o *Obfuscator) ObfuscateObject(x *uo.UnstructuredObject) error {
+	if x == nil {
+		return nil
+	}
 	ref := x.GetK8sRef()
 	if ref.GroupKind() == secretGk {
 		err := o.obfuscateSecret(x)

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/metadata"
 )
 
 type k8sClients struct {
@@ -16,8 +17,9 @@ type k8sClients struct {
 }
 
 type parallelClientEntry struct {
-	corev1        corev1.CoreV1Interface
-	dynamicClient dynamic.Interface
+	corev1         corev1.CoreV1Interface
+	dynamicClient  dynamic.Interface
+	metadataClient metadata.Interface
 
 	warnings []ApiWarning
 }
@@ -55,6 +57,11 @@ func newK8sClients(ctx context.Context, clientFactory ClientFactory, count int) 
 		}
 
 		p.dynamicClient, err = clientFactory.DynamicClient(p)
+		if err != nil {
+			return nil, err
+		}
+
+		p.metadataClient, err = clientFactory.MetadataClient(p)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/k8s/client_factory.go
+++ b/pkg/k8s/client_factory.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/client-go/discovery/cached/disk"
 	"k8s.io/client-go/dynamic"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"net/http"
@@ -24,6 +25,7 @@ type ClientFactory interface {
 	DiscoveryClient() (discovery.DiscoveryInterface, error)
 	CoreV1Client(wh rest.WarningHandler) (corev1.CoreV1Interface, error)
 	DynamicClient(wh rest.WarningHandler) (dynamic.Interface, error)
+	MetadataClient(wh rest.WarningHandler) (metadata.Interface, error)
 }
 
 type realClientFactory struct {
@@ -63,6 +65,12 @@ func (r *realClientFactory) DynamicClient(wh rest.WarningHandler) (dynamic.Inter
 	config := rest.CopyConfig(r.config)
 	config.WarningHandler = wh
 	return dynamic.NewForConfigAndClient(config, r.httpClient)
+}
+
+func (r *realClientFactory) MetadataClient(wh rest.WarningHandler) (metadata.Interface, error) {
+	config := rest.CopyConfig(r.config)
+	config.WarningHandler = wh
+	return metadata.NewForConfigAndClient(config, r.httpClient)
 }
 
 func (r *realClientFactory) CloseIdleConnections() {

--- a/pkg/k8s/k8s_cluster.go
+++ b/pkg/k8s/k8s_cluster.go
@@ -136,7 +136,7 @@ func (k *K8sCluster) ListObjects(gvk schema.GroupVersionKind, namespace string, 
 
 func (k *K8sCluster) GetSingleObject(ref k8s.ObjectRef) (*uo.UnstructuredObject, []ApiWarning, error) {
 	var result *uo.UnstructuredObject
-	apiWarnings, err := k.clients.withDynamicClientForGVK(k.Resources, ref.GVK, ref.Namespace, func(r dynamic.ResourceInterface) error {
+	apiWarnings, err := k.clients.withDynamicClientForGVK(k.Resources, ref.GroupVersionKind(), ref.Namespace, func(r dynamic.ResourceInterface) error {
 		o := v1.GetOptions{}
 		x, err := r.Get(k.ctx, ref.Name, o)
 		if err != nil {
@@ -165,7 +165,7 @@ func (k *K8sCluster) DeleteSingleObject(ref k8s.ObjectRef, options DeleteOptions
 		o.DryRun = []string{"All"}
 	}
 
-	apiWarnings, err := k.clients.withDynamicClientForGVK(k.Resources, ref.GVK, ref.Namespace, func(r dynamic.ResourceInterface) error {
+	apiWarnings, err := k.clients.withDynamicClientForGVK(k.Resources, ref.GroupVersionKind(), ref.Namespace, func(r dynamic.ResourceInterface) error {
 		err := r.Delete(k.ctx, ref.Name, o)
 		if err != nil {
 			if options.IgnoreNotFoundError && errors.IsNotFound(err) {
@@ -318,7 +318,7 @@ func (k *K8sCluster) doPatch(ref k8s.ObjectRef, data []byte, patchType types.Pat
 	status.Trace(k.ctx, "patching %s", ref.String())
 
 	var result *uo.UnstructuredObject
-	apiWarnings, err := k.clients.withDynamicClientForGVK(k.Resources, ref.GVK, ref.Namespace, func(r dynamic.ResourceInterface) error {
+	apiWarnings, err := k.clients.withDynamicClientForGVK(k.Resources, ref.GroupVersionKind(), ref.Namespace, func(r dynamic.ResourceInterface) error {
 		x, err := r.Patch(k.ctx, ref.Name, patchType, data, po)
 		if err != nil {
 			return fmt.Errorf("failed to patch %s: %w", ref.String(), err)
@@ -370,7 +370,7 @@ func (k *K8sCluster) UpdateObject(o *uo.UnstructuredObject, options UpdateOption
 	status.Trace(k.ctx, "updating %s", ref.String())
 
 	var result *uo.UnstructuredObject
-	apiWarnings, err := k.clients.withDynamicClientForGVK(k.Resources, ref.GVK, ref.Namespace, func(r dynamic.ResourceInterface) error {
+	apiWarnings, err := k.clients.withDynamicClientForGVK(k.Resources, ref.GroupVersionKind(), ref.Namespace, func(r dynamic.ResourceInterface) error {
 		x, err := r.Update(k.ctx, o.ToUnstructured(), updateOpts)
 		if err != nil {
 			return err

--- a/pkg/k8s/k8s_cluster.go
+++ b/pkg/k8s/k8s_cluster.go
@@ -111,7 +111,11 @@ func (k *K8sCluster) buildLabelSelector(labels map[string]string) string {
 		if len(ret) != 0 {
 			ret += ","
 		}
-		ret += fmt.Sprintf("%s=%s", k, v)
+		if v == "" {
+			ret += k
+		} else {
+			ret += fmt.Sprintf("%s=%s", k, v)
+		}
 	}
 	return ret
 }

--- a/pkg/k8s/resources.go
+++ b/pkg/k8s/resources.go
@@ -252,7 +252,7 @@ func (k *k8sResources) IsNamespaced(gv schema.GroupKind) *bool {
 
 func (k *k8sResources) FixNamespace(o *uo.UnstructuredObject, def string) {
 	ref := o.GetK8sRef()
-	namespaced := k.IsNamespaced(ref.GVK.GroupKind())
+	namespaced := k.IsNamespaced(ref.GroupKind())
 	if namespaced == nil {
 		return
 	}
@@ -264,7 +264,7 @@ func (k *k8sResources) FixNamespace(o *uo.UnstructuredObject, def string) {
 }
 
 func (k *k8sResources) FixNamespaceInRef(ref k8s.ObjectRef) k8s.ObjectRef {
-	namespaced := k.IsNamespaced(ref.GVK.GroupKind())
+	namespaced := k.IsNamespaced(ref.GroupKind())
 	if namespaced == nil {
 		return ref
 	}

--- a/pkg/kluctl_project/load.go
+++ b/pkg/kluctl_project/load.go
@@ -13,7 +13,7 @@ func LoadKluctlProject(ctx context.Context, args LoadKluctlProjectArgs, tmpDir s
 
 	p := &LoadedKluctlProject{
 		ctx:           ctx,
-		loadArgs:      args,
+		LoadArgs:      args,
 		TmpDir:        tmpDir,
 		J2:            j2,
 		RP:            args.RP,

--- a/pkg/kluctl_project/project.go
+++ b/pkg/kluctl_project/project.go
@@ -12,7 +12,7 @@ import (
 type LoadedKluctlProject struct {
 	ctx context.Context
 
-	loadArgs LoadKluctlProjectArgs
+	LoadArgs LoadKluctlProjectArgs
 
 	TmpDir string
 

--- a/pkg/kluctl_project/project_load.go
+++ b/pkg/kluctl_project/project_load.go
@@ -25,7 +25,7 @@ type LoadKluctlProjectArgs struct {
 }
 
 func (c *LoadedKluctlProject) getConfigPath() string {
-	configPath := c.loadArgs.ProjectConfig
+	configPath := c.LoadArgs.ProjectConfig
 	if configPath == "" {
 		p := yaml.FixPathExt(filepath.Join(c.ProjectDir, ".kluctl.yml"))
 		if utils.IsFile(p) {
@@ -38,8 +38,8 @@ func (c *LoadedKluctlProject) getConfigPath() string {
 func (c *LoadedKluctlProject) loadKluctlProject() error {
 	var err error
 
-	c.projectRootDir = c.loadArgs.RepoRoot
-	c.ProjectDir = c.loadArgs.ProjectDir
+	c.projectRootDir = c.LoadArgs.RepoRoot
+	c.ProjectDir = c.LoadArgs.ProjectDir
 	err = utils.CheckInDir(c.projectRootDir, c.ProjectDir)
 	if err != nil {
 		return err

--- a/pkg/kluctl_project/target_context.go
+++ b/pkg/kluctl_project/target_context.go
@@ -159,7 +159,7 @@ func (p *LoadedKluctlProject) loadK8sConfig(target *types.Target, offlineK8s boo
 	var err error
 	var clientConfig *rest.Config
 	var restConfig *api.Config
-	clientConfig, restConfig, err = p.loadArgs.ClientConfigGetter(contextName)
+	clientConfig, restConfig, err = p.LoadArgs.ClientConfigGetter(contextName)
 	if err != nil {
 		return nil, "", err
 	}
@@ -193,8 +193,8 @@ func (p *LoadedKluctlProject) buildVars(target *types.Target, forSeal bool) (*va
 			}
 		}
 	}
-	if p.loadArgs.ExternalArgs != nil {
-		allArgs.Merge(p.loadArgs.ExternalArgs)
+	if p.LoadArgs.ExternalArgs != nil {
+		allArgs.Merge(p.LoadArgs.ExternalArgs)
 	}
 
 	err = deployment.LoadDefaultArgs(p.Config.Args, allArgs)

--- a/pkg/kluctl_project/targets.go
+++ b/pkg/kluctl_project/targets.go
@@ -14,7 +14,12 @@ func (c *LoadedKluctlProject) loadTargets() error {
 	targetNames := make(map[string]bool)
 	c.Targets = nil
 
-	for _, configTarget := range c.Config.Targets {
+	for i, configTarget := range c.Config.Targets {
+		if configTarget.Name == "" {
+			status.Error(c.ctx, "Target at index %d has no name", i)
+			continue
+		}
+
 		target, err := c.buildTarget(configTarget)
 		if err != nil {
 			status.Warning(c.ctx, "Failed to load target config for project: %v", err)

--- a/pkg/results/result-store-secrets.go
+++ b/pkg/results/result-store-secrets.go
@@ -1,0 +1,290 @@
+package results
+
+import (
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"github.com/kluctl/kluctl/v2/pkg/k8s"
+	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
+	"github.com/kluctl/kluctl/v2/pkg/utils"
+	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
+	"github.com/kluctl/kluctl/v2/pkg/yaml"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type ResultStoreSecrets struct {
+	k              *k8s.K8sCluster
+	writeNamespace string
+}
+
+func NewResultStoreSecrets(k *k8s.K8sCluster, writeNamespace string) (*ResultStoreSecrets, error) {
+	s := &ResultStoreSecrets{
+		k:              k,
+		writeNamespace: writeNamespace,
+	}
+
+	if s.writeNamespace != "" {
+		_, _, err := k.GetSingleObject(k8s2.NewObjectRef("", "v1", "Namespace", s.writeNamespace, ""))
+		if err != nil && errors.IsNotFound(err) {
+			ns := uo.FromMap(map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Namespace",
+				"metadata": map[string]any{
+					"name": s.writeNamespace,
+				},
+			})
+			_, _, err = k.ReadWrite().PatchObject(ns, k8s.PatchOptions{})
+			if err != nil {
+				return nil, err
+			}
+		} else if err != nil {
+			return nil, err
+		}
+	}
+
+	return s, nil
+}
+
+var invalidChars = regexp.MustCompile(`[^a-zA-Z0-9-]`)
+
+func (s *ResultStoreSecrets) buildName(cr *result.CommandResult) string {
+	var name string
+
+	if cr.Project.NormalizedGitUrl != "" {
+		s := path.Base(cr.Project.NormalizedGitUrl)
+		if s != "" {
+			name = s + "-"
+		}
+	}
+
+	name = strings.ReplaceAll(name, "_", "-")
+	name = invalidChars.ReplaceAllString(name, "")
+
+	nameWithId := name + cr.Id
+	if len(nameWithId) > 63 {
+		trimmedName := []byte(name[:63-len(cr.Id)])
+		trimmedName[len(trimmedName)-1] = '-'
+		nameWithId = string(trimmedName) + cr.Id
+	}
+
+	return nameWithId
+}
+
+func (s *ResultStoreSecrets) WriteCommandResult(ctx context.Context, cr *result.CommandResult) error {
+	crJson, err := yaml.WriteJsonString(cr.ToReducedObjects())
+	if err != nil {
+		return err
+	}
+	compressedCr, err := utils.CompressGzip([]byte(crJson), gzip.BestCompression)
+	if err != nil {
+		return err
+	}
+
+	objectsJson, err := yaml.WriteJsonString(result.CompactedObjects(cr.Objects))
+	if err != nil {
+		return err
+	}
+	compressedObjects, err := utils.CompressGzip([]byte(objectsJson), gzip.BestCompression)
+	if err != nil {
+		return err
+	}
+
+	summary := cr.BuildSummary()
+	summaryJson, err := yaml.WriteJsonString(summary)
+	if err != nil {
+		return err
+	}
+
+	secret := uo.FromMap(map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]any{
+			"name":      s.buildName(cr),
+			"namespace": s.writeNamespace,
+			"labels": map[string]any{
+				"kluctl.io/result-id": cr.Id,
+			},
+			"annotations": map[string]any{
+				"kluctl.io/result-summary": summaryJson,
+			},
+		},
+		"data": map[string]any{
+			"reducedResult":    compressedCr,
+			"compactedObjects": compressedObjects,
+		},
+	})
+	if cr.Project.NormalizedGitUrl != "" {
+		secret.SetK8sAnnotation("kluctl.io/result-project-normalized-url", cr.Project.NormalizedGitUrl)
+	}
+	if cr.Project.SubDir != "" {
+		secret.SetK8sAnnotation("kluctl.io/result-project-subdir", cr.Project.SubDir)
+	}
+
+	_, _, err = s.k.ReadWrite().PatchObject(secret, k8s.PatchOptions{})
+	return err
+}
+
+func (s *ResultStoreSecrets) ListProjects(ctx context.Context, options ListProjectsOptions) ([]result.ProjectSummary, error) {
+	summaries, err := s.ListCommandResultSummaries(ctx, ListCommandResultSummariesOptions{
+		ProjectFilter: options.ProjectFilter,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m := map[result.ProjectKey]result.ProjectSummary{}
+	for _, s := range summaries {
+		if _, ok := m[s.Project]; !ok {
+			m[s.Project] = result.ProjectSummary{Project: s.Project}
+		}
+	}
+
+	ret := make([]result.ProjectSummary, 0, len(m))
+	for _, p := range m {
+		for _, rs := range summaries {
+			switch rs.Command.Command {
+			case "deploy":
+				if p.LastDeployCommand == nil {
+					rs := rs
+					p.LastDeployCommand = &rs
+				}
+			case "delete":
+				if p.LastDeleteCommand == nil {
+					rs := rs
+					p.LastDeleteCommand = &rs
+				}
+			case "prune":
+				if p.LastPruneCommand == nil {
+					rs := rs
+					p.LastPruneCommand = &rs
+				}
+			}
+		}
+		ret = append(ret, p)
+	}
+
+	return ret, nil
+}
+
+func (s *ResultStoreSecrets) ListCommandResultSummaries(ctx context.Context, options ListCommandResultSummariesOptions) ([]result.CommandResultSummary, error) {
+	l, _, err := s.k.ListMetadata(schema.GroupVersionKind{
+		Version: "v1",
+		Kind:    "Secret",
+	}, "", map[string]string{
+		"kluctl.io/result-id": "",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]result.CommandResultSummary, 0, len(l))
+
+	for _, x := range l {
+		summaryJson := x.GetK8sAnnotation("kluctl.io/result-summary")
+		if summaryJson == nil || *summaryJson == "" {
+			continue
+		}
+
+		var summary result.CommandResultSummary
+		err = yaml.ReadYamlString(*summaryJson, &summary)
+		if err != nil {
+			continue
+		}
+
+		if options.ProjectFilter != nil {
+			if summary.Project != *options.ProjectFilter {
+				continue
+			}
+		}
+
+		ret = append(ret, summary)
+	}
+
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Command.StartTime >= ret[j].Command.StartTime
+	})
+
+	return ret, nil
+}
+
+func (s *ResultStoreSecrets) GetCommandResult(ctx context.Context, options GetCommandResultOptions) (*result.CommandResult, error) {
+	l, _, err := s.k.ListObjects(schema.GroupVersionKind{
+		Version: "v1",
+		Kind:    "Secret",
+	}, "", map[string]string{
+		"kluctl.io/result-id": options.Id,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(l) == 0 {
+		return nil, nil
+	}
+
+	var crJson, objectsJson []byte
+	err = utils.RunParallelE(ctx, func() error {
+		s, ok, err := l[0].GetNestedString("data", "reducedResult")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("reducedResult field not present for %s", options.Id)
+		}
+		crJson, err = base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return err
+		}
+		crJson, err = utils.UncompressGzip(crJson)
+		if err != nil {
+			return err
+		}
+		return nil
+	}, func() error {
+		if options.Reduced {
+			return nil
+		}
+		s, ok, err := l[0].GetNestedString("data", "compactedObjects")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("compactedObjects field not present for %s", options.Id)
+		}
+		objectsJson, err = base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			return err
+		}
+
+		objectsJson, err = utils.UncompressGzip(objectsJson)
+		if err != nil {
+			return err
+		}
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var cr result.CommandResult
+	err = yaml.ReadYamlBytes(crJson, &cr)
+	if err != nil {
+		return nil, err
+	}
+	if !options.Reduced {
+		var objects result.CompactedObjects
+		err = yaml.ReadYamlBytes(objectsJson, &objects)
+		if err != nil {
+			return nil, err
+		}
+		cr.Objects = objects
+	}
+
+	return &cr, nil
+}

--- a/pkg/results/result-store-secrets.go
+++ b/pkg/results/result-store-secrets.go
@@ -131,48 +131,6 @@ func (s *ResultStoreSecrets) WriteCommandResult(ctx context.Context, cr *result.
 	return err
 }
 
-func (s *ResultStoreSecrets) ListProjects(ctx context.Context, options ListProjectsOptions) ([]result.ProjectSummary, error) {
-	summaries, err := s.ListCommandResultSummaries(ctx, ListCommandResultSummariesOptions{
-		ProjectFilter: options.ProjectFilter,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	m := map[result.ProjectKey]result.ProjectSummary{}
-	for _, s := range summaries {
-		if _, ok := m[s.Project]; !ok {
-			m[s.Project] = result.ProjectSummary{Project: s.Project}
-		}
-	}
-
-	ret := make([]result.ProjectSummary, 0, len(m))
-	for _, p := range m {
-		for _, rs := range summaries {
-			switch rs.Command.Command {
-			case "deploy":
-				if p.LastDeployCommand == nil {
-					rs := rs
-					p.LastDeployCommand = &rs
-				}
-			case "delete":
-				if p.LastDeleteCommand == nil {
-					rs := rs
-					p.LastDeleteCommand = &rs
-				}
-			case "prune":
-				if p.LastPruneCommand == nil {
-					rs := rs
-					p.LastPruneCommand = &rs
-				}
-			}
-		}
-		ret = append(ret, p)
-	}
-
-	return ret, nil
-}
-
 func (s *ResultStoreSecrets) ListCommandResultSummaries(ctx context.Context, options ListCommandResultSummariesOptions) ([]result.CommandResultSummary, error) {
 	l, _, err := s.k.ListMetadata(schema.GroupVersionKind{
 		Version: "v1",

--- a/pkg/results/result-store-secrets.go
+++ b/pkg/results/result-store-secrets.go
@@ -3,53 +3,92 @@ package results
 import (
 	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"fmt"
-	"github.com/kluctl/kluctl/v2/pkg/k8s"
-	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
-	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
 	"path"
 	"regexp"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sort"
 	"strings"
+	"sync"
 )
 
 type ResultStoreSecrets struct {
-	k              *k8s.K8sCluster
+	ctx context.Context
+
+	config         *rest.Config
 	writeNamespace string
+
+	mutex       sync.Mutex
+	client      client.Client
+	cache       cache.Cache
+	informer    cache.Informer
+	cancelCache context.CancelFunc
 }
 
-func NewResultStoreSecrets(k *k8s.K8sCluster, writeNamespace string) (*ResultStoreSecrets, error) {
+func NewResultStoreSecrets(ctx context.Context, config *rest.Config, writeNamespace string) (*ResultStoreSecrets, error) {
 	s := &ResultStoreSecrets{
-		k:              k,
+		ctx:            ctx,
+		config:         config,
 		writeNamespace: writeNamespace,
 	}
+	return s, nil
+}
 
-	if s.writeNamespace != "" {
-		_, _, err := k.GetSingleObject(k8s2.NewObjectRef("", "v1", "Namespace", s.writeNamespace, ""))
-		if err != nil && errors.IsNotFound(err) {
-			ns := uo.FromMap(map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "Namespace",
-				"metadata": map[string]any{
-					"name": s.writeNamespace,
-				},
-			})
-			_, _, err = k.ReadWrite().PatchObject(ns, k8s.PatchOptions{})
-			if err != nil {
-				return nil, err
-			}
-		} else if err != nil {
-			return nil, err
-		}
+func (s *ResultStoreSecrets) ensureClientAndCache() error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.client != nil {
+		return nil
 	}
 
-	return s, nil
+	c, err := client.New(s.config, client.Options{})
+	if err != nil {
+		return err
+	}
+
+	labelSelector, _ := labels.Parse("kluctl.io/result-id")
+
+	var partialSecret metav1.PartialObjectMetadata
+	partialSecret.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Secret"})
+
+	ca, err := cache.New(s.config, cache.Options{
+		DefaultLabelSelector: labelSelector,
+	})
+	if err != nil {
+		return err
+	}
+
+	informer, err := ca.GetInformer(s.ctx, &partialSecret)
+	if err != nil {
+		return err
+	}
+
+	s.client = c
+	s.cache = ca
+	s.informer = informer
+
+	newCtx, cancel := context.WithCancel(s.ctx)
+	s.cancelCache = cancel
+
+	go func() {
+		_ = ca.Start(newCtx)
+	}()
+
+	s.cache.WaitForCacheSync(s.ctx)
+
+	return nil
 }
 
 var invalidChars = regexp.MustCompile(`[^a-zA-Z0-9-]`)
@@ -77,7 +116,40 @@ func (s *ResultStoreSecrets) buildName(cr *result.CommandResult) string {
 	return nameWithId
 }
 
-func (s *ResultStoreSecrets) WriteCommandResult(ctx context.Context, cr *result.CommandResult) error {
+func (s *ResultStoreSecrets) ensureWriteNamespace() error {
+	if s.writeNamespace == "" {
+		return fmt.Errorf("missing writeNamespace")
+	}
+	var ns corev1.Namespace
+	err := s.client.Get(s.ctx, client.ObjectKey{Name: s.writeNamespace}, &ns)
+	if err != nil && errors.IsNotFound(err) {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: s.writeNamespace,
+			},
+		}
+		err = s.client.Create(s.ctx, ns)
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *ResultStoreSecrets) WriteCommandResult(cr *result.CommandResult) error {
+	err := s.ensureClientAndCache()
+	if err != nil {
+		return err
+	}
+
+	err = s.ensureWriteNamespace()
+	if err != nil {
+		return err
+	}
+
 	crJson, err := yaml.WriteJsonString(cr.ToReducedObjects())
 	if err != nil {
 		return err
@@ -102,67 +174,65 @@ func (s *ResultStoreSecrets) WriteCommandResult(ctx context.Context, cr *result.
 		return err
 	}
 
-	secret := uo.FromMap(map[string]interface{}{
-		"apiVersion": "v1",
-		"kind":       "Secret",
-		"metadata": map[string]any{
-			"name":      s.buildName(cr),
-			"namespace": s.writeNamespace,
-			"labels": map[string]any{
+	secret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s.buildName(cr),
+			Namespace: s.writeNamespace,
+			Labels: map[string]string{
 				"kluctl.io/result-id": cr.Id,
 			},
-			"annotations": map[string]any{
+			Annotations: map[string]string{
 				"kluctl.io/result-summary": summaryJson,
 			},
 		},
-		"data": map[string]any{
+		Data: map[string][]byte{
 			"reducedResult":    compressedCr,
 			"compactedObjects": compressedObjects,
 		},
-	})
+	}
 	if cr.Project.NormalizedGitUrl != "" {
-		secret.SetK8sAnnotation("kluctl.io/result-project-normalized-url", cr.Project.NormalizedGitUrl)
+		secret.Annotations["kluctl.io/result-project-normalized-url"] = cr.Project.NormalizedGitUrl
 	}
 	if cr.Project.SubDir != "" {
-		secret.SetK8sAnnotation("kluctl.io/result-project-subdir", cr.Project.SubDir)
+		secret.Annotations["kluctl.io/result-project-subdir"] = cr.Project.SubDir
 	}
 
-	_, _, err = s.k.ReadWrite().PatchObject(secret, k8s.PatchOptions{})
-	return err
+	err = s.client.Patch(s.ctx, &secret, client.Apply, client.FieldOwner("kluctl-results"))
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
-func (s *ResultStoreSecrets) ListCommandResultSummaries(ctx context.Context, options ListCommandResultSummariesOptions) ([]result.CommandResultSummary, error) {
-	l, _, err := s.k.ListMetadata(schema.GroupVersionKind{
-		Version: "v1",
-		Kind:    "Secret",
-	}, "", map[string]string{
-		"kluctl.io/result-id": "",
-	})
+func (s *ResultStoreSecrets) ListCommandResultSummaries(options ListCommandResultSummariesOptions) ([]result.CommandResultSummary, error) {
+	err := s.ensureClientAndCache()
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make([]result.CommandResultSummary, 0, len(l))
+	var l metav1.PartialObjectMetadataList
+	l.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "SecretList"})
+	err = s.cache.List(s.ctx, &l, client.HasLabels{"kluctl.io/result-id"})
+	if err != nil {
+		return nil, err
+	}
 
-	for _, x := range l {
-		summaryJson := x.GetK8sAnnotation("kluctl.io/result-summary")
-		if summaryJson == nil || *summaryJson == "" {
-			continue
-		}
+	ret := make([]result.CommandResultSummary, 0, len(l.Items))
 
-		var summary result.CommandResultSummary
-		err = yaml.ReadYamlString(*summaryJson, &summary)
+	for _, x := range l.Items {
+		summary, err := s.parseSummary(&x)
 		if err != nil {
 			continue
 		}
-
-		if options.ProjectFilter != nil {
-			if summary.Project != *options.ProjectFilter {
-				continue
-			}
+		if !s.filterSummary(summary, options.ProjectFilter) {
+			continue
 		}
 
-		ret = append(ret, summary)
+		ret = append(ret, *summary)
 	}
 
 	sort.Slice(ret, func(i, j int) bool {
@@ -172,32 +242,145 @@ func (s *ResultStoreSecrets) ListCommandResultSummaries(ctx context.Context, opt
 	return ret, nil
 }
 
-func (s *ResultStoreSecrets) GetCommandResult(ctx context.Context, options GetCommandResultOptions) (*result.CommandResult, error) {
-	l, _, err := s.k.ListObjects(schema.GroupVersionKind{
-		Version: "v1",
-		Kind:    "Secret",
-	}, "", map[string]string{
+func (s *ResultStoreSecrets) parseSummary(obj client.Object) (*result.CommandResultSummary, error) {
+	if len(obj.GetAnnotations()) == 0 {
+		return nil, nil
+	}
+	summaryJson := obj.GetAnnotations()["kluctl.io/result-summary"]
+	if summaryJson == "" {
+		return nil, nil
+	}
+
+	var summary result.CommandResultSummary
+	err := yaml.ReadYamlString(summaryJson, &summary)
+	if err != nil {
+		return nil, err
+	}
+
+	return &summary, nil
+}
+
+func (s *ResultStoreSecrets) filterSummary(summary *result.CommandResultSummary, project *result.ProjectKey) bool {
+	if project != nil {
+		if project.NormalizedGitUrl != "" && summary.Project.NormalizedGitUrl != project.NormalizedGitUrl {
+			return false
+		}
+		if project.SubDir != "" && summary.Project.SubDir != project.SubDir {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (s *ResultStoreSecrets) WatchCommandResultSummaries(options ListCommandResultSummariesOptions, update func(summary *result.CommandResultSummary), delete func(id string)) (func(), error) {
+	err := s.ensureClientAndCache()
+	if err != nil {
+		return nil, err
+	}
+
+	handler := func(obj any, deleted bool) {
+		obj2, ok := obj.(client.Object)
+		if !ok {
+			return
+		}
+		summary, err := s.parseSummary(obj2)
+		if err != nil {
+			return
+		}
+		if !s.filterSummary(summary, options.ProjectFilter) {
+			return
+		}
+		if deleted {
+			delete(summary.Id)
+		} else {
+			update(summary)
+		}
+	}
+
+	r, err := s.informer.AddEventHandler(toolscache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			handler(obj, false)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			handler(newObj, false)
+		},
+		DeleteFunc: func(obj interface{}) {
+			handler(obj, true)
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	cancel := func() {
+		_ = s.informer.RemoveEventHandler(r)
+	}
+	return cancel, nil
+}
+
+func (s *ResultStoreSecrets) getCommandResultSecret(id string) (*metav1.PartialObjectMetadata, error) {
+	err := s.ensureClientAndCache()
+	if err != nil {
+		return nil, err
+	}
+
+	var l metav1.PartialObjectMetadataList
+	l.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "SecretList"})
+	err = s.cache.List(s.ctx, &l, client.MatchingLabels{"kluctl.io/result-id": id})
+	if err != nil {
+		return nil, err
+	}
+	if len(l.Items) == 0 {
+		return nil, nil
+	}
+	return &l.Items[0], nil
+}
+
+func (s *ResultStoreSecrets) HasCommandResult(id string) (bool, error) {
+	secret, err := s.getCommandResultSecret(id)
+	if err != nil {
+		return false, err
+	}
+	return secret != nil, nil
+}
+
+func (s *ResultStoreSecrets) GetCommandResultSummary(id string) (*result.CommandResultSummary, error) {
+	secret, err := s.getCommandResultSecret(id)
+	if err != nil {
+		return nil, err
+	}
+	return s.parseSummary(secret)
+}
+
+func (s *ResultStoreSecrets) GetCommandResult(options GetCommandResultOptions) (*result.CommandResult, error) {
+	has, err := s.HasCommandResult(options.Id)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		return nil, nil
+	}
+
+	var l corev1.SecretList
+	err = s.client.List(s.ctx, &l, client.MatchingLabels{
 		"kluctl.io/result-id": options.Id,
 	})
 	if err != nil {
 		return nil, err
 	}
-	if len(l) == 0 {
+	if len(l.Items) == 0 {
 		return nil, nil
 	}
 
+	secret := l.Items[0]
+
 	var crJson, objectsJson []byte
-	err = utils.RunParallelE(ctx, func() error {
-		s, ok, err := l[0].GetNestedString("data", "reducedResult")
-		if err != nil {
-			return err
-		}
+	err = utils.RunParallelE(s.ctx, func() error {
+		var ok bool
+		crJson, ok = secret.Data["reducedResult"]
 		if !ok {
 			return fmt.Errorf("reducedResult field not present for %s", options.Id)
-		}
-		crJson, err = base64.StdEncoding.DecodeString(s)
-		if err != nil {
-			return err
 		}
 		crJson, err = utils.UncompressGzip(crJson)
 		if err != nil {
@@ -208,18 +391,11 @@ func (s *ResultStoreSecrets) GetCommandResult(ctx context.Context, options GetCo
 		if options.Reduced {
 			return nil
 		}
-		s, ok, err := l[0].GetNestedString("data", "compactedObjects")
-		if err != nil {
-			return err
-		}
+		var ok bool
+		objectsJson, ok = secret.Data["compactedObjects"]
 		if !ok {
 			return fmt.Errorf("compactedObjects field not present for %s", options.Id)
 		}
-		objectsJson, err = base64.StdEncoding.DecodeString(s)
-		if err != nil {
-			return err
-		}
-
 		objectsJson, err = utils.UncompressGzip(objectsJson)
 		if err != nil {
 			return err

--- a/pkg/results/result-store.go
+++ b/pkg/results/result-store.go
@@ -1,0 +1,27 @@
+package results
+
+import (
+	"context"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
+)
+
+type ListProjectsOptions struct {
+	ProjectFilter *result.ProjectKey `json:"projectFilter,omitempty"`
+}
+
+type ListCommandResultSummariesOptions struct {
+	ProjectFilter *result.ProjectKey `json:"projectFilter,omitempty"`
+}
+
+type GetCommandResultOptions struct {
+	Id      string `json:"id"`
+	Reduced bool   `json:"reduced,omitempty"`
+}
+
+type ResultStore interface {
+	WriteCommandResult(ctx context.Context, cr *result.CommandResult) error
+
+	ListProjects(ctx context.Context, options ListProjectsOptions) ([]result.ProjectSummary, error)
+	ListCommandResultSummaries(ctx context.Context, options ListCommandResultSummariesOptions) ([]result.CommandResultSummary, error)
+	GetCommandResult(ctx context.Context, options GetCommandResultOptions) (*result.CommandResult, error)
+}

--- a/pkg/results/result-store.go
+++ b/pkg/results/result-store.go
@@ -21,7 +21,48 @@ type GetCommandResultOptions struct {
 type ResultStore interface {
 	WriteCommandResult(ctx context.Context, cr *result.CommandResult) error
 
-	ListProjects(ctx context.Context, options ListProjectsOptions) ([]result.ProjectSummary, error)
 	ListCommandResultSummaries(ctx context.Context, options ListCommandResultSummariesOptions) ([]result.CommandResultSummary, error)
 	GetCommandResult(ctx context.Context, options GetCommandResultOptions) (*result.CommandResult, error)
+}
+
+func ListProjects(ctx context.Context, rs ResultStore, options ListProjectsOptions) ([]result.ProjectSummary, error) {
+	summaries, err := rs.ListCommandResultSummaries(ctx, ListCommandResultSummariesOptions{
+		ProjectFilter: options.ProjectFilter,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	m := map[result.ProjectKey]result.ProjectSummary{}
+	for _, s := range summaries {
+		if _, ok := m[s.Project]; !ok {
+			m[s.Project] = result.ProjectSummary{Project: s.Project}
+		}
+	}
+
+	ret := make([]result.ProjectSummary, 0, len(m))
+	for _, p := range m {
+		for _, rs := range summaries {
+			switch rs.Command.Command {
+			case "deploy":
+				if p.LastDeployCommand == nil {
+					rs := rs
+					p.LastDeployCommand = &rs
+				}
+			case "delete":
+				if p.LastDeleteCommand == nil {
+					rs := rs
+					p.LastDeleteCommand = &rs
+				}
+			case "prune":
+				if p.LastPruneCommand == nil {
+					rs := rs
+					p.LastPruneCommand = &rs
+				}
+			}
+		}
+		ret = append(ret, p)
+	}
+
+	return ret, nil
 }

--- a/pkg/results/results-collector.go
+++ b/pkg/results/results-collector.go
@@ -1,0 +1,174 @@
+package results
+
+import (
+	"context"
+	"fmt"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
+	"sort"
+	"sync"
+	"time"
+)
+
+type ResultsCollector struct {
+	ctx context.Context
+
+	stores []ResultStore
+
+	resultSummaries map[string]summaryEntry
+	handlers        []*handlerEntry
+
+	mutex sync.Mutex
+}
+
+type summaryEntry struct {
+	store   ResultStore
+	summary *result.CommandResultSummary
+}
+
+type handlerEntry struct {
+	options ListCommandResultSummariesOptions
+	update  func(result *result.CommandResultSummary)
+	delete  func(id string)
+}
+
+func NewResultsCollector(ctx context.Context, stores []ResultStore) *ResultsCollector {
+	ret := &ResultsCollector{
+		ctx:             ctx,
+		stores:          stores,
+		resultSummaries: map[string]summaryEntry{},
+	}
+
+	return ret
+}
+
+func (rc *ResultsCollector) Start() {
+	rc.startWatchResults()
+}
+
+func (rc *ResultsCollector) startWatchResults() {
+	for _, store := range rc.stores {
+		go rc.runWatchResults(store)
+	}
+}
+
+func (rc *ResultsCollector) runWatchResults(store ResultStore) {
+	for {
+		_, err := store.WatchCommandResultSummaries(ListCommandResultSummariesOptions{}, func(summary *result.CommandResultSummary) {
+			rc.handleUpdate(store, summary)
+		}, func(id string) {
+			rc.handleDelete(store, id)
+		})
+		if err == nil {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func (rc *ResultsCollector) handleUpdate(store ResultStore, summary *result.CommandResultSummary) {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+
+	rc.resultSummaries[summary.Id] = summaryEntry{
+		store:   store,
+		summary: summary,
+	}
+	for _, h := range rc.handlers {
+		if FilterSummary(summary, h.options.ProjectFilter) {
+			h.update(summary)
+		}
+	}
+}
+
+func (rc *ResultsCollector) handleDelete(store ResultStore, id string) {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	se, ok := rc.resultSummaries[id]
+	if !ok {
+		return
+	}
+
+	delete(rc.resultSummaries, id)
+	for _, h := range rc.handlers {
+		if FilterSummary(se.summary, h.options.ProjectFilter) {
+			h.delete(id)
+		}
+	}
+}
+
+func (rc *ResultsCollector) WriteCommandResult(cr *result.CommandResult) error {
+	return fmt.Errorf("WriteCommandResult is not supported in ResultsCollector")
+}
+
+func (rc *ResultsCollector) ListCommandResultSummaries(options ListCommandResultSummariesOptions) ([]result.CommandResultSummary, error) {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	summaries := make([]result.CommandResultSummary, 0, len(rc.resultSummaries))
+	for _, x := range rc.resultSummaries {
+		if !FilterSummary(x.summary, options.ProjectFilter) {
+			continue
+		}
+		summaries = append(summaries, *x.summary)
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		return summaries[i].Command.StartTime >= summaries[j].Command.StartTime
+	})
+	return summaries, nil
+}
+
+func (rc *ResultsCollector) WatchCommandResultSummaries(options ListCommandResultSummariesOptions, update func(summary *result.CommandResultSummary), delete func(id string)) (func(), error) {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+
+	h := &handlerEntry{
+		options: options,
+		update:  update,
+		delete:  delete,
+	}
+
+	rc.handlers = append(rc.handlers, h)
+
+	for _, se := range rc.resultSummaries {
+		if FilterSummary(se.summary, h.options.ProjectFilter) {
+			h.update(se.summary)
+		}
+	}
+
+	return func() {
+		rc.mutex.Lock()
+		defer rc.mutex.Unlock()
+		for i, h2 := range rc.handlers {
+			if h2 == h {
+				rc.handlers = append(rc.handlers[:i], rc.handlers[i+1:]...)
+				break
+			}
+		}
+	}, nil
+}
+
+func (rc *ResultsCollector) HasCommandResult(id string) (bool, error) {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	_, ok := rc.resultSummaries[id]
+	return ok, nil
+}
+
+func (rc *ResultsCollector) GetCommandResultSummary(id string) (*result.CommandResultSummary, error) {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	rs, ok := rc.resultSummaries[id]
+	if !ok {
+		return nil, nil
+	}
+	return rs.summary, nil
+}
+
+func (rc *ResultsCollector) GetCommandResult(options GetCommandResultOptions) (*result.CommandResult, error) {
+	rc.mutex.Lock()
+	se, ok := rc.resultSummaries[options.Id]
+	rc.mutex.Unlock()
+	if !ok {
+		return nil, nil
+	}
+	return se.store.GetCommandResult(options)
+}

--- a/pkg/seal/bootstrap.go
+++ b/pkg/seal/bootstrap.go
@@ -24,8 +24,10 @@ const configMapName = "sealed-secrets-key-kluctl-bootstrap"
 
 func BootstrapSealedSecrets(ctx context.Context, k *k8s.K8sCluster, namespace string) error {
 	existing, _, err := k.GetSingleObject(k8s2.ObjectRef{
-		GVK:  schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"},
-		Name: "sealedsecrets.bitnami.com",
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+		Name:    "sealedsecrets.bitnami.com",
 	})
 	if existing != nil {
 		// no bootstrap needed as the sealed-secrets operator seams to be installed already
@@ -33,7 +35,9 @@ func BootstrapSealedSecrets(ctx context.Context, k *k8s.K8sCluster, namespace st
 	}
 
 	existing, _, err = k.GetSingleObject(k8s2.ObjectRef{
-		GVK:       schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"},
+		Group:     "",
+		Version:   "v1",
+		Kind:      "ConfigMap",
 		Name:      configMapName,
 		Namespace: namespace,
 	})

--- a/pkg/types/deployment.go
+++ b/pkg/types/deployment.go
@@ -3,7 +3,7 @@ package types
 import (
 	"encoding/json"
 	"github.com/go-playground/validator/v10"
-	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
+	"github.com/kluctl/kluctl/v2/pkg/types/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 )
 
@@ -23,7 +23,7 @@ type DeploymentItemConfig struct {
 
 	// these are only allowed when writing the command result
 	RenderedHelmChartConfig *HelmChartConfig         `json:"renderedHelmChartConfig,omitempty"`
-	RenderedObjects         []*uo.UnstructuredObject `json:"renderedObjects,omitempty"`
+	RenderedObjects         []k8s.ObjectRef          `json:"renderedObjects,omitempty"`
 	RenderedInclude         *DeploymentProjectConfig `json:"renderedInclude,omitempty"`
 }
 

--- a/pkg/types/deployment.go
+++ b/pkg/types/deployment.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"github.com/go-playground/validator/v10"
+	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 )
 
@@ -19,6 +20,11 @@ type DeploymentItemConfig struct {
 	AlwaysDeploy     bool                     `json:"alwaysDeploy,omitempty"`
 	DeleteObjects    []DeleteObjectItemConfig `json:"deleteObjects,omitempty"`
 	When             string                   `json:"when,omitempty"`
+
+	// these are only allowed when writing the command result
+	RenderedHelmChartConfig *HelmChartConfig         `json:"renderedHelmChartConfig,omitempty"`
+	RenderedObjects         []*uo.UnstructuredObject `json:"renderedObjects,omitempty"`
+	RenderedInclude         *DeploymentProjectConfig `json:"renderedInclude,omitempty"`
 }
 
 func ValidateDeploymentItemConfig(sl validator.StructLevel) {

--- a/pkg/types/k8s/ref.go
+++ b/pkg/types/k8s/ref.go
@@ -6,30 +6,52 @@ import (
 )
 
 type ObjectRef struct {
-	GVK       schema.GroupVersionKind `json:"gvk,inline"`
-	Name      string
-	Namespace string
+	Group     string `json:"group"`
+	Version   string `json:"version"`
+	Kind      string `json:"kind"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 }
 
 func (r ObjectRef) String() string {
 	if r.Namespace != "" {
-		return fmt.Sprintf("%s/%s/%s", r.Namespace, r.GVK.Kind, r.Name)
+		return fmt.Sprintf("%s/%s/%s", r.Namespace, r.Kind, r.Name)
 	} else {
 		if r.Name != "" {
-			return fmt.Sprintf("%s/%s", r.GVK.Kind, r.Name)
+			return fmt.Sprintf("%s/%s", r.Kind, r.Name)
 		} else {
-			return r.GVK.Kind
+			return r.Kind
 		}
+	}
+}
+
+func (r ObjectRef) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   r.Group,
+		Version: r.Version,
+		Kind:    r.Kind,
+	}
+}
+
+func (r ObjectRef) GroupKind() schema.GroupKind {
+	return schema.GroupKind{
+		Group: r.Group,
+		Kind:  r.Kind,
+	}
+}
+
+func (r ObjectRef) GroupVersion() schema.GroupVersion {
+	return schema.GroupVersion{
+		Group:   r.Group,
+		Version: r.Version,
 	}
 }
 
 func NewObjectRef(group string, version string, kind string, name string, namespace string) ObjectRef {
 	return ObjectRef{
-		GVK: schema.GroupVersionKind{
-			Group:   group,
-			Version: version,
-			Kind:    kind,
-		},
+		Group:     group,
+		Version:   version,
+		Kind:      kind,
 		Name:      name,
 		Namespace: namespace,
 	}

--- a/pkg/types/k8s/ref.go
+++ b/pkg/types/k8s/ref.go
@@ -6,11 +6,11 @@ import (
 )
 
 type ObjectRef struct {
-	Group     string `json:"group"`
-	Version   string `json:"version"`
+	Group     string `json:"group,omitempty"`
+	Version   string `json:"version,omitempty"`
 	Kind      string `json:"kind"`
 	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
+	Namespace string `json:"namespace,omitempty"`
 }
 
 func (r ObjectRef) String() string {

--- a/pkg/types/kluctl_project.go
+++ b/pkg/types/kluctl_project.go
@@ -11,7 +11,7 @@ type SealingConfig struct {
 }
 
 type Target struct {
-	Name          string                 `json:"name,omitempty"`
+	Name          string                 `json:"name"`
 	Context       *string                `json:"context,omitempty"`
 	Args          *uo.UnstructuredObject `json:"args,omitempty"`
 	SealingConfig *SealingConfig         `json:"sealingConfig,omitempty"`

--- a/pkg/types/kluctl_project.go
+++ b/pkg/types/kluctl_project.go
@@ -11,7 +11,7 @@ type SealingConfig struct {
 }
 
 type Target struct {
-	Name          string                 `json:"name" validate:"required"`
+	Name          string                 `json:"name,omitempty"`
 	Context       *string                `json:"context,omitempty"`
 	Args          *uo.UnstructuredObject `json:"args,omitempty"`
 	SealingConfig *SealingConfig         `json:"sealingConfig,omitempty"`

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -60,8 +60,9 @@ type CommandInfo struct {
 }
 
 type CommandResult struct {
-	Command    *CommandInfo                   `json:"command,omitempty"`
-	Deployment *types.DeploymentProjectConfig `json:"deployment,omitempty"`
+	Command         *CommandInfo                   `json:"command,omitempty"`
+	Deployment      *types.DeploymentProjectConfig `json:"deployment,omitempty"`
+	RenderedObjects []*uo.UnstructuredObject       `json:"renderedObjects,omitempty"`
 
 	NewObjects     []*uo.UnstructuredObject `json:"newObjects,omitempty"`
 	ChangedObjects []*ChangedObject         `json:"changedObjects,omitempty"`

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -20,8 +20,8 @@ type ChangedObject struct {
 }
 
 type DeploymentError struct {
-	Ref   k8s.ObjectRef `json:"ref"`
-	Error string        `json:"error"`
+	Ref     k8s.ObjectRef `json:"ref"`
+	Message string        `json:"message"`
 }
 
 type KluctlDeploymentInfo struct {

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -46,7 +46,6 @@ type ProjectKey struct {
 
 type CommandInfo struct {
 	Initiator             CommandInitiator       `json:"initiator" validate:"oneof=CommandLine KluctlDeployment"`
-	Id                    string                 `json:"id"`
 	StartTime             types.JsonTime         `json:"startTime"`
 	EndTime               types.JsonTime         `json:"endTime"`
 	KluctlDeployment      *KluctlDeploymentInfo  `json:"kluctlDeployment,omitempty"`
@@ -95,6 +94,7 @@ type ResultObject struct {
 }
 
 type CommandResult struct {
+	Id         string                         `json:"id"`
 	Project    ProjectKey                     `json:"project"`
 	Command    CommandInfo                    `json:"command,omitempty"`
 	GitInfo    *GitInfo                       `json:"gitInfo,omitempty"`
@@ -135,6 +135,7 @@ type ValidateResultEntry struct {
 }
 
 type ValidateResult struct {
+	Id       string                `json:"id"`
 	Ready    bool                  `json:"ready"`
 	Warnings []DeploymentError     `json:"warnings,omitempty"`
 	Errors   []DeploymentError     `json:"errors,omitempty"`

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -116,6 +116,18 @@ func (cr *CommandResult) ToCompacted() *CompactedCommandResult {
 	return ret
 }
 
+func (cr *CommandResult) ToReducedObjects() *CommandResult {
+	ret := *cr
+	ret.Objects = make([]ResultObject, len(ret.Objects))
+	for i, o := range cr.Objects {
+		ret.Objects[i] = o
+		ret.Objects[i].Rendered = buildReducedObject(o.Rendered)
+		ret.Objects[i].Remote = buildReducedObject(o.Remote)
+		ret.Objects[i].Applied = buildReducedObject(o.Applied)
+	}
+	return &ret
+}
+
 type CompactedCommandResult struct {
 	CommandResult
 

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -1,6 +1,7 @@
 package result
 
 import (
+	git_url "github.com/kluctl/kluctl/v2/pkg/git/git-url"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/types/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
@@ -38,8 +39,14 @@ const (
 	CommandInititiator_KluctlDeployment                  = "KluctlDeployment"
 )
 
+type ProjectKey struct {
+	NormalizedGitUrl string `json:"normalizedGitUrl,omitempty"`
+	SubDir           string `json:"subDir,omitempty"`
+}
+
 type CommandInfo struct {
 	Initiator             CommandInitiator       `json:"initiator" validate:"oneof=CommandLine KluctlDeployment"`
+	Id                    string                 `json:"id"`
 	StartTime             types.JsonTime         `json:"startTime"`
 	EndTime               types.JsonTime         `json:"endTime"`
 	KluctlDeployment      *KluctlDeploymentInfo  `json:"kluctlDeployment,omitempty"`
@@ -61,6 +68,14 @@ type CommandInfo struct {
 	ExcludeDeploymentDirs []string               `json:"excludeDeploymentDirs,omitempty"`
 }
 
+type GitInfo struct {
+	Url    *git_url.GitUrl `json:"url"`
+	Ref    string          `json:"ref"`
+	SubDir string          `json:"subDir"`
+	Commit string          `json:"commit"`
+	Dirty  bool            `json:"dirty"`
+}
+
 type BaseObject struct {
 	Ref     k8s.ObjectRef `json:"ref"`
 	Changes []Change      `json:"changes,omitempty"`
@@ -80,7 +95,9 @@ type ResultObject struct {
 }
 
 type CommandResult struct {
-	Command    *CommandInfo                   `json:"command,omitempty"`
+	Project    ProjectKey                     `json:"project"`
+	Command    CommandInfo                    `json:"command,omitempty"`
+	GitInfo    *GitInfo                       `json:"gitInfo,omitempty"`
 	Deployment *types.DeploymentProjectConfig `json:"deployment,omitempty"`
 
 	Objects          []ResultObject   `json:"objects,omitempty"`

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -19,11 +19,6 @@ type ChangedObject struct {
 	Changes []Change      `json:"changes,omitempty"`
 }
 
-type RefAndObject struct {
-	Ref    k8s.ObjectRef          `json:"ref"`
-	Object *uo.UnstructuredObject `json:"object,omitempty"`
-}
-
 type DeploymentError struct {
 	Ref   k8s.ObjectRef `json:"ref"`
 	Error string        `json:"error"`
@@ -68,14 +63,14 @@ type CommandResult struct {
 	Command    *CommandInfo                   `json:"command,omitempty"`
 	Deployment *types.DeploymentProjectConfig `json:"deployment,omitempty"`
 
-	NewObjects     []*RefAndObject    `json:"newObjects,omitempty"`
-	ChangedObjects []*ChangedObject   `json:"changedObjects,omitempty"`
-	HookObjects    []*RefAndObject    `json:"hookObjects,omitempty"`
-	OrphanObjects  []k8s.ObjectRef    `json:"orphanObjects,omitempty"`
-	DeletedObjects []k8s.ObjectRef    `json:"deletedObjects,omitempty"`
-	Errors         []DeploymentError  `json:"errors,omitempty"`
-	Warnings       []DeploymentError  `json:"warnings,omitempty"`
-	SeenImages     []types.FixedImage `json:"seenImages,omitempty"`
+	NewObjects     []*uo.UnstructuredObject `json:"newObjects,omitempty"`
+	ChangedObjects []*ChangedObject         `json:"changedObjects,omitempty"`
+	HookObjects    []*uo.UnstructuredObject `json:"hookObjects,omitempty"`
+	OrphanObjects  []k8s.ObjectRef          `json:"orphanObjects,omitempty"`
+	DeletedObjects []k8s.ObjectRef          `json:"deletedObjects,omitempty"`
+	Errors         []DeploymentError        `json:"errors,omitempty"`
+	Warnings       []DeploymentError        `json:"warnings,omitempty"`
+	SeenImages     []types.FixedImage       `json:"seenImages,omitempty"`
 }
 
 type ValidateResultEntry struct {

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -1,6 +1,7 @@
-package types
+package result
 
 import (
+	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/types/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 )
@@ -31,14 +32,14 @@ type DeploymentError struct {
 }
 
 type CommandResult struct {
-	NewObjects     []*RefAndObject   `json:"newObjects,omitempty"`
-	ChangedObjects []*ChangedObject  `json:"changedObjects,omitempty"`
-	HookObjects    []*RefAndObject   `json:"hookObjects,omitempty"`
-	OrphanObjects  []k8s.ObjectRef   `json:"orphanObjects,omitempty"`
-	DeletedObjects []k8s.ObjectRef   `json:"deletedObjects,omitempty"`
-	Errors         []DeploymentError `json:"errors,omitempty"`
-	Warnings       []DeploymentError `json:"warnings,omitempty"`
-	SeenImages     []FixedImage      `json:"seenImages,omitempty"`
+	NewObjects     []*RefAndObject    `json:"newObjects,omitempty"`
+	ChangedObjects []*ChangedObject   `json:"changedObjects,omitempty"`
+	HookObjects    []*RefAndObject    `json:"hookObjects,omitempty"`
+	OrphanObjects  []k8s.ObjectRef    `json:"orphanObjects,omitempty"`
+	DeletedObjects []k8s.ObjectRef    `json:"deletedObjects,omitempty"`
+	Errors         []DeploymentError  `json:"errors,omitempty"`
+	Warnings       []DeploymentError  `json:"warnings,omitempty"`
+	SeenImages     []types.FixedImage `json:"seenImages,omitempty"`
 }
 
 type ValidateResultEntry struct {

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -31,7 +31,45 @@ type DeploymentError struct {
 	Error string        `json:"error"`
 }
 
+type KluctlDeploymentInfo struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	GitUrl    string `json:"gitUrl"`
+	GitRef    string `json:"gitRef"`
+}
+
+type CommandInitiator string
+
+const (
+	CommandInititiator_CommandLine      CommandInitiator = "CommandLine"
+	CommandInititiator_KluctlDeployment                  = "KluctlDeployment"
+)
+
+type CommandInfo struct {
+	Initiator             CommandInitiator       `json:"initiator" validate:"oneof=CommandLine KluctlDeployment"`
+	KluctlDeployment      *KluctlDeploymentInfo  `json:"kluctlDeployment,omitempty"`
+	Command               string                 `json:"command,omitempty"`
+	Target                *types.Target          `json:"target,omitempty"`
+	TargetNameOverride    string                 `json:"targetNameOverride,omitempty"`
+	ContextOverride       string                 `json:"contextOverride,omitempty"`
+	Args                  *uo.UnstructuredObject `json:"args,omitempty"`
+	Images                []types.FixedImage     `json:"images,omitempty"`
+	DryRun                bool                   `json:"dryRun,omitempty"`
+	NoWait                bool                   `json:"noWait,omitempty"`
+	ForceApply            bool                   `json:"forceApply,omitempty"`
+	ReplaceOnError        bool                   `json:"replaceOnError,omitempty"`
+	ForceReplaceOnError   bool                   `json:"forceReplaceOnError,omitempty"`
+	AbortOnError          bool                   `json:"abortOnError,omitempty"`
+	IncludeTags           []string               `json:"includeTags,omitempty"`
+	ExcludeTags           []string               `json:"excludeTags,omitempty"`
+	IncludeDeploymentDirs []string               `json:"includeDeploymentDirs,omitempty"`
+	ExcludeDeploymentDirs []string               `json:"excludeDeploymentDirs,omitempty"`
+}
+
 type CommandResult struct {
+	Command    *CommandInfo                   `json:"command,omitempty"`
+	Deployment *types.DeploymentProjectConfig `json:"deployment,omitempty"`
+
 	NewObjects     []*RefAndObject    `json:"newObjects,omitempty"`
 	ChangedObjects []*ChangedObject   `json:"changedObjects,omitempty"`
 	HookObjects    []*RefAndObject    `json:"hookObjects,omitempty"`

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -75,6 +75,10 @@ type GitInfo struct {
 	Dirty  bool            `json:"dirty"`
 }
 
+type ClusterInfo struct {
+	ClusterId string `json:"clusterId"`
+}
+
 type BaseObject struct {
 	Ref     k8s.ObjectRef `json:"ref"`
 	Changes []Change      `json:"changes,omitempty"`
@@ -94,11 +98,12 @@ type ResultObject struct {
 }
 
 type CommandResult struct {
-	Id         string                         `json:"id"`
-	Project    ProjectKey                     `json:"project"`
-	Command    CommandInfo                    `json:"command,omitempty"`
-	GitInfo    *GitInfo                       `json:"gitInfo,omitempty"`
-	Deployment *types.DeploymentProjectConfig `json:"deployment,omitempty"`
+	Id          string                         `json:"id"`
+	Project     ProjectKey                     `json:"project"`
+	Command     CommandInfo                    `json:"command,omitempty"`
+	GitInfo     *GitInfo                       `json:"gitInfo,omitempty"`
+	ClusterInfo *ClusterInfo                   `json:"clusterInfo,omitempty"`
+	Deployment  *types.DeploymentProjectConfig `json:"deployment,omitempty"`
 
 	Objects []ResultObject `json:"objects,omitempty"`
 

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -40,6 +40,8 @@ const (
 
 type CommandInfo struct {
 	Initiator             CommandInitiator       `json:"initiator" validate:"oneof=CommandLine KluctlDeployment"`
+	StartTime             types.JsonTime         `json:"startTime"`
+	EndTime               types.JsonTime         `json:"endTime"`
 	KluctlDeployment      *KluctlDeploymentInfo  `json:"kluctlDeployment,omitempty"`
 	Command               string                 `json:"command,omitempty"`
 	Target                *types.Target          `json:"target,omitempty"`

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -100,12 +100,32 @@ type CommandResult struct {
 	GitInfo    *GitInfo                       `json:"gitInfo,omitempty"`
 	Deployment *types.DeploymentProjectConfig `json:"deployment,omitempty"`
 
-	Objects          []ResultObject   `json:"objects,omitempty"`
-	CompactedObjects CompactedObjects `json:"compactedObjects,omitempty"`
+	Objects []ResultObject `json:"objects,omitempty"`
 
 	Errors     []DeploymentError  `json:"errors,omitempty"`
 	Warnings   []DeploymentError  `json:"warnings,omitempty"`
 	SeenImages []types.FixedImage `json:"seenImages,omitempty"`
+}
+
+func (cr *CommandResult) ToCompacted() *CompactedCommandResult {
+	ret := &CompactedCommandResult{
+		CommandResult: *cr,
+	}
+	ret.CompactedObjects = ret.Objects
+	ret.Objects = nil
+	return ret
+}
+
+type CompactedCommandResult struct {
+	CommandResult
+
+	CompactedObjects CompactedObjects `json:"compactedObjects,omitempty"`
+}
+
+func (ccr *CompactedCommandResult) ToNonCompacted() *CommandResult {
+	ret := ccr.CommandResult
+	ret.Objects = ccr.CompactedObjects
+	return &ret
 }
 
 type ValidateResultEntry struct {

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -15,10 +15,8 @@ type Change struct {
 }
 
 type ChangedObject struct {
-	Ref       k8s.ObjectRef          `json:"ref"`
-	NewObject *uo.UnstructuredObject `json:"newObject,omitempty"`
-	OldObject *uo.UnstructuredObject `json:"oldObject,omitempty"`
-	Changes   []Change               `json:"changes,omitempty"`
+	Ref     k8s.ObjectRef `json:"ref"`
+	Changes []Change      `json:"changes,omitempty"`
 }
 
 type RefAndObject struct {

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -61,22 +61,34 @@ type CommandInfo struct {
 	ExcludeDeploymentDirs []string               `json:"excludeDeploymentDirs,omitempty"`
 }
 
+type BaseObject struct {
+	Ref     k8s.ObjectRef `json:"ref"`
+	Changes []Change      `json:"changes,omitempty"`
+
+	New     bool `json:"new,omitempty"`
+	Orphan  bool `json:"orphan,omitempty"`
+	Deleted bool `json:"deleted,omitempty"`
+	Hook    bool `json:"hook,omitempty"`
+}
+
+type ResultObject struct {
+	BaseObject
+
+	Rendered *uo.UnstructuredObject `json:"rendered,omitempty"`
+	Remote   *uo.UnstructuredObject `json:"remote,omitempty"`
+	Applied  *uo.UnstructuredObject `json:"applied,omitempty"`
+}
+
 type CommandResult struct {
 	Command    *CommandInfo                   `json:"command,omitempty"`
 	Deployment *types.DeploymentProjectConfig `json:"deployment,omitempty"`
 
-	RenderedObjects    []*uo.UnstructuredObject `json:"renderedObjects,omitempty"`
-	RemoteObjects      []*uo.UnstructuredObject `json:"remoteObjects,omitempty"`
-	AppliedObjects     []*uo.UnstructuredObject `json:"appliedObjects,omitempty"`
-	AppliedHookObjects []*uo.UnstructuredObject `json:"appliedHookObjects,omitempty"`
+	Objects          []ResultObject   `json:"objects,omitempty"`
+	CompactedObjects CompactedObjects `json:"compactedObjects,omitempty"`
 
-	NewObjects     []k8s.ObjectRef    `json:"newObjects,omitempty"`
-	ChangedObjects []*ChangedObject   `json:"changedObjects,omitempty"`
-	OrphanObjects  []k8s.ObjectRef    `json:"orphanObjects,omitempty"`
-	DeletedObjects []k8s.ObjectRef    `json:"deletedObjects,omitempty"`
-	Errors         []DeploymentError  `json:"errors,omitempty"`
-	Warnings       []DeploymentError  `json:"warnings,omitempty"`
-	SeenImages     []types.FixedImage `json:"seenImages,omitempty"`
+	Errors     []DeploymentError  `json:"errors,omitempty"`
+	Warnings   []DeploymentError  `json:"warnings,omitempty"`
+	SeenImages []types.FixedImage `json:"seenImages,omitempty"`
 }
 
 type ValidateResultEntry struct {

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -141,7 +141,9 @@ type CompactedCommandResult struct {
 
 func (ccr *CompactedCommandResult) ToNonCompacted() *CommandResult {
 	ret := ccr.CommandResult
-	ret.Objects = ccr.CompactedObjects
+	if ccr.CompactedObjects != nil {
+		ret.Objects = ccr.CompactedObjects
+	}
 	return &ret
 }
 
@@ -157,4 +159,6 @@ type ValidateResult struct {
 	Warnings []DeploymentError     `json:"warnings,omitempty"`
 	Errors   []DeploymentError     `json:"errors,omitempty"`
 	Results  []ValidateResultEntry `json:"results,omitempty"`
+
+	Drift []ChangedObject `json:"drift,omitempty"`
 }

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -44,6 +44,35 @@ type ProjectKey struct {
 	SubDir           string `json:"subDir,omitempty"`
 }
 
+func (k ProjectKey) Less(o ProjectKey) bool {
+	if k.NormalizedGitUrl != o.NormalizedGitUrl {
+		return k.NormalizedGitUrl < o.NormalizedGitUrl
+	}
+	if k.SubDir != o.SubDir {
+		return k.SubDir < o.SubDir
+	}
+	return false
+}
+
+type TargetKey struct {
+	TargetName    string `json:"targetName,omitempty"`
+	ClusterId     string `json:"clusterId"`
+	Discriminator string `json:"discriminator,omitempty"`
+}
+
+func (k TargetKey) Less(o TargetKey) bool {
+	if k.TargetName != o.TargetName {
+		return k.TargetName < o.TargetName
+	}
+	if k.ClusterId != o.ClusterId {
+		return k.ClusterId < o.ClusterId
+	}
+	if k.Discriminator != o.Discriminator {
+		return k.Discriminator < o.Discriminator
+	}
+	return false
+}
+
 type CommandInfo struct {
 	Initiator             CommandInitiator       `json:"initiator" validate:"oneof=CommandLine KluctlDeployment"`
 	StartTime             types.JsonTime         `json:"startTime"`
@@ -100,6 +129,7 @@ type ResultObject struct {
 type CommandResult struct {
 	Id          string                         `json:"id"`
 	Project     ProjectKey                     `json:"project"`
+	Target      TargetKey                      `json:"target"`
 	Command     CommandInfo                    `json:"command,omitempty"`
 	GitInfo     *GitInfo                       `json:"gitInfo,omitempty"`
 	ClusterInfo *ClusterInfo                   `json:"clusterInfo,omitempty"`

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -132,7 +132,7 @@ type CommandResult struct {
 	Target      TargetKey                      `json:"target"`
 	Command     CommandInfo                    `json:"command,omitempty"`
 	GitInfo     *GitInfo                       `json:"gitInfo,omitempty"`
-	ClusterInfo *ClusterInfo                   `json:"clusterInfo,omitempty"`
+	ClusterInfo ClusterInfo                    `json:"clusterInfo"`
 	Deployment  *types.DeploymentProjectConfig `json:"deployment,omitempty"`
 
 	Objects []ResultObject `json:"objects,omitempty"`

--- a/pkg/types/result/command_result.go
+++ b/pkg/types/result/command_result.go
@@ -60,18 +60,21 @@ type CommandInfo struct {
 }
 
 type CommandResult struct {
-	Command         *CommandInfo                   `json:"command,omitempty"`
-	Deployment      *types.DeploymentProjectConfig `json:"deployment,omitempty"`
-	RenderedObjects []*uo.UnstructuredObject       `json:"renderedObjects,omitempty"`
+	Command    *CommandInfo                   `json:"command,omitempty"`
+	Deployment *types.DeploymentProjectConfig `json:"deployment,omitempty"`
 
-	NewObjects     []*uo.UnstructuredObject `json:"newObjects,omitempty"`
-	ChangedObjects []*ChangedObject         `json:"changedObjects,omitempty"`
-	HookObjects    []*uo.UnstructuredObject `json:"hookObjects,omitempty"`
-	OrphanObjects  []k8s.ObjectRef          `json:"orphanObjects,omitempty"`
-	DeletedObjects []k8s.ObjectRef          `json:"deletedObjects,omitempty"`
-	Errors         []DeploymentError        `json:"errors,omitempty"`
-	Warnings       []DeploymentError        `json:"warnings,omitempty"`
-	SeenImages     []types.FixedImage       `json:"seenImages,omitempty"`
+	RenderedObjects    []*uo.UnstructuredObject `json:"renderedObjects,omitempty"`
+	RemoteObjects      []*uo.UnstructuredObject `json:"remoteObjects,omitempty"`
+	AppliedObjects     []*uo.UnstructuredObject `json:"appliedObjects,omitempty"`
+	AppliedHookObjects []*uo.UnstructuredObject `json:"appliedHookObjects,omitempty"`
+
+	NewObjects     []k8s.ObjectRef    `json:"newObjects,omitempty"`
+	ChangedObjects []*ChangedObject   `json:"changedObjects,omitempty"`
+	OrphanObjects  []k8s.ObjectRef    `json:"orphanObjects,omitempty"`
+	DeletedObjects []k8s.ObjectRef    `json:"deletedObjects,omitempty"`
+	Errors         []DeploymentError  `json:"errors,omitempty"`
+	Warnings       []DeploymentError  `json:"warnings,omitempty"`
+	SeenImages     []types.FixedImage `json:"seenImages,omitempty"`
 }
 
 type ValidateResultEntry struct {

--- a/pkg/types/result/compact.go
+++ b/pkg/types/result/compact.go
@@ -1,0 +1,155 @@
+package result
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/kluctl/kluctl/v2/pkg/utils"
+	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
+	"github.com/kluctl/kluctl/v2/pkg/yaml"
+	"github.com/sergi/go-diff/diffmatchpatch"
+	"strings"
+	"sync"
+)
+
+type CompactedObjects []ResultObject
+
+type CompactedObject struct {
+	BaseObject
+
+	Rendered string `json:"rendered,omitempty"`
+	Remote   string `json:"remote,omitempty"`
+	Applied  string `json:"applied,omitempty"`
+}
+
+func (l CompactedObjects) MarshalJSON() ([]byte, error) {
+	compactedList := make([]CompactedObject, len(l))
+
+	d := diffmatchpatch.New()
+
+	createPatchOrFull := func(prevJson *string, o *uo.UnstructuredObject) string {
+		if o == nil {
+			return ""
+		}
+		j, err := yaml.WriteJsonString(o)
+		if err != nil {
+			// we are a point where this was parsed/written so many times, it really shouldn't error
+			panic(err)
+		}
+		if *prevJson == "" {
+			*prevJson = j
+			return "full: " + j
+		}
+
+		diff := d.DiffMain(*prevJson, j, false)
+		delta := d.DiffToDelta(diff)
+		*prevJson = j
+
+		if len(delta) < len(j) {
+			return "delta: " + delta
+		} else {
+			return "full: " + j
+		}
+	}
+
+	var wg sync.WaitGroup
+	for i, o := range l {
+		i := i
+		o := o
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var prevJson string
+			compactedList[i].BaseObject = o.BaseObject
+			compactedList[i].Rendered = createPatchOrFull(&prevJson, o.Rendered)
+			compactedList[i].Remote = createPatchOrFull(&prevJson, o.Remote)
+			compactedList[i].Applied = createPatchOrFull(&prevJson, o.Applied)
+		}()
+	}
+	wg.Wait()
+
+	return json.Marshal(compactedList)
+}
+
+func (l *CompactedObjects) UnmarshalJSON(b []byte) error {
+	var compactedList []CompactedObject
+	err := json.Unmarshal(b, &compactedList)
+	if err != nil {
+		return err
+	}
+
+	d := diffmatchpatch.New()
+
+	patchAndUnmarshal := func(prevJson *string, s string) (*uo.UnstructuredObject, error) {
+		if s == "" {
+			return nil, nil
+		}
+
+		if strings.HasPrefix(s, "full: ") {
+			full := s[6:]
+			*prevJson = full
+			return uo.FromString(full)
+		} else if strings.HasPrefix(s, "delta: ") {
+			if *prevJson == "" {
+				return nil, fmt.Errorf("prevJson empty")
+			}
+			delta := s[7:]
+			diff, err := d.DiffFromDelta(*prevJson, delta)
+			if err != nil {
+				return nil, err
+			}
+			patch := d.PatchMake(diff)
+			newJson, result := d.PatchApply(patch, *prevJson)
+			for _, b := range result {
+				if !b {
+					return nil, fmt.Errorf("patch did not fully apply")
+				}
+			}
+			o, err := uo.FromString(newJson)
+			if err != nil {
+				return nil, err
+			}
+			*prevJson = newJson
+			return o, nil
+		} else {
+			return nil, fmt.Errorf("unexpected object/delta")
+		}
+	}
+
+	ret := make([]ResultObject, len(compactedList))
+
+	gh := utils.NewGoHelper(context.Background(), -1)
+	for i, o := range compactedList {
+		i := i
+		o := o
+		gh.RunE(func() error {
+			var err error
+
+			o2 := ResultObject{}
+			o2.BaseObject = o.BaseObject
+
+			prevJson := ""
+			o2.Rendered, err = patchAndUnmarshal(&prevJson, o.Rendered)
+			if err != nil {
+				return err
+			}
+			o2.Remote, err = patchAndUnmarshal(&prevJson, o.Remote)
+			if err != nil {
+				return err
+			}
+			o2.Applied, err = patchAndUnmarshal(&prevJson, o.Applied)
+			if err != nil {
+				return err
+			}
+			ret[i] = o2
+			return nil
+		})
+	}
+	gh.Wait()
+	err = gh.ErrorOrNil()
+	if err != nil {
+		return err
+	}
+	*l = ret
+	return nil
+}

--- a/pkg/types/result/compact.go
+++ b/pkg/types/result/compact.go
@@ -153,3 +153,28 @@ func (l *CompactedObjects) UnmarshalJSON(b []byte) error {
 	*l = ret
 	return nil
 }
+
+func buildReducedObject(o *uo.UnstructuredObject) *uo.UnstructuredObject {
+	if o == nil {
+		return nil
+	}
+	ref := o.GetK8sRef()
+	m := map[string]any{
+		"apiVersion": ref.GroupVersion().String(),
+		"kind":       ref.Kind,
+		"metadata": map[string]any{
+			"name": ref.Name,
+		},
+	}
+	ret := uo.FromMap(m)
+	if ref.Namespace != "" {
+		ret.SetK8sNamespace(ref.Namespace)
+	}
+	if len(o.GetK8sLabels()) != 0 {
+		ret.SetK8sLabels(o.GetK8sLabels())
+	}
+	if len(o.GetK8sAnnotations()) != 0 {
+		ret.SetK8sAnnotations(o.GetK8sAnnotations())
+	}
+	return ret
+}

--- a/pkg/types/result/summary.go
+++ b/pkg/types/result/summary.go
@@ -1,10 +1,11 @@
 package result
 
 type CommandResultSummary struct {
-	Id      string      `json:"id"`
-	Project ProjectKey  `json:"project"`
-	Command CommandInfo `json:"commandInfo"`
-	GitInfo *GitInfo    `json:"gitInfo,omitempty"`
+	Id          string       `json:"id"`
+	Project     ProjectKey   `json:"project"`
+	Command     CommandInfo  `json:"commandInfo"`
+	GitInfo     *GitInfo     `json:"gitInfo,omitempty"`
+	ClusterInfo *ClusterInfo `json:"clusterInfo,omitempty"`
 
 	RenderedObjects    int `json:"renderedObjects"`
 	RemoteObjects      int `json:"remoteObjects"`
@@ -47,6 +48,7 @@ func (cr *CommandResult) BuildSummary() *CommandResultSummary {
 		Project:            cr.Project,
 		Command:            cr.Command,
 		GitInfo:            cr.GitInfo,
+		ClusterInfo:        cr.ClusterInfo,
 		RenderedObjects:    count(func(o ResultObject) bool { return o.Rendered != nil }),
 		RemoteObjects:      count(func(o ResultObject) bool { return o.Remote != nil }),
 		AppliedObjects:     count(func(o ResultObject) bool { return o.Applied != nil }),

--- a/pkg/types/result/summary.go
+++ b/pkg/types/result/summary.go
@@ -1,0 +1,20 @@
+package result
+
+type CommandResultSummary struct {
+	Id      string       `json:"id"`
+	Command *CommandInfo `json:"commandInfo"`
+
+	RenderedObjects    int `json:"renderedObjects"`
+	RemoteObjects      int `json:"remoteObjects"`
+	AppliedObjects     int `json:"appliedObjects"`
+	AppliedHookObjects int `json:"appliedHookObjects"`
+
+	NewObjects     int `json:"newObjects"`
+	ChangedObjects int `json:"changedObjects"`
+	OrphanObjects  int `json:"orphanObjects"`
+	DeletedObjects int `json:"deletedObjects"`
+	Errors         int `json:"errors"`
+	Warnings       int `json:"warnings"`
+
+	TotalChanges int `json:"totalChanges"`
+}

--- a/pkg/types/result/summary.go
+++ b/pkg/types/result/summary.go
@@ -1,6 +1,7 @@
 package result
 
 type CommandResultSummary struct {
+	Id      string      `json:"id"`
 	Project ProjectKey  `json:"project"`
 	Command CommandInfo `json:"commandInfo"`
 	GitInfo *GitInfo    `json:"gitInfo,omitempty"`

--- a/pkg/types/result/summary.go
+++ b/pkg/types/result/summary.go
@@ -1,8 +1,9 @@
 package result
 
 type CommandResultSummary struct {
-	Id      string       `json:"id"`
-	Command *CommandInfo `json:"commandInfo"`
+	Project ProjectKey  `json:"project"`
+	Command CommandInfo `json:"commandInfo"`
+	GitInfo *GitInfo    `json:"gitInfo,omitempty"`
 
 	RenderedObjects    int `json:"renderedObjects"`
 	RemoteObjects      int `json:"remoteObjects"`
@@ -17,4 +18,14 @@ type CommandResultSummary struct {
 	Warnings       int `json:"warnings"`
 
 	TotalChanges int `json:"totalChanges"`
+}
+
+type ProjectSummary struct {
+	Project ProjectKey `json:"project"`
+
+	LastValidateResult *ValidateResult `json:"lastValidateResult,omitempty"`
+
+	LastDeployCommand *CommandResultSummary `json:"lastDeployCommand,omitempty"`
+	LastDeleteCommand *CommandResultSummary `json:"LastDeleteCommand,omitempty"`
+	LastPruneCommand  *CommandResultSummary `json:"lastPruneCommand,omitempty"`
 }

--- a/pkg/types/result/summary.go
+++ b/pkg/types/result/summary.go
@@ -5,12 +5,12 @@ import (
 )
 
 type CommandResultSummary struct {
-	Id          string       `json:"id"`
-	Project     ProjectKey   `json:"project"`
-	Target      TargetKey    `json:"target"`
-	Command     CommandInfo  `json:"commandInfo"`
-	GitInfo     *GitInfo     `json:"gitInfo,omitempty"`
-	ClusterInfo *ClusterInfo `json:"clusterInfo,omitempty"`
+	Id          string      `json:"id"`
+	Project     ProjectKey  `json:"project"`
+	Target      TargetKey   `json:"target"`
+	Command     CommandInfo `json:"commandInfo"`
+	GitInfo     *GitInfo    `json:"gitInfo,omitempty"`
+	ClusterInfo ClusterInfo `json:"clusterInfo,omitempty"`
 
 	RenderedObjects    int `json:"renderedObjects"`
 	RemoteObjects      int `json:"remoteObjects"`

--- a/pkg/types/time.go
+++ b/pkg/types/time.go
@@ -1,0 +1,39 @@
+package types
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type JsonTime string
+
+func FromTime(t time.Time) JsonTime {
+	return JsonTime(t.Format(time.RFC3339Nano))
+}
+
+func (t JsonTime) ToTime() (time.Time, error) {
+	t2, err := time.Parse(time.RFC3339Nano, string(t))
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t2, nil
+}
+
+func (t *JsonTime) UnmarshalJSON(b []byte) error {
+	var s string
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	t2 := JsonTime(s)
+	_, err = t2.ToTime()
+	if err != nil {
+		return err
+	}
+	*t = t2
+	return nil
+}
+
+func (t JsonTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(t))
+}

--- a/pkg/types/vars_source.go
+++ b/pkg/types/vars_source.go
@@ -69,6 +69,9 @@ type VarsSource struct {
 	Vault             *VarsSourceVault                    `json:"vault,omitempty"`
 
 	When string `json:"when,omitempty"`
+
+	// these are only allowed when writing the command result
+	RenderedVars *uo.UnstructuredObject `json:"renderedVars,omitempty"`
 }
 
 func ValidateVarsSource(sl validator.StructLevel) {

--- a/pkg/types/vars_source.go
+++ b/pkg/types/vars_source.go
@@ -81,7 +81,7 @@ func ValidateVarsSource(sl validator.StructLevel) {
 	v := reflect.ValueOf(s)
 	for i := 0; i < v.NumField(); i++ {
 		switch v.Type().Field(i).Name {
-		case "IgnoreMissing", "NoOverride", "When":
+		case "IgnoreMissing", "NoOverride", "When", "RenderedVars":
 			continue
 		}
 		if !v.Field(i).IsNil() {

--- a/pkg/utils/go_helper.go
+++ b/pkg/utils/go_helper.go
@@ -66,3 +66,12 @@ func (g *goHelper) Wait() {
 func (g *goHelper) ErrorOrNil() error {
 	return g.errs.ErrorOrNil()
 }
+
+func RunParallelE(ctx context.Context, fs ...func() error) error {
+	g := NewGoHelper(ctx, 0)
+	for _, f := range fs {
+		g.RunE(f)
+	}
+	g.Wait()
+	return g.ErrorOrNil()
+}

--- a/pkg/utils/gzip.go
+++ b/pkg/utils/gzip.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+)
+
+func CompressGzip(input []byte, level int) ([]byte, error) {
+	buf := bytes.NewBuffer(make([]byte, 0, len(input)))
+	w, err := gzip.NewWriterLevel(buf, level)
+	if err != nil {
+		return nil, err
+	}
+	_, err = w.Write(input)
+	if err != nil {
+		return nil, err
+	}
+	err = w.Close()
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func UncompressGzip(input []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(input))
+	if err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(nil)
+	_, err = io.Copy(buf, r)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/pkg/utils/uo/k8s_fields.go
+++ b/pkg/utils/uo/k8s_fields.go
@@ -83,8 +83,11 @@ func (uo *UnstructuredObject) SetK8sNamespace(namespace string) {
 }
 
 func (uo *UnstructuredObject) GetK8sRef() k8s.ObjectRef {
+	gvk := uo.GetK8sGVK()
 	return k8s.ObjectRef{
-		GVK:       uo.GetK8sGVK(),
+		Group:     gvk.Group,
+		Version:   gvk.Version,
+		Kind:      gvk.Kind,
 		Name:      uo.GetK8sName(),
 		Namespace: uo.GetK8sNamespace(),
 	}

--- a/pkg/utils/uo/k8s_fields.go
+++ b/pkg/utils/uo/k8s_fields.go
@@ -79,7 +79,6 @@ func (uo *UnstructuredObject) SetK8sNamespace(namespace string) {
 			panic(err)
 		}
 	}
-
 }
 
 func (uo *UnstructuredObject) GetK8sRef() k8s.ObjectRef {
@@ -91,6 +90,14 @@ func (uo *UnstructuredObject) GetK8sRef() k8s.ObjectRef {
 		Name:      uo.GetK8sName(),
 		Namespace: uo.GetK8sNamespace(),
 	}
+}
+
+func (uo *UnstructuredObject) GetK8sUid() string {
+	s, _, err := uo.GetNestedString("metadata", "uid")
+	if err != nil {
+		panic(err)
+	}
+	return s
 }
 
 func (uo *UnstructuredObject) GetK8sLabels() map[string]string {

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -126,7 +126,7 @@ func ValidateObject(k *k8s.K8sCluster, o *uo.UnstructuredObject, notReadyIsError
 			// can't really say anything...
 			return
 		}
-		s, err := k.Resources.GetSchemaForGVK(ref.GVK)
+		s, err := k.Resources.GetSchemaForGVK(ref.GroupVersionKind())
 		if err != nil && !errors.IsNotFound(err) {
 			addError(err.Error())
 			return

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -3,7 +3,7 @@ package validation
 import (
 	"fmt"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
-	"github.com/kluctl/kluctl/v2/pkg/types"
+	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -45,7 +45,7 @@ const (
 	reactNotReady
 )
 
-func ValidateObject(k *k8s.K8sCluster, o *uo.UnstructuredObject, notReadyIsError bool, forceStatusRequired bool) (ret types.ValidateResult) {
+func ValidateObject(k *k8s.K8sCluster, o *uo.UnstructuredObject, notReadyIsError bool, forceStatusRequired bool) (ret result.ValidateResult) {
 	ref := o.GetK8sRef()
 
 	// We assume all is good in case no validation is performed
@@ -61,17 +61,17 @@ func ValidateObject(k *k8s.K8sCluster, o *uo.UnstructuredObject, notReadyIsError
 				// all good
 			} else if e, ok := r.(error); ok {
 				err := fmt.Errorf("panic in ValidateObject: %w", e)
-				ret.Errors = append(ret.Errors, types.DeploymentError{Ref: ref, Error: err.Error()})
+				ret.Errors = append(ret.Errors, result.DeploymentError{Ref: ref, Error: err.Error()})
 			} else {
 				err := fmt.Errorf("panic in ValidateObject: %v", e)
-				ret.Errors = append(ret.Errors, types.DeploymentError{Ref: ref, Error: err.Error()})
+				ret.Errors = append(ret.Errors, result.DeploymentError{Ref: ref, Error: err.Error()})
 			}
 			ret.Ready = false
 		}
 	}()
 
 	for k, v := range o.GetK8sAnnotationsWithRegex(resultAnnotation) {
-		ret.Results = append(ret.Results, types.ValidateResultEntry{
+		ret.Results = append(ret.Results, result.ValidateResultEntry{
 			Ref:        ref,
 			Annotation: k,
 			Message:    v,
@@ -79,14 +79,14 @@ func ValidateObject(k *k8s.K8sCluster, o *uo.UnstructuredObject, notReadyIsError
 	}
 
 	addError := func(message string) {
-		ret.Errors = append(ret.Errors, types.DeploymentError{
+		ret.Errors = append(ret.Errors, result.DeploymentError{
 			Ref:   ref,
 			Error: message,
 		})
 		ret.Ready = false
 	}
 	addWarning := func(message string) {
-		ret.Warnings = append(ret.Warnings, types.DeploymentError{
+		ret.Warnings = append(ret.Warnings, result.DeploymentError{
 			Ref:   ref,
 			Error: message,
 		})

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -61,10 +61,10 @@ func ValidateObject(k *k8s.K8sCluster, o *uo.UnstructuredObject, notReadyIsError
 				// all good
 			} else if e, ok := r.(error); ok {
 				err := fmt.Errorf("panic in ValidateObject: %w", e)
-				ret.Errors = append(ret.Errors, result.DeploymentError{Ref: ref, Error: err.Error()})
+				ret.Errors = append(ret.Errors, result.DeploymentError{Ref: ref, Message: err.Error()})
 			} else {
 				err := fmt.Errorf("panic in ValidateObject: %v", e)
-				ret.Errors = append(ret.Errors, result.DeploymentError{Ref: ref, Error: err.Error()})
+				ret.Errors = append(ret.Errors, result.DeploymentError{Ref: ref, Message: err.Error()})
 			}
 			ret.Ready = false
 		}
@@ -80,15 +80,15 @@ func ValidateObject(k *k8s.K8sCluster, o *uo.UnstructuredObject, notReadyIsError
 
 	addError := func(message string) {
 		ret.Errors = append(ret.Errors, result.DeploymentError{
-			Ref:   ref,
-			Error: message,
+			Ref:     ref,
+			Message: message,
 		})
 		ret.Ready = false
 	}
 	addWarning := func(message string) {
 		ret.Warnings = append(ret.Warnings, result.DeploymentError{
-			Ref:   ref,
-			Error: message,
+			Ref:     ref,
+			Message: message,
 		})
 	}
 	addNotReady := func(message string) {

--- a/pkg/vars/vars.go
+++ b/pkg/vars/vars.go
@@ -2,6 +2,7 @@ package vars
 
 import (
 	"github.com/kluctl/go-jinja2"
+	"github.com/kluctl/kluctl/v2/pkg/kluctl_jinja2"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 )
@@ -97,4 +98,20 @@ func (vc *VarsCtx) RenderDirectory(sourceDir string, targetDir string, excludePa
 		return err
 	}
 	return vc.J2.RenderDirectory(sourceDir, targetDir, excludePatterns, jinja2.WithGlobals(globals), jinja2.WithSearchDirs(searchDirs), jinja2.WithTemplateIgnoreRootDir(templateIgnoreRoot))
+}
+
+func (vc *VarsCtx) CheckConditional(c string) (bool, error) {
+	if kluctl_jinja2.IsConditionalTrue(c) {
+		return true, nil
+	}
+
+	m, err := vc.Vars.ToMap()
+	if err != nil {
+		return false, err
+	}
+	c, err = kluctl_jinja2.RenderConditional(vc.J2, m, c)
+	if err != nil {
+		return false, err
+	}
+	return kluctl_jinja2.IsConditionalTrue(c), nil
 }

--- a/pkg/vars/vars_loader.go
+++ b/pkg/vars/vars_loader.go
@@ -63,6 +63,10 @@ func (v *VarsLoader) LoadVarsList(varsCtx *VarsCtx, varsList []*types.VarsSource
 }
 
 func (v *VarsLoader) LoadVars(varsCtx *VarsCtx, sourceIn *types.VarsSource, searchDirs []string, rootKey string) error {
+	if sourceIn.RenderedVars != nil && len(sourceIn.RenderedVars.Object) != 0 {
+		return fmt.Errorf("renderedVars is not allowed here")
+	}
+
 	var source types.VarsSource
 	err := utils.DeepCopy(&source, sourceIn)
 	if err != nil {
@@ -124,6 +128,8 @@ func (v *VarsLoader) LoadVars(varsCtx *VarsCtx, sourceIn *types.VarsSource, sear
 	if err != nil {
 		return err
 	}
+
+	sourceIn.RenderedVars = newVars.Clone()
 
 	if source.NoOverride == nil || !*source.NoOverride {
 		varsCtx.Vars.Merge(newVars)

--- a/pkg/vars/vars_loader.go
+++ b/pkg/vars/vars_loader.go
@@ -8,7 +8,6 @@ import (
 	types2 "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	"github.com/kluctl/go-jinja2"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
-	"github.com/kluctl/kluctl/v2/pkg/kluctl_jinja2"
 	"github.com/kluctl/kluctl/v2/pkg/repocache"
 	"github.com/kluctl/kluctl/v2/pkg/sops"
 	"github.com/kluctl/kluctl/v2/pkg/sops/decryptor"
@@ -83,14 +82,12 @@ func (v *VarsLoader) LoadVars(varsCtx *VarsCtx, sourceIn *types.VarsSource, sear
 		return err
 	}
 
-	if source.When != "" {
-		r, err := kluctl_jinja2.RenderConditional(varsCtx.J2, globals, source.When)
-		if err != nil {
-			return err
-		}
-		if !kluctl_jinja2.IsConditionalTrue(r) {
-			return nil
-		}
+	whenTrue, err := varsCtx.CheckConditional(source.When)
+	if err != nil {
+		return err
+	}
+	if !whenTrue {
+		return nil
 	}
 
 	ignoreMissing := false

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -193,6 +193,14 @@ func WriteJsonString(o interface{}) (string, error) {
 	return string(b), nil
 }
 
+func WriteJsonStringMust(o interface{}) string {
+	b, err := json.Marshal(o)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
 // RemoveDuplicateFields is a helper/hack to remove duplicate fields from yaml maps/structs. The yaml spec explicitly
 // forbids duplicate keys, but yaml.v2 ignored those by default, leading to some tools (e.g. Helm) ignoring these
 func RemoveDuplicateFields(r io.Reader) ([]byte, error) {


### PR DESCRIPTION
# Description

This PR updates the `CommandResult` structures (which are still internal API) and makes Kluctl write the command result into the target cluster when `--write-command-result` is specified.

This feature is the preparation for the upcoming Kluctl UI which will process these command results and visualise them.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
