### PR TITLE
fix: Use strict yaml unmarshalling in custom unmarshallers

### DIFF
--- a/pkg/deployment/external_args.go
+++ b/pkg/deployment/external_args.go
@@ -1,7 +1,6 @@
 package deployment
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
@@ -61,7 +60,7 @@ func LoadDefaultArgs(args []*types.DeploymentArg, deployArgs *uo.UnstructuredObj
 	for _, a := range args {
 		if a.Default != nil {
 			var v any
-			err := json.Unmarshal(a.Default.Raw, &v)
+			err := yaml.ReadYamlBytes(a.Default.Raw, &v)
 			if err != nil {
 				return err
 			}

--- a/pkg/types/deployment.go
+++ b/pkg/types/deployment.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"github.com/go-playground/validator/v10"
 	"github.com/kluctl/kluctl/v2/pkg/types/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
@@ -70,14 +69,14 @@ type SingleStringOrList []string
 
 func (s *SingleStringOrList) UnmarshalJSON(b []byte) error {
 	var single string
-	if err := json.Unmarshal(b, &single); err == nil {
+	if err := yaml.ReadYamlBytes(b, &single); err == nil {
 		// it's a single project
 		*s = []string{single}
 		return nil
 	}
 	// try as array
 	var arr []string
-	if err := json.Unmarshal(b, &arr); err != nil {
+	if err := yaml.ReadYamlBytes(b, &arr); err != nil {
 		return err
 	}
 	*s = arr

--- a/pkg/types/git_project.go
+++ b/pkg/types/git_project.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -20,12 +19,12 @@ type GitProject struct {
 }
 
 func (gp *GitProject) UnmarshalJSON(b []byte) error {
-	if err := json.Unmarshal(b, &gp.Url); err == nil {
+	if err := yaml.ReadYamlBytes(b, &gp.Url); err == nil {
 		// it's a simple string
 		return nil
 	}
 	type raw GitProject
-	return json.Unmarshal(b, (*raw)(gp))
+	return yaml.ReadYamlBytes(b, (*raw)(gp))
 }
 
 // invalidDirName evaluate directory name against forbidden characters

--- a/pkg/types/git_url.go
+++ b/pkg/types/git_url.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/kluctl/kluctl/v2/pkg/git/giturls"
+	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	"net/url"
 	"strings"
 )
@@ -43,7 +44,7 @@ func (in *GitUrl) DeepCopyInto(out *GitUrl) {
 
 func (u *GitUrl) UnmarshalJSON(b []byte) error {
 	var s string
-	err := json.Unmarshal(b, &s)
+	err := yaml.ReadYamlBytes(b, &s)
 	if err != nil {
 		return err
 	}
@@ -142,7 +143,7 @@ func (u GitRepoKey) String() string {
 
 func (u *GitRepoKey) UnmarshalJSON(b []byte) error {
 	var s string
-	err := json.Unmarshal(b, &s)
+	err := yaml.ReadYamlBytes(b, &s)
 	if err != nil {
 		return err
 	}

--- a/pkg/types/result/compact.go
+++ b/pkg/types/result/compact.go
@@ -73,7 +73,7 @@ func (l CompactedObjects) MarshalJSON() ([]byte, error) {
 
 func (l *CompactedObjects) UnmarshalJSON(b []byte) error {
 	var compactedList []CompactedObject
-	err := json.Unmarshal(b, &compactedList)
+	err := yaml.ReadYamlBytes(b, &compactedList)
 	if err != nil {
 		return err
 	}

--- a/pkg/types/yaml_url.go
+++ b/pkg/types/yaml_url.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	"net/url"
 )
 
@@ -11,7 +12,7 @@ type YamlUrl struct {
 
 func (u *YamlUrl) UnmarshalJSON(b []byte) error {
 	var s string
-	err := json.Unmarshal(b, &s)
+	err := yaml.ReadYamlBytes(b, &s)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/uo/uo.go
+++ b/pkg/utils/uo/uo.go
@@ -19,7 +19,7 @@ func (uo *UnstructuredObject) MarshalJSON() ([]byte, error) {
 }
 
 func (uo *UnstructuredObject) UnmarshalJSON(b []byte) error {
-	return json.Unmarshal(b, &uo.Object)
+	return yaml.ReadYamlBytes(b, &uo.Object)
 }
 
 func (uo *UnstructuredObject) IsZero() bool {

--- a/pkg/webui/ui/.gitignore
+++ b/pkg/webui/ui/.gitignore
@@ -1,0 +1,23 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
# Description

Otherwise custom unmarshallers ignore unknown fields, e.g. in `GitProject`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
