### PR TITLE
fix: Pin markdown-link-check to 3.10.3 until the latest version gets fixed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,9 @@ endif
 replace-commands-help: ## Replace commands help in docs
 	$(GOCMD) run ./internal/replace-commands-help --docs-dir ./docs/reference/commands
 
+MARKDOWN_LINK_CHECK_VERSION=3.10.3 # warning, 3.11.x is broken
 markdown-link-check: ## Check markdown files for dead links
-	find . -name '*.md' | xargs docker run -v ${PWD}:/tmp:ro --rm -i -w /tmp ghcr.io/tcort/markdown-link-check:stable
+	find . -name '*.md' | xargs docker run -v ${PWD}:/tmp:ro --rm -i -w /tmp ghcr.io/tcort/markdown-link-check:$(MARKDOWN_LINK_CHECK_VERSION)
 
 ## Release:
 version: ## Write next version into version file


### PR DESCRIPTION
# Description

markdown-link-check 3.11.x is failing with this error:
```
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
/src/markdown-link-check:99
                input.opts.config = program.opts().config.trim();
                                                         ^

TypeError: Cannot read properties of undefined (reading 'trim')
    at getInputs (/src/markdown-link-check:99:44)
    at main (/src/markdown-link-check:232:20)

Node.js v19.8.1
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
