### PR TITLE
fix: Set seccompProfile for controller deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,13 +58,8 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: controller
         image: ghcr.io/kluctl/kluctl:latest

--- a/install/controller/controller/manager.yaml
+++ b/install/controller/controller/manager.yaml
@@ -73,5 +73,7 @@ spec:
             - ALL
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kluctl-controller
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
# Description
This PR sets the seccompProfile of the controller deployment to comply with the restricted PodSecurity policy.

Fixes #569 

I have tested that it deploys successfully without the previously present warning and continues working once deployed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)