### PR TITLE
fix: Allow to run render without a KUBECONFIG being present

### DIFF
--- a/e2e/render_test.go
+++ b/e2e/render_test.go
@@ -1,0 +1,61 @@
+package e2e
+
+import (
+	test_utils "github.com/kluctl/kluctl/v2/e2e/test-utils"
+	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
+	"github.com/kluctl/kluctl/v2/pkg/yaml"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRenderPrintAll(t *testing.T) {
+	t.Parallel()
+
+	p := test_utils.NewTestProject(t)
+
+	p.UpdateTarget("test", func(target *uo.UnstructuredObject) {
+	})
+
+	addConfigMapDeployment(p, "cm", nil, resourceOpts{
+		name:      "cm",
+		namespace: p.TestSlug(),
+	})
+
+	stdout, _ := p.KluctlMust("render", "-t", "test", "--print-all")
+	y, err := yaml.ReadYamlAllString(stdout)
+	assert.NoError(t, err)
+	assert.Equal(t, []any{map[string]any{
+		"apiVersion": "v1",
+		"kind":       "ConfigMap",
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{"kluctl.io/deployment-item-dir": "cm"},
+			"labels": map[string]interface{}{
+				"kluctl.io/discriminator": p.Discriminator("test"),
+				"kluctl.io/tag-0":         "cm",
+				"project_name":            p.TestSlug(),
+			},
+			"name":      "cm",
+			"namespace": "test-render-print-all",
+		}}}, y)
+}
+
+func TestRenderNoKubeconfig(t *testing.T) {
+	t.Setenv("KUBECONFIG", "invalid")
+
+	p := test_utils.NewTestProject(t)
+
+	addConfigMapDeployment(p, "cm", nil, resourceOpts{
+		name:      "cm",
+		namespace: p.TestSlug(),
+	})
+
+	_, stderr := p.KluctlMust("render", "--print-all")
+	assert.Contains(t, stderr, "No valid KUBECONFIG provided, which means the Kubernetes client is not available")
+
+	p.UpdateTarget("test", func(target *uo.UnstructuredObject) {
+		_ = target.SetNestedField("context1", "context")
+	})
+	_, stderr, _ = p.Kluctl("render", "-t", "test", "--print-all")
+	assert.Contains(t, stderr, "context \"context1\" does not exist")
+
+}

--- a/e2e/test-utils/project.go
+++ b/e2e/test-utils/project.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	registry2 "helm.sh/helm/v3/pkg/registry"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"net/url"
 	"os"
 	"os/exec"
@@ -82,7 +81,7 @@ func NewTestProject(t *testing.T, opts ...TestProjectOption) *TestProject {
 
 	if !p.bare {
 		p.UpdateKluctlYaml(func(o *uo.UnstructuredObject) error {
-			_ = o.SetNestedField(fmt.Sprintf("%s-{{ target.name or 'no-name' }}", rand.String(16)), "discriminator")
+			_ = o.SetNestedField(fmt.Sprintf("%s-{{ target.name or 'no-name' }}", p.TestSlug()), "discriminator")
 			return nil
 		})
 		p.UpdateDeploymentYaml(".", func(c *uo.UnstructuredObject) error {
@@ -101,6 +100,13 @@ func (p *TestProject) TestSlug() string {
 	n = xstrings.ToKebabCase(n)
 	n = strings.ReplaceAll(n, "/", "-")
 	return n
+}
+
+func (p TestProject) Discriminator(targetName string) string {
+	if targetName == "" {
+		targetName = "no-name"
+	}
+	return fmt.Sprintf("%s-%s", p.TestSlug(), targetName)
 }
 
 func (p *TestProject) AddExtraEnv(e string) {

--- a/pkg/kluctl_project/target_context.go
+++ b/pkg/kluctl_project/target_context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/vars"
 	"github.com/kluctl/kluctl/v2/pkg/vars/aws"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 	"path/filepath"
 )
@@ -168,6 +169,10 @@ func (p *LoadedKluctlProject) loadK8sConfig(target *types.Target, offlineK8s boo
 	var restConfig *api.Config
 	clientConfig, restConfig, err = p.LoadArgs.ClientConfigGetter(contextName)
 	if err != nil {
+		if contextName == nil && clientcmd.IsEmptyConfig(err) {
+			status.Warning(p.ctx, "No valid KUBECONFIG provided, which means the Kubernetes client is not available. Depending on your deployment project, this might cause follow-up errors.")
+			return nil, "", nil
+		}
 		return nil, "", err
 	}
 	if contextName == nil {


### PR DESCRIPTION
# Description

This allows to call render without any kubeconfig available.

Fixes #599

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
