### PR TITLE
fix: Enforce LF line-ending for .svg files

### DIFF
--- a/pkg/webui/ui/.gitattributes
+++ b/pkg/webui/ui/.gitattributes
@@ -1,0 +1,1 @@
+*.svg text eol=lf


### PR DESCRIPTION
# Description

As seen in #584, Git on Windows converts line-endings in .svg files which results in content hashes to change, which in turn results in different build results as observed on Linux/Mac. This PR fixes this by enforcing LF on .svg files.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
