### PR TITLE
feat: Add ability to include custom message in barriers

### DIFF
--- a/docs/reference/deployments/deployment-yml.md
+++ b/docs/reference/deployments/deployment-yml.md
@@ -128,6 +128,24 @@ deployments:
 - path: kustomizeDeployment3
 ```
 
+To create a barrier with a custom message, include the message parameter when creating the barrier. The message parameter accepts a string value that represents the custom message.
+
+Example:
+```yaml
+deployments:
+- path: kustomizeDeployment1
+- path: kustomizeDeployment2
+- include: subDeployment1
+- barrier: true
+  message: "Waiting for subDeployment1 to be finished"
+# At this point, it's ensured that kustomizeDeployment1, kustomizeDeployment2 and all sub-deployments from
+# subDeployment1 are fully deployed.
+- path: kustomizeDeployment3
+```
+If no custom message is provided, the barrier will be created without a specific message, and the default behavior will be applied.
+
+When viewing the `kluctl deploy` status, the custom message, if provided, will be displayed along with default barrier information.
+
 ### deleteObjects
 Causes kluctl to delete matching objects, specified by a list of group/kind/name/namespace dictionaries.
 The order/parallelization of deletion is identical to the order and parallelization of normal deployment items,

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -34,6 +34,7 @@ type DeploymentItem struct {
 
 	// These values come from the metadata of the kustomization.yml
 	Barrier       bool
+	Message       *string
 	WaitReadiness bool
 
 	Objects []*uo.UnstructuredObject

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -34,7 +34,6 @@ type DeploymentItem struct {
 
 	// These values come from the metadata of the kustomization.yml
 	Barrier       bool
-	Message       *string
 	WaitReadiness bool
 
 	Objects []*uo.UnstructuredObject

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -711,7 +711,6 @@ func (a *ApplyDeploymentsUtil) ApplyDeployments(deployments []*deployment.Deploy
 		if barrier {
 			sctx := status.StartWithOptions(a.ctx, status.WithStatus("Waiting on barrier: "+*message), status.WithTotal(1))
 			wg.Wait()
-			time.Sleep(10 * time.Second)
 			sctx.UpdateAndInfoFallback(fmt.Sprintf("Finished waiting"))
 			sctx.Success()
 		}

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -697,10 +697,21 @@ func (a *ApplyDeploymentsUtil) ApplyDeployments(deployments []*deployment.Deploy
 			sctx.Failed()
 		}()
 
+		var message *string
+
+		if d.Message != nil {
+			message = d.Message
+		}
+
+		if d.Config.Message != nil {
+			message = d.Config.Message
+		}
+
 		barrier := d.Config.Barrier || d.Barrier
 		if barrier {
-			sctx := status.StartWithOptions(a.ctx, status.WithStatus("Waiting on barrier..."), status.WithTotal(1))
+			sctx := status.StartWithOptions(a.ctx, status.WithStatus("Waiting on barrier: "+*message), status.WithTotal(1))
 			wg.Wait()
+			time.Sleep(10 * time.Second)
 			sctx.UpdateAndInfoFallback(fmt.Sprintf("Finished waiting"))
 			sctx.Success()
 		}

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -697,19 +697,13 @@ func (a *ApplyDeploymentsUtil) ApplyDeployments(deployments []*deployment.Deploy
 			sctx.Failed()
 		}()
 
-		var message *string
-
-		if d.Message != nil {
-			message = d.Message
-		}
-
-		if d.Config.Message != nil {
-			message = d.Config.Message
-		}
-
 		barrier := d.Config.Barrier || d.Barrier
 		if barrier {
-			sctx := status.StartWithOptions(a.ctx, status.WithStatus("Waiting on barrier: "+*message), status.WithTotal(1))
+			barrierMessage := "Waiting on barrier..."
+			if d.Config.Message != nil {
+				barrierMessage = fmt.Sprintf("Waiting on barrier: %s", *d.Config.Message)
+			}
+			sctx := status.StartWithOptions(a.ctx, status.WithStatus(barrierMessage), status.WithTotal(1))
 			wg.Wait()
 			sctx.UpdateAndInfoFallback(fmt.Sprintf("Finished waiting"))
 			sctx.Success()

--- a/pkg/types/deployment.go
+++ b/pkg/types/deployment.go
@@ -13,6 +13,7 @@ type DeploymentItemConfig struct {
 	Git              *GitProject              `json:"git,omitempty"`
 	Tags             []string                 `json:"tags,omitempty"`
 	Barrier          bool                     `json:"barrier,omitempty"`
+	Message          *string                  `json:"message,omitempty"`
 	WaitReadiness    bool                     `json:"waitReadiness,omitempty"`
 	Vars             []*VarsSource            `json:"vars,omitempty"`
 	SkipDeleteIfTags bool                     `json:"skipDeleteIfTags,omitempty"`

--- a/pkg/types/zz_generated.deepcopy.go
+++ b/pkg/types/zz_generated.deepcopy.go
@@ -94,6 +94,11 @@ func (in *DeploymentItemConfig) DeepCopyInto(out *DeploymentItemConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Message != nil {
+		in, out := &in.Message, &out.Message
+		*out = new(string)
+		**out = **in
+	}
 	if in.Vars != nil {
 		in, out := &in.Vars, &out.Vars
 		*out = make([]*VarsSource, len(*in))


### PR DESCRIPTION
# Description

This commit adds a new feature that allows users to include a custom message when creating barriers. With this enhancement, users can provide additional information or context related to the barrier, which will be displayed when waiting on the barrier. This feature enhances the usability and flexibility of the barrier functionality. It also updates the project documentation to reflect the recent enhancement regarding optional custom messages for barriers. The documentation now includes clear instructions and examples on how to utilize the message parameter when creating barriers to provide custom messages.

The implementation includes the necessary updates to the barrier creation logic to accept a custom message. Additionally, the cli output has been updated to display the custom message when showing the status or details of a barrier.

Implements (#420)

## Type of change
- [x] New feature (non-breaking change which adds functionality)
