### PR TITLE
feat: Support SOPS decryption for all files involved in Kustomize deployments

### DIFF
--- a/pkg/sops/decrypting_fs.go
+++ b/pkg/sops/decrypting_fs.go
@@ -1,0 +1,86 @@
+package sops
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/kluctl/kluctl/v2/pkg/sops/decryptor"
+	"go.mozilla.org/sops/v3/cmd/sops/formats"
+	"io"
+	"os"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+type decryptingFs struct {
+	filesys.FileSystem
+	decryptor *decryptor.Decryptor
+}
+
+type file struct {
+	os.FileInfo
+	data *bytes.Buffer
+	size int64
+}
+
+func NewDecryptingFs(fs filesys.FileSystem, decryptor *decryptor.Decryptor) filesys.FileSystem {
+	return &decryptingFs{
+		FileSystem: fs,
+		decryptor:  decryptor,
+	}
+}
+
+// Open opens the named file for reading.
+func (fs *decryptingFs) Open(path string) (filesys.File, error) {
+	f, err := fs.FileSystem.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	st, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	b, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	format := formats.FormatForPath(path)
+	b2, _, err := MaybeDecrypt(fs.decryptor, b, format, format)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt file %s: %w", path, err)
+	}
+	ret := &file{
+		FileInfo: st,
+		data:     bytes.NewBuffer(b2),
+	}
+	return ret, nil
+}
+
+// ReadFile returns the contents of the file at the given path.
+func (fs *decryptingFs) ReadFile(path string) ([]byte, error) {
+	f, err := fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return io.ReadAll(f)
+}
+
+func (f file) Read(p []byte) (n int, err error) {
+	return f.data.Read(p)
+}
+
+func (f file) Write(p []byte) (n int, err error) {
+	panic("write is not implemented")
+}
+
+func (f file) Close() error {
+	return nil
+}
+
+func (f file) Stat() (os.FileInfo, error) {
+	return f, nil
+}
+
+func (f file) Size() int64 {
+	return int64(f.data.Len())
+}

--- a/pkg/sops/utils.go
+++ b/pkg/sops/utils.go
@@ -17,7 +17,7 @@ func IsMaybeSopsFile(s []byte) bool {
 }
 
 func MaybeDecrypt(decrypter *decryptor.Decryptor, encrypted []byte, inputFormat, outputFormat formats.Format) ([]byte, bool, error) {
-	if decrypter == nil {
+	if decrypter == nil || inputFormat == formats.Binary {
 		return encrypted, false, nil
 	}
 


### PR DESCRIPTION
# Description

This is solved with the help of the decryptingFs that automatically decrypts all files that are loaded by Kustomize.

Fixes #422

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
