### PR TITLE
ci: Only run manifests/generate targets on test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,14 +70,14 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: test-unit test-e2e fmt vet ## Run all tests.
+test: manifests generate test-unit test-e2e fmt vet ## Run all tests.
 
 .PHONY: test-unit
 test-unit: ## Run unit tests.
 	go test $(RACE) $(shell go list ./... | grep -v v2/e2e) -coverprofile cover.out
 
 .PHONY: test-e2e
-test-e2e: manifests generate envtest ## Run e2e tests.
+test-e2e: envtest ## Run e2e tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(RACE) ./e2e -coverprofile cover.out
 
 replace-commands-help: ## Replace commands help in docs


### PR DESCRIPTION
# Description

This should fix e2e tests on Windows.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
