### PR TITLE
fix: Ignore ESC in readLine

### DIFF
--- a/pkg/utils/term/read_line.go
+++ b/pkg/utils/term/read_line.go
@@ -17,6 +17,9 @@ func readLine(reader io.Reader, cb func(ret []byte)) ([]byte, error) {
 		n, err := reader.Read(buf[:])
 		if n > 0 {
 			switch buf[0] {
+			case '':
+				// ignore ESC sequences
+				continue
 			case '', '\b':
 				if len(ret) > 0 {
 					ret = ret[:len(ret)-1]


### PR DESCRIPTION
# Description

This will at least prevent ESC sequences being interpreted when printing the status line. It's not an optimal solution, but better then repeated execution of ESC sequences.

Fixes #396

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
