### PR TITLE
fix: Properly convert viber bool/int to string args

### DIFF
--- a/cmd/kluctl/commands/cobra_utils.go
+++ b/cmd/kluctl/commands/cobra_utils.go
@@ -251,6 +251,10 @@ func copyViperValuesToCobraFlags(flags *pflag.FlagSet) error {
 		if v != nil {
 			if x, ok := v.(string); ok {
 				a = []string{x}
+			} else if x, ok := v.(bool); ok {
+				a = []string{strconv.FormatBool(x)}
+			} else if x, ok := v.(int); ok {
+				a = []string{strconv.FormatInt(int64(x), 10)}
 			} else if x, ok := v.([]any); ok {
 				for _, y := range x {
 					s, ok := y.(string)


### PR DESCRIPTION
# Description

Otherwise args from ~/.kluctl/config can't contain bools/ints.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
