### PR TITLE
feat: Simulate applying of CRs where the CRD is not applied yet

### DIFF
--- a/pkg/yaml/validator.go
+++ b/pkg/yaml/validator.go
@@ -4,16 +4,23 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/mitchellh/reflectwalk"
 	"reflect"
+	"time"
 )
 
 var (
 	Validator = validator.New()
+	timeType  = reflect.TypeOf(time.Time{})
 )
 
 type structValidationWalker struct {
 }
 
 func (w *structValidationWalker) Struct(v reflect.Value) error {
+	if v.Type().ConvertibleTo(timeType) {
+		// this is for some reason causing validation to fail
+		return reflectwalk.SkipEntry
+	}
+
 	v2 := v.Interface()
 	err := Validator.Struct(v2)
 	if err != nil {


### PR DESCRIPTION
# Description

This will prevent showing many "the server could not find the requested resource" errors when performing dry-runs via
`kluctl diff` or the automatic diff happening before deploy.

Fixes #393

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
