### PR TITLE
fix: Add non-generated version of GitRef to react code that supports loading a string

### DIFF
--- a/pkg/webui/generate-ts/main.go
+++ b/pkg/webui/generate-ts/main.go
@@ -20,11 +20,14 @@ func main() {
 		Add(uo.UnstructuredObject{}).
 		Add(webui.ProjectTargetKey{}).
 		ManageType(types.GitUrl{}, typescriptify.TypeOptions{TSType: "string"}).
+		ManageType(types.GitRef{}, typescriptify.TypeOptions{TSType: "GitRef", TSTransform: "new GitRef(__VALUE__)"}).
 		ManageType(types.GitRepoKey{}, typescriptify.TypeOptions{TSType: "string"}).
 		ManageType(types.YamlUrl{}, typescriptify.TypeOptions{TSType: "string"}).
 		ManageType(uo.UnstructuredObject{}, typescriptify.TypeOptions{TSType: "any"}).
 		ManageType(metav1.Time{}, typescriptify.TypeOptions{TSType: "string"}).
 		ManageType(apiextensionsv1.JSON{}, typescriptify.TypeOptions{TSType: "any"})
+
+	converter.AddImport("import { GitRef } from './models-static'")
 
 	err := converter.ConvertToFile("ui/src/models.ts")
 	if err != nil {

--- a/pkg/webui/ui/src/api.tsx
+++ b/pkg/webui/ui/src/api.tsx
@@ -1,6 +1,6 @@
 import {
     CommandResult,
-    CommandResultSummary, GitRef,
+    CommandResultSummary,
     ObjectRef,
     ProjectKey,
     ResultObject,
@@ -13,6 +13,7 @@ import { Box, Typography } from "@mui/material";
 import Tooltip from "@mui/material/Tooltip";
 import "./staticbuild.d.ts"
 import { loadScript } from "./loadscript";
+import { GitRef } from "./models-static";
 
 console.log(window.location)
 

--- a/pkg/webui/ui/src/models-static.ts
+++ b/pkg/webui/ui/src/models-static.ts
@@ -1,0 +1,19 @@
+export class GitRef {
+    branch?: string;
+    tag?: string;
+    commit?: string;
+
+    ref?: string
+
+    constructor(source: any = {}) {
+        if ('string' === typeof source) {
+            // this is needed to parse legacy string refs
+            this.ref = source
+            return
+        }
+
+        this.branch = source["branch"];
+        this.tag = source["tag"];
+        this.commit = source["commit"];
+    }
+}

--- a/pkg/webui/ui/src/models.ts
+++ b/pkg/webui/ui/src/models.ts
@@ -1,5 +1,6 @@
 /* Do not change, this code is generated from Golang structs */
 
+import { GitRef } from './models-static'
 
 export class DeploymentError {
     ref: ObjectRef;
@@ -157,27 +158,9 @@ export class GitProject {
     constructor(source: any = {}) {
         if ('string' === typeof source) source = JSON.parse(source);
         this.url = source["url"];
-        this.ref = this.convertValues(source["ref"], GitRef);
+        this.ref = new GitRef(source["ref"]);
         this.subDir = source["subDir"];
     }
-
-	convertValues(a: any, classs: any, asMap: boolean = false): any {
-	    if (!a) {
-	        return a;
-	    }
-	    if (a.slice) {
-	        return (a as any[]).map(elem => this.convertValues(elem, classs));
-	    } else if ("object" === typeof a) {
-	        if (asMap) {
-	            for (const key of Object.keys(a)) {
-	                a[key] = new classs(a[key]);
-	            }
-	            return a;
-	        }
-	        return new classs(a);
-	    }
-	    return a;
-	}
 }
 export class DeploymentItemConfig {
     path?: string;
@@ -305,27 +288,9 @@ export class VarsSourceGit {
     constructor(source: any = {}) {
         if ('string' === typeof source) source = JSON.parse(source);
         this.url = source["url"];
-        this.ref = this.convertValues(source["ref"], GitRef);
+        this.ref = new GitRef(source["ref"]);
         this.path = source["path"];
     }
-
-	convertValues(a: any, classs: any, asMap: boolean = false): any {
-	    if (!a) {
-	        return a;
-	    }
-	    if (a.slice) {
-	        return (a as any[]).map(elem => this.convertValues(elem, classs));
-	    } else if ("object" === typeof a) {
-	        if (asMap) {
-	            for (const key of Object.keys(a)) {
-	                a[key] = new classs(a[key]);
-	            }
-	            return a;
-	        }
-	        return new classs(a);
-	    }
-	    return a;
-	}
 }
 export class VarsSource {
     ignoreMissing?: boolean;
@@ -427,18 +392,6 @@ export class ClusterInfo {
         this.clusterId = source["clusterId"];
     }
 }
-export class GitRef {
-    branch?: string;
-    tag?: string;
-    commit?: string;
-
-    constructor(source: any = {}) {
-        if ('string' === typeof source) source = JSON.parse(source);
-        this.branch = source["branch"];
-        this.tag = source["tag"];
-        this.commit = source["commit"];
-    }
-}
 export class GitInfo {
     url?: string;
     ref?: GitRef;
@@ -449,29 +402,11 @@ export class GitInfo {
     constructor(source: any = {}) {
         if ('string' === typeof source) source = JSON.parse(source);
         this.url = source["url"];
-        this.ref = this.convertValues(source["ref"], GitRef);
+        this.ref = new GitRef(source["ref"]);
         this.subDir = source["subDir"];
         this.commit = source["commit"];
         this.dirty = source["dirty"];
     }
-
-	convertValues(a: any, classs: any, asMap: boolean = false): any {
-	    if (!a) {
-	        return a;
-	    }
-	    if (a.slice) {
-	        return (a as any[]).map(elem => this.convertValues(elem, classs));
-	    } else if ("object" === typeof a) {
-	        if (asMap) {
-	            for (const key of Object.keys(a)) {
-	                a[key] = new classs(a[key]);
-	            }
-	            return a;
-	        }
-	        return new classs(a);
-	    }
-	    return a;
-	}
 }
 export class KluctlDeploymentInfo {
     name: string;


### PR DESCRIPTION
# Description

There are still old command results in some clusters that have string based refs...these need to be properly parsed by the webui as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
