### PR TITLE
feat: Implement pruning right after deploying

### DIFF
--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -21,10 +21,6 @@ const (
 	// kluctl deploy command failed.
 	DeployFailedReason string = "DeployFailed"
 
-	// PruneFailedReason represents the fact that the
-	// pruning of the KluctlDeployment failed.
-	PruneFailedReason string = "PruneFailed"
-
 	// ValidateFailedReason represents the fact that the
 	// validate of the KluctlDeployment failed.
 	ValidateFailedReason string = "ValidateFailed"

--- a/api/v1beta1/kluctldeployment_types.go
+++ b/api/v1beta1/kluctldeployment_types.go
@@ -322,18 +322,12 @@ type KluctlDeploymentStatus struct {
 	// +optional
 	LastDeployError string `json:"lastDeployError,omitempty"`
 	// +optional
-	LastPruneError string `json:"lastPruneError,omitempty"`
-	// +optional
 	LastValidateError string `json:"lastValidateError,omitempty"`
 
 	// LastDeployResult is the result of the last deploy command
 	// +optional
 	// +kubebuilder:pruning:PreserveUnknownFields
 	LastDeployResult *runtime.RawExtension `json:"lastDeployResult,omitempty"`
-
-	// LastDeployResult is the result of the last prune command
-	// +optional
-	LastPruneResult *runtime.RawExtension `json:"lastPruneResult,omitempty"`
 
 	// LastValidateResult is the result of the last validate command
 	// +optional
@@ -353,23 +347,6 @@ func (s *KluctlDeploymentStatus) SetLastDeployResult(crs *result.CommandResultSu
 			return err
 		}
 		s.LastDeployResult = &runtime.RawExtension{Raw: []byte(b)}
-	}
-	return nil
-}
-
-func (s *KluctlDeploymentStatus) SetLastPruneResult(crs *result.CommandResultSummary, err error) error {
-	s.LastPruneError = ""
-	if err != nil {
-		s.LastPruneError = err.Error()
-	}
-	if crs == nil {
-		s.LastPruneResult = nil
-	} else {
-		b, err := yaml.WriteJsonString(crs)
-		if err != nil {
-			return err
-		}
-		s.LastPruneResult = &runtime.RawExtension{Raw: []byte(b)}
 	}
 	return nil
 }
@@ -397,18 +374,6 @@ func (s *KluctlDeploymentStatus) GetLastDeployResult() (*result.CommandResultSum
 	}
 	var ret result.CommandResultSummary
 	err := yaml.ReadYamlBytes(s.LastDeployResult.Raw, &ret)
-	if err != nil {
-		return nil, err
-	}
-	return &ret, nil
-}
-
-func (s *KluctlDeploymentStatus) GetLastPruneResult() (*result.CommandResultSummary, error) {
-	if s.LastPruneResult == nil {
-		return nil, nil
-	}
-	var ret result.CommandResultSummary
-	err := yaml.ReadYamlBytes(s.LastPruneResult.Raw, &ret)
 	if err != nil {
 		return nil, err
 	}

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -258,11 +258,6 @@ func (in *KluctlDeploymentStatus) DeepCopyInto(out *KluctlDeploymentStatus) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.LastPruneResult != nil {
-		in, out := &in.LastPruneResult, &out.LastPruneResult
-		*out = new(runtime.RawExtension)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.LastValidateResult != nil {
 		in, out := &in.LastValidateResult, &out.LastValidateResult
 		*out = new(runtime.RawExtension)

--- a/cmd/kluctl/commands/cmd_deploy.go
+++ b/cmd/kluctl/commands/cmd_deploy.go
@@ -27,6 +27,7 @@ type deployCmd struct {
 	args.CommandResultFlags
 
 	NoWait bool `group:"misc" help:"Don't wait for objects readiness'"`
+	Prune  bool `group:"misc" help:"Prune orphaned objects directly after deploying. See the help for the 'prune' sub-command for details.'"`
 
 	internal bool
 }
@@ -67,6 +68,8 @@ func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
 	cmd2.AbortOnError = cmd.AbortOnError
 	cmd2.ReadinessTimeout = cmd.ReadinessTimeout
 	cmd2.NoWait = cmd.NoWait
+	cmd2.Prune = cmd.Prune
+	cmd2.WaitPrune = !cmd.NoWait
 
 	cb := func(diffResult *result.CommandResult) error {
 		return cmd.diffResultCb(cmdCtx, diffResult)

--- a/config/crd/bases/gitops.kluctl.io_kluctldeployments.yaml
+++ b/config/crd/bases/gitops.kluctl.io_kluctldeployments.yaml
@@ -456,12 +456,6 @@ spec:
                 type: string
               lastObjectsHash:
                 type: string
-              lastPruneError:
-                type: string
-              lastPruneResult:
-                description: LastDeployResult is the result of the last prune command
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
               lastValidateError:
                 type: string
               lastValidateResult:

--- a/docs/reference/commands/deploy.md
+++ b/docs/reference/commands/deploy.md
@@ -61,6 +61,8 @@ Misc arguments:
                                                     'format=path'. Format can either be 'text' or 'yaml'. Can be
                                                     specified multiple times. The actual format for yaml is
                                                     currently not documented and subject to change.
+      --prune                                       Prune orphaned objects directly after deploying. See the help
+                                                    for the 'prune' sub-command for details.'
       --readiness-timeout duration                  Maximum time to wait for object readiness. The timeout is
                                                     meant per-object. Timeouts are in the duration format (1s, 1m,
                                                     1h, ...). If not specified, a default timeout of 5m is used.

--- a/docs/reference/gitops/api/kluctl-controller.md
+++ b/docs/reference/gitops/api/kluctl-controller.md
@@ -1170,17 +1170,6 @@ string
 </tr>
 <tr>
 <td>
-<code>lastPruneError</code><br>
-<em>
-string
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-</td>
-</tr>
-<tr>
-<td>
 <code>lastValidateError</code><br>
 <em>
 string
@@ -1200,18 +1189,6 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <em>(Optional)</em>
 <p>LastDeployResult is the result of the last deploy command</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>lastPruneResult</code><br>
-<em>
-k8s.io/apimachinery/pkg/runtime.RawExtension
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>LastDeployResult is the result of the last prune command</p>
 </td>
 </tr>
 <tr>

--- a/e2e/gitops_errors_test.go
+++ b/e2e/gitops_errors_test.go
@@ -226,13 +226,15 @@ data:
 			return nil
 		})
 		suite.waitForCommit(key, getHeadRevision(suite.T(), p))
-		suite.assertErrors(key, metav1.ConditionFalse, kluctlv1.PruneFailedReason, "pruning without a discriminator is not supported", nil, nil)
+		suite.assertErrors(key, metav1.ConditionFalse, kluctlv1.DeployFailedReason, "deploy failed with 1 errors", []result.DeploymentError{
+			{Message: "pruning without a discriminator is not supported"},
+		}, nil)
 		p.UpdateKluctlYaml(func(o *uo.UnstructuredObject) error {
 			_ = o.SetNestedField(backup, "discriminator")
 			return nil
 		})
 		suite.waitForCommit(key, getHeadRevision(suite.T(), p))
-		suite.assertErrors(key, metav1.ConditionTrue, kluctlv1.ReconciliationSucceededReason, "deploy: ok, prune: ok", nil, nil)
+		suite.assertErrors(key, metav1.ConditionTrue, kluctlv1.ReconciliationSucceededReason, "deploy: ok", nil, nil)
 		suite.updateKluctlDeployment(key, func(kd *kluctlv1.KluctlDeployment) {
 			kd.Spec.Prune = false
 		})

--- a/e2e/prune_test.go
+++ b/e2e/prune_test.go
@@ -1,0 +1,73 @@
+package e2e
+
+import (
+	test_utils "github.com/kluctl/kluctl/v2/e2e/test-utils"
+	"testing"
+)
+
+func TestPrune(t *testing.T) {
+	t.Parallel()
+
+	k := defaultCluster1
+
+	p := test_utils.NewTestProject(t)
+
+	createNamespace(t, k, p.TestSlug())
+
+	p.UpdateTarget("test", nil)
+
+	addConfigMapDeployment(p, "cm1", map[string]string{}, resourceOpts{
+		name:      "cm1",
+		namespace: p.TestSlug(),
+	})
+	addConfigMapDeployment(p, "cm2", map[string]string{}, resourceOpts{
+		name:      "cm2",
+		namespace: p.TestSlug(),
+	})
+
+	p.KluctlMust("deploy", "--yes", "-t", "test")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm2")
+
+	p.DeleteKustomizeDeployment("cm2")
+
+	p.KluctlMust("prune", "--yes", "-t", "test")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+	assertConfigMapNotExists(t, k, p.TestSlug(), "cm2")
+}
+
+func TestDeployWithPrune(t *testing.T) {
+	t.Parallel()
+
+	k := defaultCluster1
+
+	p := test_utils.NewTestProject(t)
+
+	createNamespace(t, k, p.TestSlug())
+
+	p.UpdateTarget("test", nil)
+
+	addConfigMapDeployment(p, "cm1", map[string]string{}, resourceOpts{
+		name:      "cm1",
+		namespace: p.TestSlug(),
+	})
+	addConfigMapDeployment(p, "cm2", map[string]string{}, resourceOpts{
+		name:      "cm2",
+		namespace: p.TestSlug(),
+	})
+
+	p.KluctlMust("deploy", "--yes", "-t", "test")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm2")
+
+	p.DeleteKustomizeDeployment("cm2")
+	addConfigMapDeployment(p, "cm3", map[string]string{}, resourceOpts{
+		name:      "cm3",
+		namespace: p.TestSlug(),
+	})
+
+	p.KluctlMust("deploy", "--yes", "-t", "test", "--prune")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+	assertConfigMapNotExists(t, k, p.TestSlug(), "cm2")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm3")
+}

--- a/e2e/results_test.go
+++ b/e2e/results_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	test_utils "github.com/kluctl/kluctl/v2/e2e/test-utils"
 	"github.com/kluctl/kluctl/v2/pkg/results"
+	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/types/result"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/stretchr/testify/assert"
@@ -44,7 +45,13 @@ func TestWriteResult(t *testing.T) {
 	rs, err := results.NewResultStoreSecrets(context.Background(), k.Client, nil, "kluctl-results", 0)
 	assert.NoError(t, err)
 
-	summaries, err := rs.ListCommandResultSummaries(results.ListCommandResultSummariesOptions{})
+	opts := results.ListCommandResultSummariesOptions{
+		ProjectFilter: &result.ProjectKey{
+			GitRepoKey: types.ParseGitUrlMust(p.GitUrl()).RepoKey(),
+		},
+	}
+
+	summaries, err := rs.ListCommandResultSummaries(opts)
 	assert.NoError(t, err)
 	assert.Len(t, summaries, 1)
 	assertSummary(t, result.CommandResultSummary{
@@ -63,7 +70,7 @@ func TestWriteResult(t *testing.T) {
 	p.KluctlMust("deploy", "--yes", "-t", "test", "--write-command-result")
 	assertConfigMapExists(t, k, p.TestSlug(), "cm2")
 
-	summaries, err = rs.ListCommandResultSummaries(results.ListCommandResultSummariesOptions{})
+	summaries, err = rs.ListCommandResultSummaries(opts)
 	assert.NoError(t, err)
 	assert.Len(t, summaries, 2)
 	assertSummary(t, result.CommandResultSummary{
@@ -80,7 +87,7 @@ func TestWriteResult(t *testing.T) {
 	p.KluctlMust("deploy", "--yes", "-t", "test", "--write-command-result")
 	assertConfigMapExists(t, k, p.TestSlug(), "cm2")
 
-	summaries, err = rs.ListCommandResultSummaries(results.ListCommandResultSummariesOptions{})
+	summaries, err = rs.ListCommandResultSummaries(opts)
 	assert.NoError(t, err)
 	assert.Len(t, summaries, 3)
 	assertSummary(t, result.CommandResultSummary{
@@ -91,7 +98,7 @@ func TestWriteResult(t *testing.T) {
 	p.KluctlMust("prune", "--yes", "-t", "test", "--write-command-result")
 	assertConfigMapNotExists(t, k, p.TestSlug(), "cm2")
 
-	summaries, err = rs.ListCommandResultSummaries(results.ListCommandResultSummariesOptions{})
+	summaries, err = rs.ListCommandResultSummaries(opts)
 	assert.NoError(t, err)
 	assert.Len(t, summaries, 4)
 	assertSummary(t, result.CommandResultSummary{

--- a/install/controller/controller/crd.yaml
+++ b/install/controller/controller/crd.yaml
@@ -455,12 +455,6 @@ spec:
                 type: string
               lastObjectsHash:
                 type: string
-              lastPruneError:
-                type: string
-              lastPruneResult:
-                description: LastDeployResult is the result of the last prune command
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
               lastValidateError:
                 type: string
               lastValidateResult:

--- a/pkg/controllers/kluctl_project.go
+++ b/pkg/controllers/kluctl_project.go
@@ -707,6 +707,8 @@ func (pt *preparedTarget) kluctlDeploy(ctx context.Context, targetContext *kluct
 	cmd.AbortOnError = pt.pp.obj.Spec.AbortOnError
 	cmd.ReadinessTimeout = time.Minute * 10
 	cmd.NoWait = pt.pp.obj.Spec.NoWait
+	cmd.Prune = pt.pp.obj.Spec.Prune
+	cmd.WaitPrune = false
 
 	cmdResult, err := cmd.Run(nil)
 	err = pt.handleCommandResult(ctx, err, cmdResult, "deploy")
@@ -720,26 +722,6 @@ func (pt *preparedTarget) kluctlPokeImages(ctx context.Context, targetContext *k
 
 	cmdResult, err := cmd.Run()
 	err = pt.handleCommandResult(ctx, err, cmdResult, "poke-images")
-	return cmdResult, err
-}
-
-func (pt *preparedTarget) kluctlPrune(ctx context.Context, targetContext *kluctl_project.TargetContext) (*result.CommandResult, error) {
-	if !pt.pp.obj.Spec.Prune {
-		return nil, nil
-	}
-
-	timer := prometheus.NewTimer(internal_metrics.NewKluctlPruneDuration(pt.pp.obj.ObjectMeta.Namespace, pt.pp.obj.ObjectMeta.Name))
-	defer timer.ObserveDuration()
-
-	cmd := commands.NewPruneCommand("", targetContext, false)
-	cmdResult, err := cmd.Run(func(refs []k8s.ObjectRef) error {
-		pt.printDeletedRefs(ctx, refs)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	err = pt.handleCommandResult(ctx, err, cmdResult, "prune")
 	return cmdResult, err
 }
 

--- a/pkg/deployment/commands/delete.go
+++ b/pkg/deployment/commands/delete.go
@@ -66,10 +66,7 @@ func (cmd *DeleteCommand) Run(ctx context.Context, k *k8s.K8sCluster, confirmCb 
 		}
 	}
 
-	deleted, err := utils2.DeleteObjects(ctx, k, deleteRefs, dew, cmd.wait)
-	if err != nil {
-		return nil, err
-	}
+	deleted := utils2.DeleteObjects(ctx, k, deleteRefs, dew, cmd.wait)
 
 	var c *deployment.DeploymentCollection
 	if cmd.targetCtx != nil {

--- a/pkg/deployment/commands/prune.go
+++ b/pkg/deployment/commands/prune.go
@@ -54,10 +54,7 @@ func (cmd *PruneCommand) Run(confirmCb func(refs []k8s2.ObjectRef) error) (*resu
 		}
 	}
 
-	deleted, err := utils2.DeleteObjects(cmd.targetCtx.SharedContext.Ctx, cmd.targetCtx.SharedContext.K, deleteRefs, dew, cmd.wait)
-	if err != nil {
-		return nil, err
-	}
+	deleted := utils2.DeleteObjects(cmd.targetCtx.SharedContext.Ctx, cmd.targetCtx.SharedContext.K, deleteRefs, dew, cmd.wait)
 
 	r := &result.CommandResult{
 		Id:       uuid.New().String(),

--- a/pkg/deployment/utils/delete_utils.go
+++ b/pkg/deployment/utils/delete_utils.go
@@ -163,7 +163,7 @@ func FindObjectsForDelete(k *k8s.K8sCluster, allClusterObjects []*uo.Unstructure
 	return ret, nil
 }
 
-func DeleteObjects(ctx context.Context, k *k8s.K8sCluster, refs []k8s2.ObjectRef, dew *DeploymentErrorsAndWarnings, doWait bool) ([]k8s2.ObjectRef, error) {
+func DeleteObjects(ctx context.Context, k *k8s.K8sCluster, refs []k8s2.ObjectRef, dew *DeploymentErrorsAndWarnings, doWait bool) []k8s2.ObjectRef {
 	g := utils.NewGoHelper(ctx, 8)
 
 	var ret []k8s2.ObjectRef
@@ -210,5 +210,5 @@ func DeleteObjects(ctx context.Context, k *k8s.K8sCluster, refs []k8s2.ObjectRef
 	}
 	g.Wait()
 
-	return ret, nil
+	return ret
 }

--- a/pkg/git/test_git_server.go
+++ b/pkg/git/test_git_server.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"fmt"
+	config2 "github.com/go-git/go-git/v5/config"
 	"log"
 	"net"
 	"net/http"
@@ -84,6 +85,15 @@ func (p *TestGitServer) GitInit(repo string) {
 	if err != nil {
 		p.t.Fatal(err)
 	}
+
+	_, err = r.CreateRemote(&config2.RemoteConfig{
+		Name: "origin",
+		URLs: []string{p.GitRepoUrl(repo)},
+	})
+	if err != nil {
+		p.t.Fatal(err)
+	}
+
 	config, err := r.Config()
 	if err != nil {
 		p.t.Fatal(err)


### PR DESCRIPTION
# Description

This implements the `--prune` flag for the deploy command and changes the controller to perform pruning as part of the deploy phase.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
