### PR TITLE
fix: Use projectDir as repoRoot in case there is no Git repo involved

### DIFF
--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -50,6 +50,10 @@ func withKluctlProjectFromArgs(ctx context.Context, projectFlags args.ProjectFla
 		}
 	}
 
+	if repoRoot == "" {
+		repoRoot = projectDir
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, projectFlags.Timeout)
 	defer cancel()
 

--- a/docs/reference/gitops/spec/v1beta1/kluctldeployment.md
+++ b/docs/reference/gitops/spec/v1beta1/kluctldeployment.md
@@ -156,7 +156,7 @@ The above example is equivalent to calling `kluctl deploy -t prod -a arg1=value1
 
 ### images
 `spec.images` specifies a list of fixed images to be used by
-[`image.get_image(...)`](../../../deployments/images#imagesget_image). Example:
+[`image.get_image(...)`](../../../deployments/images.md#imagesget_image). Example:
 
 ```
 apiVersion: gitops.kluctl.io/v1beta1


### PR DESCRIPTION
# Description

This fixes the new "kluctl controller install" sub-command.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
