### PR TITLE
fix: Fix inclusion of relative base dirs when the project is not at the repo root

### DIFF
--- a/cmd/kluctl/commands/cmd_seal.go
+++ b/cmd/kluctl/commands/cmd_seal.go
@@ -93,7 +93,7 @@ func (cmd *sealCmd) loadCert(cmdCtx *commandCtx) (*x509.Certificate, error) {
 	var certFile string
 
 	if sealingConfig != nil && sealingConfig.CertFile != nil {
-		path, err := securejoin.SecureJoin(cmdCtx.targetCtx.KluctlProject.ProjectDir, *sealingConfig.CertFile)
+		path, err := securejoin.SecureJoin(cmdCtx.targetCtx.KluctlProject.LoadArgs.ProjectDir, *sealingConfig.CertFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kluctl_project/project.go
+++ b/pkg/kluctl_project/project.go
@@ -18,8 +18,6 @@ type LoadedKluctlProject struct {
 
 	TmpDir string
 
-	ProjectDir string
-
 	sealedSecretsDir string
 
 	Config  types2.KluctlProject

--- a/pkg/kluctl_project/project_load.go
+++ b/pkg/kluctl_project/project_load.go
@@ -27,7 +27,7 @@ type LoadKluctlProjectArgs struct {
 func (c *LoadedKluctlProject) getConfigPath() string {
 	configPath := c.LoadArgs.ProjectConfig
 	if configPath == "" {
-		p := yaml.FixPathExt(filepath.Join(c.ProjectDir, ".kluctl.yml"))
+		p := yaml.FixPathExt(filepath.Join(c.LoadArgs.ProjectDir, ".kluctl.yml"))
 		if utils.IsFile(p) {
 			configPath = p
 		}
@@ -38,10 +38,8 @@ func (c *LoadedKluctlProject) getConfigPath() string {
 func (c *LoadedKluctlProject) loadKluctlProject() error {
 	var err error
 
-	c.ProjectDir = c.LoadArgs.ProjectDir
-
 	if c.LoadArgs.RepoRoot != "" {
-		err = utils.CheckInDir(c.LoadArgs.RepoRoot, c.ProjectDir)
+		err = utils.CheckInDir(c.LoadArgs.RepoRoot, c.LoadArgs.ProjectDir)
 		if err != nil {
 			return err
 		}
@@ -59,7 +57,7 @@ func (c *LoadedKluctlProject) loadKluctlProject() error {
 	s := status.Start(c.ctx, "Loading kluctl project")
 	defer s.Failed()
 
-	c.sealedSecretsDir = filepath.Join(c.ProjectDir, ".sealed-secrets")
+	c.sealedSecretsDir = filepath.Join(c.LoadArgs.ProjectDir, ".sealed-secrets")
 
 	sealedSecretsUsed := false
 	if c.Config.SecretsConfig != nil {

--- a/pkg/kluctl_project/target_context.go
+++ b/pkg/kluctl_project/target_context.go
@@ -44,7 +44,11 @@ type TargetContextParams struct {
 }
 
 func (p *LoadedKluctlProject) NewTargetContext(ctx context.Context, params TargetContextParams) (*TargetContext, error) {
-	deploymentDir, err := filepath.Abs(p.LoadArgs.ProjectDir)
+	repoRoot, err := filepath.Abs(p.LoadArgs.RepoRoot)
+	if err != nil {
+		return nil, err
+	}
+	relProjectDir, err := filepath.Rel(repoRoot, p.LoadArgs.ProjectDir)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +133,7 @@ func (p *LoadedKluctlProject) NewTargetContext(ctx context.Context, params Targe
 		DefaultSealedSecretsOutputPattern: target.Name,
 	}
 
-	d, err := deployment.NewDeploymentProject(dctx, varsCtx, deployment.NewSource(deploymentDir), ".", nil)
+	d, err := deployment.NewDeploymentProject(dctx, varsCtx, deployment.NewSource(repoRoot), relProjectDir, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kluctl_project/target_context.go
+++ b/pkg/kluctl_project/target_context.go
@@ -44,7 +44,7 @@ type TargetContextParams struct {
 }
 
 func (p *LoadedKluctlProject) NewTargetContext(ctx context.Context, params TargetContextParams) (*TargetContext, error) {
-	deploymentDir, err := filepath.Abs(p.ProjectDir)
+	deploymentDir, err := filepath.Abs(p.LoadArgs.ProjectDir)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func (p *LoadedKluctlProject) findSecretsEntry(name string) (*types.SecretSet, e
 }
 
 func (p *LoadedKluctlProject) loadSecrets(target *types.Target, varsCtx *vars.VarsCtx, varsLoader *vars.VarsLoader) error {
-	searchDirs := []string{p.ProjectDir}
+	searchDirs := []string{p.LoadArgs.ProjectDir}
 
 	for _, secretSetName := range target.SealingConfig.SecretSets {
 		secretEntry, err := p.findSecretsEntry(secretSetName)


### PR DESCRIPTION
# Description

This allows `./foo` to include `../base` when Kluctl is run from inside `foo`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
