### PR TITLE
feat: Allow .templateignore files in parent folders

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/kevinburke/ssh_config v1.2.0
 	github.com/kluctl/go-embed-python v0.0.0-3.10.9-20230206-2
-	github.com/kluctl/go-jinja2 v0.0.0-20230427204639-8226cd4a231e
+	github.com/kluctl/go-jinja2 v0.0.0-20230428103343-a832225dc94c
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.18
 	github.com/mattn/go-runewidth v0.0.14

--- a/go.sum
+++ b/go.sum
@@ -535,8 +535,8 @@ github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw
 github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kluctl/go-embed-python v0.0.0-3.10.9-20230206-2 h1:K96SwIr8MzBQ3kFFz2H/pA2y+EEk04vZ4fWj/YZghBU=
 github.com/kluctl/go-embed-python v0.0.0-3.10.9-20230206-2/go.mod h1:vzngsPshNKUtq0gxkYQKNJafrcH7Qy7Qt6yGNt7JmQI=
-github.com/kluctl/go-jinja2 v0.0.0-20230427204639-8226cd4a231e h1:x5QMWvWLiuwJWojKXSH/3SAVkT2/y35Q5WlMSfnsDGk=
-github.com/kluctl/go-jinja2 v0.0.0-20230427204639-8226cd4a231e/go.mod h1:16hIQ1ibrf02WYqeCPggfIBQx23lTUQ+jlk5kJGF0xI=
+github.com/kluctl/go-jinja2 v0.0.0-20230428103343-a832225dc94c h1:qAIvhYamCEU/tY6NaENEIQCynGV5sdON7zgZKnbrhhw=
+github.com/kluctl/go-jinja2 v0.0.0-20230428103343-a832225dc94c/go.mod h1:16hIQ1ibrf02WYqeCPggfIBQx23lTUQ+jlk5kJGF0xI=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kortschak/utter v1.0.1/go.mod h1:vSmSjbyrlKjjsL71193LmzBOKgwePk9DH6uFaWHIInc=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -162,6 +162,7 @@ func (di *DeploymentItem) render(forSeal bool) error {
 		di.RenderedDir,
 		excludePatterns,
 		searchDirs,
+		di.Project.source.dir,
 	)
 }
 

--- a/pkg/vars/vars.go
+++ b/pkg/vars/vars.go
@@ -91,10 +91,10 @@ func (vc *VarsCtx) RenderYamlFile(p string, searchDirs []string, out interface{}
 	return nil
 }
 
-func (vc *VarsCtx) RenderDirectory(sourceDir string, targetDir string, excludePatterns []string, searchDirs []string) error {
+func (vc *VarsCtx) RenderDirectory(sourceDir string, targetDir string, excludePatterns []string, searchDirs []string, templateIgnoreRoot string) error {
 	globals, err := vc.Vars.ToMap()
 	if err != nil {
 		return err
 	}
-	return vc.J2.RenderDirectory(sourceDir, targetDir, excludePatterns, jinja2.WithGlobals(globals), jinja2.WithSearchDirs(searchDirs))
+	return vc.J2.RenderDirectory(sourceDir, targetDir, excludePatterns, jinja2.WithGlobals(globals), jinja2.WithSearchDirs(searchDirs), jinja2.WithTemplateIgnoreRootDir(templateIgnoreRoot))
 }


### PR DESCRIPTION
# Description

This PR updates go-jinja2 to get in WithTemplateIgnoreRootDir support and then passes the project source root to RenderDirectory. This will then allow to use .templateignore files outside of deployment items.

Fixes #418

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
