### PR TITLE
feat: Upgrade go-jinja2 to latest main branch to implement sha256 prefix_length

### DIFF
--- a/docs/reference/templating/filters.md
+++ b/docs/reference/templating/filters.md
@@ -84,10 +84,15 @@ Renders the input string with the current Jinja2 context. Example:
 {{ a | render }}
 ```
 
-### sha256
+### sha256(digest_len)
 Calculates the sha256 digest of the input string. Example:
 ```
 {{ "some-string" | sha256 }}
+```
+
+`digest_len` is an optional parameter that allows to limit the length of the returned hex digest. Example:
+```
+{{ "some-string" | sha256(6) }}
 ```
 
 ### slugify

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/kevinburke/ssh_config v1.2.0
 	github.com/kluctl/go-embed-python v0.0.0-3.10.9-20230206-2
-	github.com/kluctl/go-jinja2 v0.0.0-20230310104535-8136715a1e5a
+	github.com/kluctl/go-jinja2 v0.0.0-20230427204639-8226cd4a231e
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.18
 	github.com/mattn/go-runewidth v0.0.14

--- a/go.sum
+++ b/go.sum
@@ -535,8 +535,8 @@ github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw
 github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kluctl/go-embed-python v0.0.0-3.10.9-20230206-2 h1:K96SwIr8MzBQ3kFFz2H/pA2y+EEk04vZ4fWj/YZghBU=
 github.com/kluctl/go-embed-python v0.0.0-3.10.9-20230206-2/go.mod h1:vzngsPshNKUtq0gxkYQKNJafrcH7Qy7Qt6yGNt7JmQI=
-github.com/kluctl/go-jinja2 v0.0.0-20230310104535-8136715a1e5a h1:48Mz5ZZmv64Pg/cKR4nIo3Ry49Hqs5YggLPGju0e8PU=
-github.com/kluctl/go-jinja2 v0.0.0-20230310104535-8136715a1e5a/go.mod h1:qMY3lmIUPcCfjj5fZm39j+h7FilaqaQFYAze19xG0Dw=
+github.com/kluctl/go-jinja2 v0.0.0-20230427204639-8226cd4a231e h1:x5QMWvWLiuwJWojKXSH/3SAVkT2/y35Q5WlMSfnsDGk=
+github.com/kluctl/go-jinja2 v0.0.0-20230427204639-8226cd4a231e/go.mod h1:16hIQ1ibrf02WYqeCPggfIBQx23lTUQ+jlk5kJGF0xI=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kortschak/utter v1.0.1/go.mod h1:vSmSjbyrlKjjsL71193LmzBOKgwePk9DH6uFaWHIInc=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=


### PR DESCRIPTION
# Description

This upgrades go-jinja2 to the latest main branch to enable the optional prefix_length parameter to the sha256 filter.

Fixes #426

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
