### PR TITLE
fix: Add some tracing when the worktree or index is unclean

### DIFF
--- a/cmd/kluctl/commands/cmd_helm_update.go
+++ b/cmd/kluctl/commands/cmd_helm_update.go
@@ -61,9 +61,11 @@ func (cmd *helmUpdateCmd) Run(ctx context.Context) error {
 		}
 		for pth, s := range gitStatus {
 			if strings.HasPrefix(pth, ".helm-charts/") {
+				status.Trace(ctx, "gitStatus=%s", gitStatus.String())
 				return fmt.Errorf("--commit can only be used when .helm-chart directory is clean")
 			}
 			if (s.Staging != git.Untracked && s.Staging != git.Unmodified) || (s.Worktree != git.Untracked && s.Worktree != git.Unmodified) {
+				status.Trace(ctx, "gitStatus=%s", gitStatus.String())
 				return fmt.Errorf("--commit can only be used when the git worktree is unmodified")
 			}
 		}


### PR DESCRIPTION
# Description

This adds some tracing to find an incompatibility between go-git and git.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
