### PR TITLE
feat: Enable writing of command results by default

### DIFF
--- a/cmd/kluctl/args/project.go
+++ b/cmd/kluctl/args/project.go
@@ -44,7 +44,7 @@ type TargetFlags struct {
 }
 
 type CommandResultFlags struct {
-	WriteCommandResult      bool   `group:"results" help:"Enable writing of command results into the cluster."`
+	WriteCommandResult      bool   `group:"results" help:"Enable writing of command results into the cluster. This is enabled by default." default:"true"`
 	ForceWriteCommandResult bool   `group:"results" help:"Force writing of command results, even if the command is run in dry-run mode."`
 	CommandResultNamespace  string `group:"results" help:"Override the namespace to be used when writing command results." default:"kluctl-results"`
 	KeepCommandResultsCount int    `group:"results" help:"Configure how many old command results to keep." default:"10"`

--- a/docs/reference/commands/common-arguments.md
+++ b/docs/reference/commands/common-arguments.md
@@ -138,7 +138,8 @@ Command Results:
                                           "kluctl-results")
       --force-write-command-result        Force writing of command results, even if the command is run in dry-run mode.
       --keep-command-results-count int    Configure how many old command results to keep. (default 10)
-      --write-command-result              Enable writing of command results into the cluster.
+      --write-command-result              Enable writing of command results into the cluster. This is enabled by
+                                          default. (default true)
 
 ```
 <!-- END SECTION -->

--- a/e2e/gitops_test.go
+++ b/e2e/gitops_test.go
@@ -101,7 +101,6 @@ func (suite *GitopsTestSuite) startController() {
 		tmpKubeconfig,
 		"--context",
 		"context1",
-		"--write-command-result",
 	}
 	done := make(chan struct{})
 	go func() {

--- a/e2e/results_test.go
+++ b/e2e/results_test.go
@@ -39,7 +39,7 @@ func TestWriteResult(t *testing.T) {
 		name:      "cm",
 		namespace: p.TestSlug(),
 	})
-	p.KluctlMust("deploy", "--yes", "-t", "test", "--write-command-result")
+	p.KluctlMust("deploy", "--yes", "-t", "test")
 	assertConfigMapExists(t, k, p.TestSlug(), "cm")
 
 	rs, err := results.NewResultStoreSecrets(context.Background(), k.Client, "kluctl-results", 0)
@@ -67,7 +67,7 @@ func TestWriteResult(t *testing.T) {
 		_ = o.SetNestedField("v2", "data", "d1")
 		return nil
 	}, "")
-	p.KluctlMust("deploy", "--yes", "-t", "test", "--write-command-result")
+	p.KluctlMust("deploy", "--yes", "-t", "test")
 	assertConfigMapExists(t, k, p.TestSlug(), "cm2")
 
 	summaries, err = rs.ListCommandResultSummaries(opts)
@@ -84,7 +84,7 @@ func TestWriteResult(t *testing.T) {
 		_ = o.RemoveNestedField("deployments", 1)
 		return nil
 	})
-	p.KluctlMust("deploy", "--yes", "-t", "test", "--write-command-result")
+	p.KluctlMust("deploy", "--yes", "-t", "test")
 	assertConfigMapExists(t, k, p.TestSlug(), "cm2")
 
 	summaries, err = rs.ListCommandResultSummaries(opts)
@@ -95,7 +95,7 @@ func TestWriteResult(t *testing.T) {
 		OrphanObjects:  1,
 	}, summaries[0])
 
-	p.KluctlMust("prune", "--yes", "-t", "test", "--write-command-result")
+	p.KluctlMust("prune", "--yes", "-t", "test")
 	assertConfigMapNotExists(t, k, p.TestSlug(), "cm2")
 
 	summaries, err = rs.ListCommandResultSummaries(opts)


### PR DESCRIPTION
# Description

Command results will be written by default from now on. This way, the webui can show all past results.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
