### PR TITLE
fix: Upgrade go-jinja2 to fix symlinks handling in RenderDirectory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/jinzhu/copier v0.3.5
 	github.com/kevinburke/ssh_config v1.2.0
 	github.com/kluctl/go-embed-python v0.0.0-3.10.9-20230206-2
-	github.com/kluctl/go-jinja2 v0.0.0-20230428103343-a832225dc94c
+	github.com/kluctl/go-jinja2 v0.0.0-20230625212202-e9c395af7587
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.19
 	github.com/mattn/go-runewidth v0.0.14

--- a/go.sum
+++ b/go.sum
@@ -554,8 +554,8 @@ github.com/klauspost/cpuid/v2 v2.2.4 h1:acbojRNwl3o09bUq+yDCtZFc1aiwaAAxtcn8YkZX
 github.com/klauspost/cpuid/v2 v2.2.4/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/kluctl/go-embed-python v0.0.0-3.10.9-20230206-2 h1:K96SwIr8MzBQ3kFFz2H/pA2y+EEk04vZ4fWj/YZghBU=
 github.com/kluctl/go-embed-python v0.0.0-3.10.9-20230206-2/go.mod h1:vzngsPshNKUtq0gxkYQKNJafrcH7Qy7Qt6yGNt7JmQI=
-github.com/kluctl/go-jinja2 v0.0.0-20230428103343-a832225dc94c h1:qAIvhYamCEU/tY6NaENEIQCynGV5sdON7zgZKnbrhhw=
-github.com/kluctl/go-jinja2 v0.0.0-20230428103343-a832225dc94c/go.mod h1:16hIQ1ibrf02WYqeCPggfIBQx23lTUQ+jlk5kJGF0xI=
+github.com/kluctl/go-jinja2 v0.0.0-20230625212202-e9c395af7587 h1:sp9BhXobMzmd1qwbbQSIUMpj6ivDE+tYf3FeYVNvTLw=
+github.com/kluctl/go-jinja2 v0.0.0-20230625212202-e9c395af7587/go.mod h1:yIf5kSdssmZghhQZPG0XcM6nXtvuV+K4Ag8ijMyHnfM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kortschak/utter v1.0.1/go.mod h1:vSmSjbyrlKjjsL71193LmzBOKgwePk9DH6uFaWHIInc=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=


### PR DESCRIPTION
# Description

This upgrades go-jinja2 to the latest main version, which contains a fix for the handling of symlinks in RenderDirectory. Symlinks are now simply re-created in the target directory.

Fixes #474

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
