### PR TITLE
refactor: Use Client from controller-runtime whenever possible

### DIFF
--- a/pkg/deployment/deployment_collection.go
+++ b/pkg/deployment/deployment_collection.go
@@ -200,17 +200,6 @@ func (c *DeploymentCollection) buildKustomizeObjects() error {
 	s.Success()
 
 	s = status.Start(c.ctx.Ctx, "Postprocessing objects")
-	for _, d_ := range c.Deployments {
-		d := d_
-		g.RunE(func() error {
-			err := d.postprocessCRDs()
-			if err != nil {
-				return fmt.Errorf("postprocessing CRDs failed: %w", err)
-			}
-			return nil
-		})
-	}
-	g.Wait()
 
 	g = utils.NewGoHelper(c.ctx.Ctx, 16)
 	for _, d_ := range c.Deployments {

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -581,7 +581,7 @@ func (di *DeploymentItem) postprocessObjects(images *Images) error {
 
 		_ = k8s.UnwrapListItems(o, true, func(o *uo.UnstructuredObject) error {
 			if di.ctx.K != nil {
-				di.ctx.K.Resources.FixNamespace(o, "default")
+				di.ctx.K.FixNamespace(o, "default")
 			}
 
 			// Set common labels/annotations

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -14,7 +14,6 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/vars"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	"io/fs"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"os"
 	"path"
 	"path/filepath"
@@ -538,32 +537,6 @@ func (di *DeploymentItem) buildKustomize() error {
 		di.Config.RenderedObjects = append(di.Config.RenderedObjects, o.GetK8sRef())
 	}
 
-	return nil
-}
-
-var crdGV = schema.GroupKind{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}
-
-// postprocessCRDs will update api resources from freshly deployed CRDs
-// value even if the CRD is not deployed yet.
-func (di *DeploymentItem) postprocessCRDs() error {
-	if di.dir == nil {
-		return nil
-	}
-	if di.ctx.K == nil {
-		return nil
-	}
-
-	for _, o := range di.Objects {
-		gvk := o.GetK8sGVK()
-		if gvk.GroupKind() != crdGV {
-			continue
-		}
-
-		err := di.ctx.K.Resources.UpdateResourcesFromCRD(o)
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -373,11 +373,17 @@ func (a *ApplyUtil) ApplyObject(x *uo.UnstructuredObject, replaced bool, hook bo
 		_ = r.ReplaceKeys(tmpName, ref.Name)
 		_ = r.ReplaceValues(tmpName, ref.Name)
 		r.SetK8sNamespace(ref.Namespace)
-	} else if a.o.DryRun && errors.IsNotFound(err) {
+	} else if meta.IsNoMatchError(err) {
 		if _, ok := a.allCRDs.Load(x.GetK8sGVK()); ok {
-			a.handleResult(x, hook)
-			a.HandleWarning(x.GetK8sRef(), fmt.Errorf("the underyling custom resource definition for %s has not been applied yet as Kluctl is running in dry-run mode. It is not guaranteed that the object will actually sucessfully apply", x.GetK8sRef().String()))
-			return
+			if a.o.DryRun {
+				a.handleResult(x, hook)
+				a.HandleWarning(x.GetK8sRef(), fmt.Errorf("the underyling custom resource definition for %s has not been applied yet as Kluctl is running in dry-run mode. It is not guaranteed that the object will actually sucessfully apply", x.GetK8sRef().String()))
+				return
+			} else {
+				// retry with invalidated discovery
+				a.k.ResetMapper()
+				r, apiWarnings, err = a.k.ApplyObject(x, options)
+			}
 		}
 	}
 	if r != nil && ref.GroupKind().String() == "Namespace" {
@@ -502,7 +508,11 @@ func (a *ApplyUtil) WaitReadiness(ref k8s2.ObjectRef, timeout time.Duration) boo
 func (a *ApplyUtil) applyDeploymentItem(d *deployment.DeploymentItem) {
 	toDelete := map[k8s2.ObjectRef]bool{}
 	for _, x := range d.Config.DeleteObjects {
-		for _, gvk := range a.k.Resources.GetFilteredGVKs(k8s.BuildGVKFilter(x.Group, nil, x.Kind)) {
+		gvks, err := a.k.GetFilteredGVKs(k8s.BuildGVKFilter(x.Group, nil, x.Kind))
+		if err != nil {
+			a.HandleError(k8s2.ObjectRef{}, err)
+		}
+		for _, gvk := range gvks {
 			ref := k8s2.ObjectRef{
 				Group:     gvk.Group,
 				Version:   gvk.Version,

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -250,7 +250,7 @@ func (a *ApplyUtil) retryApplyForceReplace(x *uo.UnstructuredObject, hook bool, 
 		o := k8s.PatchOptions{
 			ForceDryRun: a.o.DryRun,
 		}
-		r, apiWarnings, err := a.k.PatchObject(x, o)
+		r, apiWarnings, err := a.k.ApplyObject(x, o)
 		a.handleApiWarnings(ref, apiWarnings)
 		if err != nil {
 			a.HandleError(ref, err)
@@ -324,7 +324,7 @@ func (a *ApplyUtil) retryApplyWithConflicts(x *uo.UnstructuredObject, hook bool,
 		ForceDryRun: a.o.DryRun,
 		ForceApply:  true,
 	}
-	r, apiWarnings, err := a.k.PatchObject(x2, options)
+	r, apiWarnings, err := a.k.ApplyObject(x2, options)
 	a.handleApiWarnings(ref, apiWarnings)
 	if err != nil {
 		// We didn't manage to solve it, better to abort (and not retry with replace!)
@@ -367,7 +367,7 @@ func (a *ApplyUtil) ApplyObject(x *uo.UnstructuredObject, replaced bool, hook bo
 	options := k8s.PatchOptions{
 		ForceDryRun: a.o.DryRun,
 	}
-	r, apiWarnings, err := a.k.PatchObject(x, options)
+	r, apiWarnings, err := a.k.ApplyObject(x, options)
 	if r != nil && usesDummyName {
 		tmpName := r.GetK8sName()
 		_ = r.ReplaceKeys(tmpName, ref.Name)

--- a/pkg/deployment/utils/delete_utils.go
+++ b/pkg/deployment/utils/delete_utils.go
@@ -40,7 +40,7 @@ var deleteOrder = [][]string{
 }
 
 func objectRefForExclusion(k *k8s.K8sCluster, ref k8s2.ObjectRef) k8s2.ObjectRef {
-	ref = k.Resources.FixNamespaceInRef(ref)
+	ref = k.FixNamespaceInRef(ref)
 	ref.Version = ""
 	return ref
 }

--- a/pkg/deployment/utils/delete_utils.go
+++ b/pkg/deployment/utils/delete_utils.go
@@ -75,7 +75,11 @@ func filterObjectsForDelete(k *k8s.K8sCluster, objects []*uo.UnstructuredObject,
 	}
 
 	filteredResources := make(map[schema.GroupKind]bool)
-	for _, gvk := range k.Resources.GetFilteredPreferredGVKs(filterFunc) {
+	gvks, err := k.GetFilteredPreferredGVKs(filterFunc)
+	if err != nil {
+		return nil, err
+	}
+	for _, gvk := range gvks {
 		filteredResources[gvk.GroupKind()] = true
 	}
 

--- a/pkg/helm/helm_release.go
+++ b/pkg/helm/helm_release.go
@@ -260,7 +260,7 @@ func (hr *Release) doRender(ctx context.Context, k *k8s.K8sCluster, k8sVersion s
 		// add the necessary namespace in the rendered resources
 		if k != nil {
 			err = k8s.UnwrapListItems(o, true, func(o *uo.UnstructuredObject) error {
-				k.Resources.FixNamespace(o, namespace)
+				k.FixNamespace(o, namespace)
 				return nil
 			})
 			if err != nil {

--- a/pkg/helm/helm_release.go
+++ b/pkg/helm/helm_release.go
@@ -203,7 +203,10 @@ func (hr *Release) doRender(ctx context.Context, k *k8s.K8sCluster, k8sVersion s
 	client.Replace = true
 	client.ClientOnly = true
 	client.KubeVersion = kubeVersion
-	client.APIVersions = hr.getApiVersions(k)
+	client.APIVersions, err = hr.getApiVersions(k)
+	if err != nil {
+		return err
+	}
 
 	if hr.Config.SkipCRDs {
 		client.SkipCRDs = true
@@ -281,14 +284,17 @@ func (hr *Release) doRender(ctx context.Context, k *k8s.K8sCluster, k8sVersion s
 	return nil
 }
 
-func (hr *Release) getApiVersions(k *k8s.K8sCluster) chartutil.VersionSet {
+func (hr *Release) getApiVersions(k *k8s.K8sCluster) (chartutil.VersionSet, error) {
 	if k == nil {
-		return nil
+		return nil, nil
 	}
 
 	m := map[string]bool{}
 
-	gvks := k.Resources.GetFilteredGVKs(nil)
+	gvks, err := k.GetFilteredGVKs(nil)
+	if err != nil {
+		return nil, err
+	}
 	for _, gvk := range gvks {
 		gvStr := gvk.GroupVersion().String()
 		m[gvStr] = true
@@ -301,7 +307,7 @@ func (hr *Release) getApiVersions(k *k8s.K8sCluster) chartutil.VersionSet {
 		ret = append(ret, id)
 	}
 
-	return ret
+	return ret, nil
 }
 
 func (hr *Release) parseRenderedManifests(s string) ([]*uo.UnstructuredObject, error) {

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/metadata"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type k8sClients struct {
@@ -17,6 +18,8 @@ type k8sClients struct {
 }
 
 type parallelClientEntry struct {
+	client client.Client
+
 	corev1         corev1.CoreV1Interface
 	dynamicClient  dynamic.Interface
 	metadataClient metadata.Interface
@@ -50,6 +53,11 @@ func newK8sClients(ctx context.Context, clientFactory ClientFactory, count int) 
 
 	for i := 0; i < count; i++ {
 		p := &parallelClientEntry{}
+
+		p.client, err = clientFactory.Client(p)
+		if err != nil {
+			return nil, err
+		}
 
 		p.corev1, err = clientFactory.CoreV1Client(p)
 		if err != nil {

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -3,9 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"k8s.io/client-go/dynamic"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/metadata"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -18,10 +16,7 @@ type k8sClients struct {
 
 type parallelClientEntry struct {
 	client client.Client
-
-	corev1         corev1.CoreV1Interface
-	dynamicClient  dynamic.Interface
-	metadataClient metadata.Interface
+	corev1 corev1.CoreV1Interface
 
 	warnings []ApiWarning
 }
@@ -59,16 +54,6 @@ func newK8sClients(ctx context.Context, clientFactory ClientFactory, count int) 
 		}
 
 		p.corev1, err = clientFactory.CoreV1Client(p)
-		if err != nil {
-			return nil, err
-		}
-
-		p.dynamicClient, err = clientFactory.DynamicClient(p)
-		if err != nil {
-			return nil, err
-		}
-
-		p.metadataClient, err = clientFactory.MetadataClient(p)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/metadata"
@@ -109,15 +108,5 @@ func (k *k8sClients) withCClientFromPool(dryRun bool, cb func(c client.Client) e
 			c = client.NewDryRunClient(c)
 		}
 		return cb(c)
-	})
-}
-
-func (k *k8sClients) withDynamicClientForGVR(gvr *schema.GroupVersionResource, namespace string, cb func(r dynamic.ResourceInterface) error) ([]ApiWarning, error) {
-	return k.withClientFromPool(func(p *parallelClientEntry) error {
-		if namespace != "" {
-			return cb(p.dynamicClient.Resource(*gvr).Namespace(namespace))
-		} else {
-			return cb(p.dynamicClient.Resource(*gvr))
-		}
 	})
 }

--- a/pkg/k8s/client_factory.go
+++ b/pkg/k8s/client_factory.go
@@ -25,13 +25,11 @@ type ClientFactory interface {
 
 	CloseIdleConnections()
 
-	Mapper() meta.ResettableRESTMapper
+	Mapper() meta.RESTMapper
 	Client(wh rest.WarningHandler) (client.Client, error)
 
 	DiscoveryClient() (discovery.DiscoveryInterface, error)
 	CoreV1Client(wh rest.WarningHandler) (corev1.CoreV1Interface, error)
-	DynamicClient(wh rest.WarningHandler) (dynamic.Interface, error)
-	MetadataClient(wh rest.WarningHandler) (metadata.Interface, error)
 }
 
 type realClientFactory struct {
@@ -51,7 +49,7 @@ func (r *realClientFactory) GetCA() []byte {
 	return r.config.CAData
 }
 
-func (r *realClientFactory) Mapper() meta.ResettableRESTMapper {
+func (r *realClientFactory) Mapper() meta.RESTMapper {
 	return r.mapper
 }
 

--- a/pkg/k8s/client_factory.go
+++ b/pkg/k8s/client_factory.go
@@ -3,12 +3,14 @@ package k8s
 import (
 	"context"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached/disk"
 	"k8s.io/client-go/dynamic"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	"net/http"
 	"net/url"
@@ -23,6 +25,7 @@ type ClientFactory interface {
 
 	CloseIdleConnections()
 
+	Mapper() meta.ResettableRESTMapper
 	Client(wh rest.WarningHandler) (client.Client, error)
 
 	DiscoveryClient() (discovery.DiscoveryInterface, error)
@@ -35,6 +38,9 @@ type realClientFactory struct {
 	ctx        context.Context
 	config     *rest.Config
 	httpClient *http.Client
+
+	discoveryClient discovery.DiscoveryInterface
+	mapper          meta.ResettableRESTMapper
 }
 
 func (r *realClientFactory) RESTConfig() *rest.Config {
@@ -45,10 +51,16 @@ func (r *realClientFactory) GetCA() []byte {
 	return r.config.CAData
 }
 
+func (r *realClientFactory) Mapper() meta.ResettableRESTMapper {
+	return r.mapper
+}
+
 func (r *realClientFactory) Client(wh rest.WarningHandler) (client.Client, error) {
 	config := rest.CopyConfig(r.config)
 	config.WarningHandler = wh
+
 	return client.New(config, client.Options{
+		Mapper: r.mapper,
 		WarningHandler: client.WarningHandlerOptions{
 			SuppressWarnings: true,
 		},
@@ -56,16 +68,7 @@ func (r *realClientFactory) Client(wh rest.WarningHandler) (client.Client, error
 }
 
 func (r *realClientFactory) DiscoveryClient() (discovery.DiscoveryInterface, error) {
-	apiHost, err := url.Parse(r.config.Host)
-	if err != nil {
-		return nil, err
-	}
-	discoveryCacheDir := filepath.Join(utils.GetTmpBaseDir(r.ctx), "kube-cache/discovery", apiHost.Hostname())
-	discovery2, err := disk.NewCachedDiscoveryClientForConfig(dynamic.ConfigFor(r.config), discoveryCacheDir, "", time.Hour*24)
-	if err != nil {
-		return nil, err
-	}
-	return discovery2, nil
+	return r.discoveryClient, nil
 }
 
 func (r *realClientFactory) CoreV1Client(wh rest.WarningHandler) (corev1.CoreV1Interface, error) {
@@ -90,6 +93,19 @@ func (r *realClientFactory) CloseIdleConnections() {
 	r.httpClient.CloseIdleConnections()
 }
 
+func initDiscoveryClient(ctx context.Context, config *rest.Config) (discovery.CachedDiscoveryInterface, error) {
+	apiHost, err := url.Parse(config.Host)
+	if err != nil {
+		return nil, err
+	}
+	discoveryCacheDir := filepath.Join(utils.GetTmpBaseDir(ctx), "kube-cache/discovery", apiHost.Hostname())
+	discovery2, err := disk.NewCachedDiscoveryClientForConfig(dynamic.ConfigFor(config), discoveryCacheDir, "", time.Hour*24)
+	if err != nil {
+		return nil, err
+	}
+	return discovery2, nil
+}
+
 func NewClientFactory(ctx context.Context, configIn *rest.Config) (ClientFactory, error) {
 	restConfig := rest.CopyConfig(configIn)
 	restConfig.QPS = 10
@@ -100,10 +116,19 @@ func NewClientFactory(ctx context.Context, configIn *rest.Config) (ClientFactory
 		return nil, err
 	}
 
+	dc, err := initDiscoveryClient(ctx, restConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(dc)
+
 	return &realClientFactory{
-		ctx:        ctx,
-		config:     restConfig,
-		httpClient: httpClient,
+		ctx:             ctx,
+		config:          restConfig,
+		httpClient:      httpClient,
+		discoveryClient: dc,
+		mapper:          mapper,
 	}, nil
 }
 

--- a/pkg/k8s/fake_client_factory.go
+++ b/pkg/k8s/fake_client_factory.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"context"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -8,26 +9,37 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
-	fake_dynamic "k8s.io/client-go/dynamic/fake"
+	fake4 "k8s.io/client-go/discovery/fake"
+	fake3 "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/metadata"
-	fake_metadata "k8s.io/client-go/metadata/fake"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fake2 "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"strings"
 )
 
 type fakeClientFactory struct {
-	clientSet      *fake.Clientset
-	dynamicClient  *fake_dynamic.FakeDynamicClient
-	metadataClient *fake_metadata.FakeMetadataClient
-	clientBuilder  *fake2.ClientBuilder
+	scheme           *runtime.Scheme
+	mapper           meta.RESTMapper
+	objects          []runtime.Object
+	simpleClientSet  *fake.Clientset
+	dynamicClientSet *fake3.FakeDynamicClient
+	discovery        discovery.DiscoveryInterface
+
+	errors []errorEntry
+}
+
+type errorEntry struct {
+	gvr       schema.GroupVersionResource
+	name      string
+	namespace string
+	retErr    error
 }
 
 func (f *fakeClientFactory) RESTConfig() *rest.Config {
@@ -41,71 +53,135 @@ func (f *fakeClientFactory) GetCA() []byte {
 func (f *fakeClientFactory) CloseIdleConnections() {
 }
 
-func (f *fakeClientFactory) Mapper() meta.ResettableRESTMapper {
-	return nil
+func (f *fakeClientFactory) Mapper() meta.RESTMapper {
+	return f.mapper
 }
 
 func (f *fakeClientFactory) Client(wh rest.WarningHandler) (client.Client, error) {
-	return f.clientBuilder.Build(), nil
+	return fake2.NewClientBuilder().
+		WithScheme(f.scheme).
+		WithRESTMapper(f.mapper).
+		WithObjectTracker(f.dynamicClientSet.Tracker()).
+		WithInterceptorFuncs(f.buildErrorInterceptor()).
+		Build(), nil
 }
 
 func (f *fakeClientFactory) DiscoveryClient() (discovery.DiscoveryInterface, error) {
-	return f.clientSet.Discovery(), nil
+	return f.discovery, nil
 }
 
 func (f *fakeClientFactory) CoreV1Client(wh rest.WarningHandler) (corev1.CoreV1Interface, error) {
-	return f.clientSet.CoreV1(), nil
-}
-
-func (f *fakeClientFactory) DynamicClient(wh rest.WarningHandler) (dynamic.Interface, error) {
-	return f.dynamicClient, nil
-}
-
-func (f *fakeClientFactory) MetadataClient(wh rest.WarningHandler) (metadata.Interface, error) {
-	return f.metadataClient, nil
+	return f.simpleClientSet.CoreV1(), nil
 }
 
 func NewFakeClientFactory(objects ...runtime.Object) *fakeClientFactory {
 	scheme := runtime.NewScheme()
 	_ = v1.AddToScheme(scheme)
 	_ = apiextensionsv1.AddToScheme(scheme)
-	clientSet := fake.NewSimpleClientset(objects...)
 
-	clientSet.Fake.Resources = ConvertSchemeToAPIResources(scheme)
+	simpleClientSet := fake.NewSimpleClientset(objects...)
+	dynamicClientSet := fake3.NewSimpleDynamicClient(scheme, objects...)
+	dynamicClientSet.Fake.Resources = ConvertSchemeToAPIResources(scheme)
+	dc := &fake4.FakeDiscovery{Fake: &dynamicClientSet.Fake}
 
-	dynamicClient := fake_dynamic.NewSimpleDynamicClient(scheme, objects...)
-	metadataClient := fake_metadata.NewSimpleMetadataClient(scheme, objects...)
+	agrs, _ := restmapper.GetAPIGroupResources(dc)
+	mapper := restmapper.NewDiscoveryRESTMapper(agrs)
 
-	clientBuilder := fake2.NewClientBuilder().
-		WithScheme(scheme).
-		WithRuntimeObjects(objects...)
-
-	return &fakeClientFactory{
-		clientSet:      clientSet,
-		dynamicClient:  dynamicClient,
-		metadataClient: metadataClient,
-		clientBuilder:  clientBuilder,
+	f := &fakeClientFactory{
+		scheme:           scheme,
+		mapper:           mapper,
+		objects:          objects,
+		simpleClientSet:  simpleClientSet,
+		dynamicClientSet: dynamicClientSet,
+		discovery:        dc,
 	}
+	simpleClientSet.PrependReactor("*", "*", f.errorReactor)
+	dynamicClientSet.PrependReactor("*", "*", f.errorReactor)
+	return f
 }
 
 type HasName interface {
 	GetName() string
 }
 
-func (f *fakeClientFactory) AddError(gvr schema.GroupVersionResource, name string, namespace string, retErr error) {
-	f.dynamicClient.PrependReactor("*", gvr.Resource, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
-		if namespace != "" && namespace != action.GetNamespace() {
-			return false, nil, nil
+func (f *fakeClientFactory) findError(gvr schema.GroupVersionResource, name string, namespace string) error {
+	for _, ee := range f.errors {
+		if ee.gvr != gvr {
+			continue
 		}
-		switch a := action.(type) {
-		case HasName:
-			if name != "" && name != a.GetName() {
-				return false, nil, nil
+		if ee.namespace != "" && ee.namespace != namespace {
+			continue
+		}
+
+		if ee.name != "" && ee.namespace != name {
+			continue
+		}
+
+		return ee.retErr
+	}
+	return nil
+}
+
+func (f *fakeClientFactory) buildErrorInterceptor() interceptor.Funcs {
+	h := func(key *client.ObjectKey, obj runtime.Object) error {
+		name := ""
+		namespace := ""
+		if key != nil {
+			name = key.Name
+			namespace = key.Namespace
+		} else if o, ok := obj.(client.Object); ok {
+			name = o.GetName()
+			namespace = o.GetNamespace()
+		}
+
+		gk := obj.GetObjectKind().GroupVersionKind().GroupKind()
+		rm, err := f.mapper.RESTMapping(gk, obj.GetObjectKind().GroupVersionKind().Version)
+		if err != nil {
+			return nil
+		}
+		return f.findError(rm.Resource, name, namespace)
+	}
+
+	return interceptor.Funcs{
+		Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			err := h(&key, obj)
+			if err != nil {
+				return err
 			}
-			return true, nil, retErr
-		default:
-			return true, nil, retErr
-		}
+			return client.Get(ctx, key, obj)
+		},
+		List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			err := h(nil, list)
+			if err != nil {
+				return err
+			}
+			return client.List(ctx, list, opts...)
+		},
+	}
+}
+
+func (f *fakeClientFactory) errorReactor(action testing.Action) (handled bool, ret runtime.Object, err error) {
+	a, ok := action.(HasName)
+	if !ok {
+		return false, nil, nil
+	}
+	if err != nil {
+		return false, nil, nil
+	}
+
+	err = f.findError(action.GetResource(), a.GetName(), action.GetNamespace())
+	if err != nil {
+		return true, nil, err
+	}
+	return false, nil, err
+}
+
+func (f *fakeClientFactory) AddError(gvr schema.GroupVersionResource, name string, namespace string, retErr error) {
+	f.errors = append(f.errors, errorEntry{
+		gvr:       gvr,
+		name:      name,
+		namespace: namespace,
+		retErr:    retErr,
 	})
 }
 

--- a/pkg/k8s/fake_client_factory.go
+++ b/pkg/k8s/fake_client_factory.go
@@ -41,6 +41,10 @@ func (f *fakeClientFactory) GetCA() []byte {
 func (f *fakeClientFactory) CloseIdleConnections() {
 }
 
+func (f *fakeClientFactory) Mapper() meta.ResettableRESTMapper {
+	return nil
+}
+
 func (f *fakeClientFactory) Client(wh rest.WarningHandler) (client.Client, error) {
 	return f.clientBuilder.Build(), nil
 }

--- a/pkg/k8s/resources.go
+++ b/pkg/k8s/resources.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"github.com/kluctl/kluctl/v2/pkg/types/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -240,40 +239,6 @@ func (k *k8sResources) UpdateResourcesFromCRD(crd *uo.UnstructuredObject) error 
 	}
 
 	return nil
-}
-
-func (k *k8sResources) IsNamespaced(gv schema.GroupKind) *bool {
-	ar := k.GetPreferredResource(gv)
-	if ar == nil {
-		return nil
-	}
-	return &ar.Namespaced
-}
-
-func (k *k8sResources) FixNamespace(o *uo.UnstructuredObject, def string) {
-	ref := o.GetK8sRef()
-	namespaced := k.IsNamespaced(ref.GroupKind())
-	if namespaced == nil {
-		return
-	}
-	if !*namespaced && ref.Namespace != "" {
-		o.SetK8sNamespace("")
-	} else if *namespaced && ref.Namespace == "" {
-		o.SetK8sNamespace(def)
-	}
-}
-
-func (k *k8sResources) FixNamespaceInRef(ref k8s.ObjectRef) k8s.ObjectRef {
-	namespaced := k.IsNamespaced(ref.GroupKind())
-	if namespaced == nil {
-		return ref
-	}
-	if !*namespaced && ref.Namespace != "" {
-		ref.Namespace = ""
-	} else if *namespaced && ref.Namespace == "" {
-		ref.Namespace = "default"
-	}
-	return ref
 }
 
 func (k *k8sResources) GetAllGroupVersions() ([]schema.GroupVersion, error) {

--- a/pkg/k8s/resources.go
+++ b/pkg/k8s/resources.go
@@ -1,20 +1,12 @@
 package k8s
 
 import (
-	"context"
 	"fmt"
-	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
-	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
-	"runtime"
-	"sort"
+	"k8s.io/client-go/restmapper"
 	"strings"
-	"sync"
 )
 
 var (
@@ -24,49 +16,14 @@ var (
 	}
 )
 
-type k8sResources struct {
-	ctx       context.Context
-	discovery discovery.DiscoveryInterface
-
-	allResources       map[schema.GroupVersionKind]v1.APIResource
-	preferredResources map[schema.GroupKind]v1.APIResource
-	crds               map[schema.GroupKind]*uo.UnstructuredObject
-	mutex              sync.Mutex
-}
-
-func newK8sResources(ctx context.Context, clientFactory ClientFactory) (*k8sResources, error) {
-	k := &k8sResources{
-		ctx:                ctx,
-		allResources:       map[schema.GroupVersionKind]v1.APIResource{},
-		preferredResources: map[schema.GroupKind]v1.APIResource{},
-		crds:               map[schema.GroupKind]*uo.UnstructuredObject{},
-		mutex:              sync.Mutex{},
-	}
-
-	var err error
-	k.discovery, err = clientFactory.DiscoveryClient()
-	if err != nil {
-		return nil, err
-	}
-
-	return k, nil
-}
-
-func (k *k8sResources) updateResources() error {
-	k.mutex.Lock()
-	defer k.mutex.Unlock()
-
-	k.allResources = map[schema.GroupVersionKind]v1.APIResource{}
-	k.preferredResources = map[schema.GroupKind]v1.APIResource{}
-	k.crds = map[schema.GroupKind]*uo.UnstructuredObject{}
+func (k *K8sCluster) doGetApiGroupResources() ([]*restmapper.APIGroupResources, error) {
+	var ret []*restmapper.APIGroupResources
 
 	// the discovery client doesn't support cancellation, so we need to run it in the background and wait for it
-	var ags []*v1.APIGroup
-	var arls []*v1.APIResourceList
 	finished := make(chan error)
 	go func() {
 		var err error
-		ags, arls, err = k.discovery.ServerGroupsAndResources()
+		ret, err = restmapper.GetAPIGroupResources(k.discovery)
 		if err != nil && !discovery.IsGroupDiscoveryFailedError(err) {
 			finished <- err
 			return
@@ -77,234 +34,65 @@ func (k *k8sResources) updateResources() error {
 	select {
 	case err := <-finished:
 		if err != nil {
-			return err
+			return nil, err
 		}
 	case <-k.ctx.Done():
-		return fmt.Errorf("failed listing api resources: %w", k.ctx.Err())
+		return nil, fmt.Errorf("failed listing api resources: %w", k.ctx.Err())
 	}
+	return ret, nil
+}
 
-	for _, arl := range arls {
-		var ag *v1.APIGroup
-		for _, x := range ags {
-			if x.Name == arl.GroupVersionKind().Group {
-				ag = x
-				break
-			}
-		}
-		if ag == nil {
+func (k *K8sCluster) doGetFilteredGVKs(ret *[]schema.GroupVersionKind, g v1.APIGroup, v string, vrs []v1.APIResource, filter func(ar *v1.APIResource) bool) {
+	for _, vr := range vrs {
+		if strings.Index(vr.Name, "/") != -1 {
+			// skip sub-resources
 			continue
 		}
-
-		for _, ar := range arl.APIResources {
-			if ar.Version == "__internal" {
-				continue
-			}
-			if strings.Index(ar.Name, "/") != -1 {
-				// skip subresources
-				continue
-			}
-			gv, err := schema.ParseGroupVersion(arl.GroupVersion)
-			if err != nil {
-				continue
-			}
-
-			ar := ar
-			ar.Group = gv.Group
-			ar.Version = gv.Version
-
-			gvk := schema.GroupVersionKind{
-				Group:   ar.Group,
-				Version: ar.Version,
-				Kind:    ar.Kind,
-			}
-			if _, ok := deprecatedResources[gvk.GroupKind()]; ok {
-				continue
-			}
-
-			k.allResources[gvk] = ar
-
-			if gvk.Version == ag.PreferredVersion.Version {
-				k.preferredResources[gvk.GroupKind()] = ar
-			}
-		}
-	}
-	if len(k.preferredResources) == 0 {
-		runtime.Breakpoint()
-	}
-
-	return nil
-}
-
-var crdGVR = schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}
-
-func (k *k8sResources) updateResourcesFromCRDs(clients *k8sClients) error {
-	var crdList *unstructured.UnstructuredList
-	_, err := clients.withDynamicClientForGVR(&crdGVR, "", func(r dynamic.ResourceInterface) error {
-		var err error
-		crdList, err = r.List(k.ctx, v1.ListOptions{})
-		return err
-	})
-	if err != nil {
-		return err
-	}
-
-	for _, x := range crdList.Items {
-		x := x
-		crd := uo.FromUnstructured(&x)
-		err = k.UpdateResourcesFromCRD(crd)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (k *k8sResources) UpdateResourcesFromCRD(crd *uo.UnstructuredObject) error {
-	var err error
-	var ar v1.APIResource
-	ar.Group, _, err = crd.GetNestedString("spec", "group")
-	if err != nil {
-		return err
-	}
-	ar.Name, _, err = crd.GetNestedString("spec", "names", "plural")
-	if err != nil {
-		return err
-	}
-	ar.Kind, _, err = crd.GetNestedString("spec", "names", "kind")
-	if err != nil {
-		return err
-	}
-	ar.SingularName, _, err = crd.GetNestedString("spec", "names", "singular")
-	if err != nil {
-		return err
-	}
-	scope, _, err := crd.GetNestedString("spec", "scope")
-	if err != nil {
-		return err
-	}
-	ar.Namespaced = strings.ToLower(scope) == "namespaced"
-	ar.ShortNames, _, err = crd.GetNestedStringList("spec", "names", "shortNames")
-	if err != nil {
-		return err
-	}
-	ar.Categories, _, err = crd.GetNestedStringList("spec", "names", "categories")
-	if err != nil {
-		return err
-	}
-	versions, _, err := crd.GetNestedObjectList("spec", "versions")
-	if err != nil {
-		return err
-	}
-
-	ar.Verbs = []string{"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch"}
-
-	gk := schema.GroupKind{
-		Group: ar.Group,
-		Kind:  ar.Kind,
-	}
-
-	k.mutex.Lock()
-	defer k.mutex.Unlock()
-
-	k.crds[gk] = crd
-
-	var versionStrs []string
-	for _, v := range versions {
-		name, _, err := v.GetNestedString("name")
-		if err != nil {
-			return err
-		}
-		versionStrs = append(versionStrs, name)
-	}
-
-	// Sort the same way as api discovery does it. The first entry is then the preferred version
-	sort.Slice(versionStrs, func(i, j int) bool {
-		return version.CompareKubeAwareVersionStrings(versionStrs[i], versionStrs[j]) > 0
-	})
-
-	for i, v := range versionStrs {
-		ar2 := ar
-		ar2.Version = v
 		gvk := schema.GroupVersionKind{
-			Group:   gk.Group,
-			Version: ar2.Version,
-			Kind:    gk.Kind,
+			Group:   g.Name,
+			Version: v,
+			Kind:    vr.Kind,
 		}
-		k.allResources[gvk] = ar2
-
-		if i == 0 {
-			k.preferredResources[gk] = ar2
+		if _, ok := deprecatedResources[gvk.GroupKind()]; ok {
+			continue
 		}
+		if filter != nil && !filter(&vr) {
+			continue
+		}
+		*ret = append(*ret, gvk)
 	}
-
-	return nil
 }
 
-func (k *k8sResources) GetAllGroupVersions() ([]schema.GroupVersion, error) {
-	k.mutex.Lock()
-	defer k.mutex.Unlock()
-
-	m := make(map[schema.GroupVersion]bool)
-	var l []schema.GroupVersion
-
-	for gvk, _ := range k.allResources {
-		gv := gvk.GroupVersion()
-		if _, ok := m[gv]; !ok {
-			m[gv] = true
-			l = append(l, gv)
-		}
+func (k *K8sCluster) GetFilteredGVKs(filter func(ar *v1.APIResource) bool) ([]schema.GroupVersionKind, error) {
+	agrs, err := k.doGetApiGroupResources()
+	if err != nil {
+		return nil, err
 	}
-	return l, nil
-}
-
-func (k *k8sResources) GetPreferredResource(gk schema.GroupKind) *v1.APIResource {
-	k.mutex.Lock()
-	defer k.mutex.Unlock()
-
-	ar, ok := k.preferredResources[gk]
-	if !ok {
-		return nil
-	}
-	return &ar
-}
-
-func (k *k8sResources) GetFilteredGVKs(filter func(ar *v1.APIResource) bool) []schema.GroupVersionKind {
-	k.mutex.Lock()
-	defer k.mutex.Unlock()
 
 	var ret []schema.GroupVersionKind
-	for _, ar := range k.allResources {
-		if filter != nil && !filter(&ar) {
-			continue
+	for _, agr := range agrs {
+		for v, vrs := range agr.VersionedResources {
+			k.doGetFilteredGVKs(&ret, agr.Group, v, vrs, filter)
 		}
-		gvk := schema.GroupVersionKind{
-			Group:   ar.Group,
-			Version: ar.Version,
-			Kind:    ar.Kind,
-		}
-		ret = append(ret, gvk)
 	}
-	return ret
+	return ret, nil
 }
 
-func (k *k8sResources) GetFilteredPreferredGVKs(filter func(ar *v1.APIResource) bool) []schema.GroupVersionKind {
-	k.mutex.Lock()
-	defer k.mutex.Unlock()
+func (k *K8sCluster) GetFilteredPreferredGVKs(filter func(ar *v1.APIResource) bool) ([]schema.GroupVersionKind, error) {
+	agrs, err := k.doGetApiGroupResources()
+	if err != nil {
+		return nil, err
+	}
 
 	var ret []schema.GroupVersionKind
-	for _, ar := range k.preferredResources {
-		if !filter(&ar) {
+	for _, agr := range agrs {
+		vrs, ok := agr.VersionedResources[agr.Group.PreferredVersion.Version]
+		if !ok {
 			continue
 		}
-		gvk := schema.GroupVersionKind{
-			Group:   ar.Group,
-			Version: ar.Version,
-			Kind:    ar.Kind,
-		}
-		ret = append(ret, gvk)
+		k.doGetFilteredGVKs(&ret, agr.Group, agr.Group.PreferredVersion.Version, vrs, filter)
 	}
-	return ret
+	return ret, nil
 }
 
 func BuildGVKFilter(group *string, version *string, kind *string) func(ar *v1.APIResource) bool {
@@ -320,63 +108,4 @@ func BuildGVKFilter(group *string, version *string, kind *string) func(ar *v1.AP
 		}
 		return true
 	}
-}
-
-func (k *k8sResources) GetGVRForGVK(gvk schema.GroupVersionKind) (*schema.GroupVersionResource, error) {
-	k.mutex.Lock()
-	defer k.mutex.Unlock()
-
-	ar, ok := k.allResources[gvk]
-	if !ok {
-		return nil, &meta.NoKindMatchError{
-			GroupKind:        gvk.GroupKind(),
-			SearchedVersions: []string{gvk.Version},
-		}
-	}
-
-	return &schema.GroupVersionResource{
-		Group:    ar.Group,
-		Version:  ar.Version,
-		Resource: ar.Name,
-	}, nil
-}
-
-func (k *k8sResources) GetCRDForGK(gk schema.GroupKind) *uo.UnstructuredObject {
-	k.mutex.Lock()
-	defer k.mutex.Unlock()
-
-	crd, _ := k.crds[gk]
-
-	return crd
-}
-
-func (k *k8sResources) GetSchemaForGVK(gvk schema.GroupVersionKind) (*uo.UnstructuredObject, error) {
-	crd := k.GetCRDForGK(gvk.GroupKind())
-	if crd == nil {
-		return nil, nil
-	}
-
-	versions, ok, err := crd.GetNestedObjectList("spec", "versions")
-	if err != nil {
-		return nil, err
-	}
-	if !ok {
-		return nil, fmt.Errorf("versions not found in CRD")
-	}
-
-	for _, v := range versions {
-		name, _, _ := v.GetNestedString("name")
-		if name != gvk.Version {
-			continue
-		}
-		s, ok, err := v.GetNestedObject("schema", "openAPIV3Schema")
-		if err != nil {
-			return nil, err
-		}
-		if !ok {
-			return nil, fmt.Errorf("version %s has no schema", name)
-		}
-		return s, nil
-	}
-	return nil, fmt.Errorf("schema for %s not found", gvk.String())
 }

--- a/pkg/seal/bootstrap.go
+++ b/pkg/seal/bootstrap.go
@@ -87,11 +87,11 @@ func writeKey(k *k8s.K8sCluster, key *rsa.PrivateKey, certs []*x509.Certificate,
 		v1.TLSCertKey: string(certbytes),
 	}
 
-	_, _, err := k.ReadWrite().PatchObject(secret, k8s.PatchOptions{})
+	_, _, err := k.ReadWrite().ApplyObject(secret, k8s.PatchOptions{})
 	if err != nil {
 		return err
 	}
-	_, _, err = k.ReadWrite().PatchObject(configMap, k8s.PatchOptions{})
+	_, _, err = k.ReadWrite().ApplyObject(configMap, k8s.PatchOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -126,7 +126,7 @@ func ValidateObject(k *k8s.K8sCluster, o *uo.UnstructuredObject, notReadyIsError
 			// can't really say anything...
 			return
 		}
-		s, err := k.Resources.GetSchemaForGVK(ref.GroupVersionKind())
+		s, err := k.GetSchemaForGVK(ref.GroupVersionKind())
 		if err != nil && !errors.IsNotFound(err) {
 			addError(err.Error())
 			return


### PR DESCRIPTION
# Description

This mostly changes `K8sCluster` to not use the dynamic client anymore but instead use the controller-runtime Client implementation.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
