### PR TITLE
fix: Don't perform version check in completion command

### DIFF
--- a/cmd/kluctl/commands/root.go
+++ b/cmd/kluctl/commands/root.go
@@ -245,7 +245,9 @@ func Main() {
 		}
 		ctx = initStatusHandler(ctxIn, flags.Debug, flags.NoColor)
 		if !flags.NoUpdateCheck {
-			checkNewVersion(ctx)
+			if len(os.Args) < 2 || (os.Args[1] != "completion" && os.Args[1] != "__complete") {
+				checkNewVersion(ctx)
+			}
 		}
 		return ctx, nil
 	})


### PR DESCRIPTION
# Description

A version check while generating completion scripts or while performing completion is clearly not intended.

Fixes #447

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
