### PR TITLE
feat: Implement --short-output flag

### DIFF
--- a/cmd/kluctl/args/misc.go
+++ b/cmd/kluctl/args/misc.go
@@ -43,6 +43,7 @@ type AbortOnErrorFlags struct {
 type OutputFormatFlags struct {
 	OutputFormat []string `group:"misc" short:"o" help:"Specify output format and target file, in the format 'format=path'. Format can either be 'text' or 'yaml'. Can be specified multiple times. The actual format for yaml is currently not documented and subject to change."`
 	NoObfuscate  bool     `group:"misc" help:"Disable obfuscation of sensitive/secret data"`
+	ShortOutput  bool     `group:"misc" help:"When using the 'text' output format (which is the default), only names of changes objects are shown instead of showing all changes."`
 }
 
 type OutputFlags struct {

--- a/cmd/kluctl/commands/cmd_delete.go
+++ b/cmd/kluctl/commands/cmd_delete.go
@@ -61,7 +61,7 @@ func (cmd *deleteCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(ctx, cmd.OutputFormat, cmd.NoObfuscate, result)
+		err = outputCommandResult(ctx, cmd.OutputFormatFlags, result)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_deploy.go
+++ b/cmd/kluctl/commands/cmd_deploy.go
@@ -64,7 +64,7 @@ func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
 	cmd2.NoWait = cmd.NoWait
 
 	cb := func(diffResult *types.CommandResult) error {
-		return cmd.diffResultCb(cmdCtx.ctx, cmd.NoObfuscate, diffResult)
+		return cmd.diffResultCb(cmdCtx.ctx, diffResult)
 	}
 	if cmd.Yes || cmd.DryRun {
 		cb = nil
@@ -74,7 +74,7 @@ func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
 	if err != nil {
 		return err
 	}
-	err = outputCommandResult(cmdCtx.ctx, cmd.OutputFormat, cmd.NoObfuscate, result)
+	err = outputCommandResult(cmdCtx.ctx, cmd.OutputFormatFlags, result)
 	if err != nil {
 		return err
 	}
@@ -84,8 +84,11 @@ func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
 	return nil
 }
 
-func (cmd *deployCmd) diffResultCb(ctx context.Context, noObfuscate bool, diffResult *types.CommandResult) error {
-	err := outputCommandResult(ctx, nil, noObfuscate, diffResult)
+func (cmd *deployCmd) diffResultCb(ctx context.Context, diffResult *types.CommandResult) error {
+	flags := cmd.OutputFormatFlags
+	flags.OutputFormat = nil // use default output format
+
+	err := outputCommandResult(ctx, flags, diffResult)
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/cmd_diff.go
+++ b/cmd/kluctl/commands/cmd_diff.go
@@ -50,7 +50,7 @@ func (cmd *diffCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(ctx, cmd.OutputFormat, cmd.NoObfuscate, result)
+		err = outputCommandResult(ctx, cmd.OutputFormatFlags, result)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_poke_images.go
+++ b/cmd/kluctl/commands/cmd_poke_images.go
@@ -51,7 +51,7 @@ func (cmd *pokeImagesCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = outputCommandResult(ctx, cmd.OutputFormat, cmd.NoObfuscate, result)
+		err = outputCommandResult(ctx, cmd.OutputFormatFlags, result)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_prune.go
+++ b/cmd/kluctl/commands/cmd_prune.go
@@ -54,7 +54,7 @@ func (cmd *pruneCmd) runCmdPrune(cmdCtx *commandCtx) error {
 	if err != nil {
 		return err
 	}
-	err = outputCommandResult(cmdCtx.ctx, cmd.OutputFormat, cmd.NoObfuscate, result)
+	err = outputCommandResult(cmdCtx.ctx, cmd.OutputFormatFlags, result)
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 )
 
-func formatCommandResultText(cr *types.CommandResult) string {
+func formatCommandResultText(cr *types.CommandResult, short bool) string {
 	buf := bytes.NewBuffer(nil)
 
 	if len(cr.Warnings) != 0 {
@@ -40,12 +40,15 @@ func formatCommandResultText(cr *types.CommandResult) string {
 		}
 		prettyObjectRefs(buf, refs)
 
-		buf.WriteString("\n")
-		for i, co := range cr.ChangedObjects {
-			if i != 0 {
-				buf.WriteString("\n")
+		if !short {
+			buf.WriteString("\n")
+
+			for i, co := range cr.ChangedObjects {
+				if i != 0 {
+					buf.WriteString("\n")
+				}
+				prettyChanges(buf, co.Ref, co.Changes)
 			}
-			prettyChanges(buf, co.Ref, co.Changes)
 		}
 	}
 
@@ -112,10 +115,10 @@ func formatCommandResultYaml(cr *types.CommandResult) (string, error) {
 	return b, nil
 }
 
-func formatCommandResult(cr *types.CommandResult, format string) (string, error) {
+func formatCommandResult(cr *types.CommandResult, format string, short bool) (string, error) {
 	switch format {
 	case "text":
-		return formatCommandResultText(cr), nil
+		return formatCommandResultText(cr, short), nil
 	case "yaml":
 		return formatCommandResultYaml(cr)
 	default:
@@ -217,7 +220,7 @@ func outputCommandResult(ctx context.Context, flags args.OutputFormatFlags, cr *
 	}
 
 	return outputHelper(ctx, flags.OutputFormat, func(format string) (string, error) {
-		return formatCommandResult(cr, format)
+		return formatCommandResult(cr, format, flags.ShortOutput)
 	})
 }
 

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/diff"
 	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/types"
@@ -202,10 +203,10 @@ func outputHelper(ctx context.Context, output []string, cb func(format string) (
 	return nil
 }
 
-func outputCommandResult(ctx context.Context, output []string, noObfuscate bool, cr *types.CommandResult) error {
+func outputCommandResult(ctx context.Context, flags args.OutputFormatFlags, cr *types.CommandResult) error {
 	status.Flush(ctx)
 
-	if !noObfuscate {
+	if !flags.NoObfuscate {
 		var obfuscator diff.Obfuscator
 		for _, c := range cr.ChangedObjects {
 			err := obfuscator.Obfuscate(c.Ref, c.Changes)
@@ -215,7 +216,7 @@ func outputCommandResult(ctx context.Context, output []string, noObfuscate bool,
 		}
 	}
 
-	return outputHelper(ctx, output, func(format string) (string, error) {
+	return outputHelper(ctx, flags.OutputFormat, func(format string) (string, error) {
 		return formatCommandResult(cr, format)
 	})
 }

--- a/docs/reference/commands/delete.md
+++ b/docs/reference/commands/delete.md
@@ -58,6 +58,9 @@ Misc arguments:
                                                     currently not documented and subject to change.
       --render-output-dir string                    Specifies the target directory to render the project into. If
                                                     omitted, a temporary directory is used.
+      --short-output                                When using the 'text' output format (which is the default),
+                                                    only names of changes objects are shown instead of showing all
+                                                    changes.
   -y, --yes                                         Suppresses 'Are you sure?' questions and proceeds as if you
                                                     would answer 'yes'.
 

--- a/docs/reference/commands/deploy.md
+++ b/docs/reference/commands/deploy.md
@@ -68,6 +68,9 @@ Misc arguments:
                                                     omitted, a temporary directory is used.
       --replace-on-error                            When patching an object fails, try to replace it. See
                                                     documentation for more details.
+      --short-output                                When using the 'text' output format (which is the default),
+                                                    only names of changes objects are shown instead of showing all
+                                                    changes.
   -y, --yes                                         Suppresses 'Are you sure?' questions and proceeds as if you
                                                     would answer 'yes'.
 

--- a/docs/reference/commands/diff.md
+++ b/docs/reference/commands/diff.md
@@ -64,6 +64,9 @@ Misc arguments:
                                                     omitted, a temporary directory is used.
       --replace-on-error                            When patching an object fails, try to replace it. See
                                                     documentation for more details.
+      --short-output                                When using the 'text' output format (which is the default),
+                                                    only names of changes objects are shown instead of showing all
+                                                    changes.
 
 ```
 <!-- END SECTION -->

--- a/docs/reference/commands/poke-images.md
+++ b/docs/reference/commands/poke-images.md
@@ -55,6 +55,9 @@ Misc arguments:
                                                     currently not documented and subject to change.
       --render-output-dir string                    Specifies the target directory to render the project into. If
                                                     omitted, a temporary directory is used.
+      --short-output                                When using the 'text' output format (which is the default),
+                                                    only names of changes objects are shown instead of showing all
+                                                    changes.
   -y, --yes                                         Suppresses 'Are you sure?' questions and proceeds as if you
                                                     would answer 'yes'.
 

--- a/docs/reference/commands/prune.md
+++ b/docs/reference/commands/prune.md
@@ -51,6 +51,9 @@ Misc arguments:
                                                     currently not documented and subject to change.
       --render-output-dir string                    Specifies the target directory to render the project into. If
                                                     omitted, a temporary directory is used.
+      --short-output                                When using the 'text' output format (which is the default),
+                                                    only names of changes objects are shown instead of showing all
+                                                    changes.
   -y, --yes                                         Suppresses 'Are you sure?' questions and proceeds as if you
                                                     would answer 'yes'.
 


### PR DESCRIPTION
# Description

`--short-output` will cause Kluctl to not print detailed changes anymore. Only the names of changed objects are then printed.

Fixes #449

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
