### PR TITLE
feat: Implement webui impersonation and add a deployment for the webui

### DIFF
--- a/cmd/kluctl/commands/cmd_webui.go
+++ b/cmd/kluctl/commands/cmd_webui.go
@@ -84,6 +84,9 @@ func (cmd *webuiCmd) createResultStores(ctx context.Context) ([]results.ResultSt
 		for name, _ := range kcfg.Contexts {
 			contexts = append(contexts, name)
 		}
+	} else if cmd.InCluster {
+		// placeholder for current context
+		contexts = append(contexts, "")
 	} else {
 		if len(cmd.Context) == 0 {
 			// placeholder for current context

--- a/cmd/kluctl/commands/root.go
+++ b/cmd/kluctl/commands/root.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/pprof"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"strings"
 	"time"
 
@@ -110,7 +111,7 @@ func redirectLogsAndStderr(ctxGetter func() context.Context) {
 	klog.LogToStderr(false)
 	klog.SetOutput(lr1)
 	log.SetOutput(lr2)
-	//ctrl.SetLogger(klog.NewKlogr())
+	ctrl.SetLogger(klog.NewKlogr())
 
 	pr, pw, err := os.Pipe()
 	if err != nil {

--- a/hack/prepare-release.sh
+++ b/hack/prepare-release.sh
@@ -24,7 +24,11 @@ fi
 
 echo VERSION=$VERSION
 
-FILES="install/controller/.kluctl.yaml install/controller/controller/kustomization.yaml docs/installation.md"
+FILES=""
+FILES="$FILES install/controller/.kluctl.yaml"
+FILES="$FILES install/controller/controller/kustomization.yaml"
+FILES="$FILES install/webui/.kluctl.yaml"
+FILES="$FILES docs/installation.md"
 
 for f in $FILES; do
   cat $f | sed "s/$VERSION_REGEX_SED/$VERSION/g" > $f.tmp

--- a/install/webui/.kluctl.yaml
+++ b/install/webui/.kluctl.yaml
@@ -1,0 +1,9 @@
+discriminator: kluctl.io-webui
+
+args:
+  - name: kluctl_version
+    default: v2.20.4
+  - name: webui_args
+    default: []
+  - name: webui_envs
+    default: []

--- a/install/webui/deployment.yaml
+++ b/install/webui/deployment.yaml
@@ -1,0 +1,3 @@
+
+deployments:
+  - path: webui

--- a/install/webui/webui/admin-rbac.yaml
+++ b/install/webui/webui/admin-rbac.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kluctl-webui-admin-role
+rules:
+  - apiGroups:
+      - gitops.kluctl.io
+    resources:
+      - kluctldeployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  # Read access for all other Kubernetes objects
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: controller
+    app.kubernetes.io/instance: kluctl-webui-rolebinding
+    app.kubernetes.io/managed-by: kluctl
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: controller
+  name: kluctl-webui-admin-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kluctl-webui-admin-role
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: kluctl-webui-admin

--- a/install/webui/webui/deployment.yaml
+++ b/install/webui/webui/deployment.yaml
@@ -1,0 +1,65 @@
+{% set kluctl_version = get_var("args.kluctl_version", "v2.20.4") %}
+{% set pull_policy = "Always" if "-devel" in kluctl_version or "-snapshot" in kluctl_version else "IfNotPresent" %}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: kluctl-webui
+    app.kubernetes.io/instance: kluctl-controller
+    app.kubernetes.io/managed-by: kluctl
+    app.kubernetes.io/name: kluctl-webui
+    control-plane: kluctl-webui
+  name: kluctl-webui
+  namespace: kluctl-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: kluctl-controller
+  template:
+    metadata:
+      labels:
+        control-plane: kluctl-controller
+    spec:
+      containers:
+      - name: webui
+        image: ghcr.io/kluctl/kluctl:{{ kluctl_version }}
+        imagePullPolicy: {{ pull_policy }}
+        command:
+          - kluctl
+          - webui
+          - --in-cluster
+        args: {{ get_var(["args.webui_args", "webui_args"], []) | to_json }}
+        env: {{ get_var(["args.webui_envs", "webui_envs"], []) | to_json }}
+        ports:
+          - containerPort: 8080
+            name: http
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: kluctl-webui
+      terminationGracePeriodSeconds: 10

--- a/install/webui/webui/webui-rbac.yaml
+++ b/install/webui/webui/webui-rbac.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/instance: kluctl-webui-sa
+    app.kubernetes.io/managed-by: kluctl
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: controller
+  name: kluctl-webui
+  namespace: kluctl-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kluctl-webui-cluster-role
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+    # allow access to results
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+    # allow to impersonate other users, groups and serviceaccounts
+  - apiGroups: [""]
+    resources: ["users", "groups", "serviceaccounts"]
+    verbs: ["impersonate"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: controller
+    app.kubernetes.io/instance: kluctl-webui-rolebinding
+    app.kubernetes.io/managed-by: kluctl
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: controller
+  name: kluctl-webui-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kluctl-webui-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: kluctl-webui
+    namespace: kluctl-system

--- a/pkg/controllers/kluctl_project.go
+++ b/pkg/controllers/kluctl_project.go
@@ -760,7 +760,7 @@ func (pt *preparedTarget) kluctlDelete(ctx context.Context, discriminator string
 	if err != nil {
 		return nil, err
 	}
-	clientFactory, err := k8s2.NewClientFactory(ctx, restConfig)
+	clientFactory, err := k8s2.NewClientFactoryFromConfig(ctx, restConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/k8s/k8s_cluster.go
+++ b/pkg/k8s/k8s_cluster.go
@@ -78,26 +78,6 @@ func (k *K8sCluster) ReadWrite() *K8sCluster {
 	return &k2
 }
 
-func (k *K8sCluster) GetCA() []byte {
-	return k.clientFactory.GetCA()
-}
-
-func (k *K8sCluster) buildLabelSelector(labels map[string]string) string {
-	ret := ""
-
-	for k, v := range labels {
-		if len(ret) != 0 {
-			ret += ","
-		}
-		if v == "" {
-			ret += k
-		} else {
-			ret += fmt.Sprintf("%s=%s", k, v)
-		}
-	}
-	return ret
-}
-
 func (k *K8sCluster) doList(l client.ObjectList, namespace string, labels map[string]string) ([]*uo.UnstructuredObject, []ApiWarning, error) {
 	apiWarnings, err := k.clients.withCClientFromPool(true, func(c client.Client) error {
 		return c.List(k.ctx, l, client.InNamespace(namespace), client.MatchingLabels(labels))

--- a/pkg/kluctl_project/target_context.go
+++ b/pkg/kluctl_project/target_context.go
@@ -98,7 +98,7 @@ func (p *LoadedKluctlProject) NewTargetContext(ctx context.Context, params Targe
 	var k *k8s.K8sCluster
 	if clientConfig != nil {
 		s := status.Start(ctx, fmt.Sprintf("Initializing k8s client"))
-		clientFactory, err := k8s.NewClientFactory(ctx, clientConfig)
+		clientFactory, err := k8s.NewClientFactoryFromConfig(ctx, clientConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -29,11 +29,13 @@ type authHandler struct {
 
 	serverClient    client.Client
 	webuiSecretName string
+	adminRbacUser   string
 }
 
 type User struct {
 	Username string `json:"username"`
 	IsAdmin  bool   `json:"isAdmin"`
+	RbacUser string `json:"RbacUser"`
 }
 
 func (s *authHandler) setupAuth(r gin.IRouter) error {
@@ -223,6 +225,7 @@ func (s *authHandler) getAdminUserFromClaims(claims jwt.MapClaims) *User {
 	return &User{
 		Username: id,
 		IsAdmin:  true,
+		RbacUser: s.adminRbacUser,
 	}
 }
 

--- a/pkg/webui/clusteraccessor.go
+++ b/pkg/webui/clusteraccessor.go
@@ -5,10 +5,14 @@ import (
 	kluctlv1 "github.com/kluctl/kluctl/v2/api/v1beta1"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/k8s"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sync"
 	"time"
 )
@@ -19,12 +23,14 @@ type clusterAccessorManager struct {
 }
 
 type clusterAccessor struct {
-	ctx       context.Context
-	config    *rest.Config
-	client    client.Client
-	k         *k8s2.K8sCluster
-	clusterId string
-	mutex     sync.Mutex
+	ctx        context.Context
+	config     *rest.Config
+	httpClient *http.Client
+	scheme     *runtime.Scheme
+	discovery  discovery.DiscoveryInterface
+	mapper     meta.RESTMapper
+	clusterId  string
+	mutex      sync.Mutex
 }
 
 func (cam *clusterAccessorManager) add(config *rest.Config) {
@@ -64,6 +70,9 @@ func (ca *clusterAccessor) initClient() {
 }
 
 func (ca *clusterAccessor) tryInitClient() error {
+	ca.mutex.Lock()
+	defer ca.mutex.Unlock()
+
 	scheme := runtime.NewScheme()
 	err := clientgoscheme.AddToScheme(scheme)
 	if err != nil {
@@ -73,33 +82,37 @@ func (ca *clusterAccessor) tryInitClient() error {
 	if err != nil {
 		return err
 	}
+	ca.scheme = scheme
 
-	c, err := client.New(ca.config, client.Options{
-		Scheme: scheme,
-	})
+	httpClient, err := rest.HTTPClientFor(ca.config)
 	if err != nil {
 		return err
 	}
+	ca.httpClient = httpClient
+
+	dc, err := k8s2.CreateDiscoveryClient(context.Background(), ca.config)
+	if err != nil {
+		return err
+	}
+	ca.discovery = dc
+
+	mapper, err := apiutil.NewDynamicRESTMapper(ca.config, ca.httpClient)
+	if err != nil {
+		return err
+	}
+	ca.mapper = mapper
+
+	c, err := ca.getClientLocked("", nil)
+	if err != nil {
+		return err
+	}
+
 	var ns corev1.Namespace
 	err = c.Get(context.Background(), client.ObjectKey{Name: "kube-system"}, &ns)
 	if err != nil {
 		return err
 	}
 
-	cf, err := k8s2.NewClientFactory(context.Background(), ca.config)
-	if err != nil {
-		return err
-	}
-
-	k, err := k8s2.NewK8sCluster(context.Background(), cf, true)
-	if err != nil {
-		return err
-	}
-
-	ca.mutex.Lock()
-	defer ca.mutex.Unlock()
-	ca.client = c
-	ca.k = k
 	ca.clusterId = string(ns.UID)
 
 	return nil
@@ -111,14 +124,40 @@ func (ca *clusterAccessor) getClusterId() string {
 	return ca.clusterId
 }
 
-func (ca *clusterAccessor) getClient() client.Client {
+func (ca *clusterAccessor) getClient(asUser string, asGroups []string) (client.Client, error) {
 	ca.mutex.Lock()
 	defer ca.mutex.Unlock()
-	return ca.client
+	return ca.getClientLocked(asUser, asGroups)
 }
 
-func (ca *clusterAccessor) getK() *k8s2.K8sCluster {
+func (ca *clusterAccessor) getClientLocked(asUser string, asGroups []string) (client.Client, error) {
+	config := rest.CopyConfig(ca.config)
+	config.Impersonate.UserName = asUser
+	config.Impersonate.Groups = asGroups
+
+	c, err := client.New(config, client.Options{
+		HTTPClient: ca.httpClient,
+		Scheme:     ca.scheme,
+		Mapper:     ca.mapper,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (ca *clusterAccessor) getK(ctx context.Context, asUser string, asGroups []string) (*k8s2.K8sCluster, error) {
 	ca.mutex.Lock()
 	defer ca.mutex.Unlock()
-	return ca.k
+
+	config := rest.CopyConfig(ca.config)
+	config.Impersonate.UserName = asUser
+	config.Impersonate.Groups = asGroups
+
+	cf, err := k8s2.NewClientFactory(ctx, config, ca.httpClient, ca.discovery, ca.mapper)
+	if err != nil {
+		return nil, err
+	}
+
+	return k8s2.NewK8sCluster(ctx, cf, false)
 }


### PR DESCRIPTION
# Description

This is the start of the impersonation implementation that will later also impersonate groups, mapped via OIDC. For now, it only impersonates the kluctl-webui-admin RBAC user.

This PR also adds a deployment for the webui.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
