### PR TITLE
fix: Revert handling - as "simple identifier" when building a json path

### DIFF
--- a/pkg/utils/uo/jsonpath.go
+++ b/pkg/utils/uo/jsonpath.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-var isSimpleIdentifier = regexp.MustCompile(`^[A-Za-z_-][A-Za-z0-9_-]+$`)
+var isSimpleIdentifier = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]+$`)
 
 type KeyPath []interface{}
 


### PR DESCRIPTION
# Description

The dash is actually not a valid character in JSON Path identifiers.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
