### PR TITLE
fix: Strip bin parent folder from release tarballs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,12 +35,14 @@ archives:
     format: tar.gz
     files:
       - none*
+    strip_parent_binary_folder: true
   - name_template: "{{ .Binary }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     id: windows
     builds: [windows]
     format: zip
     files:
       - none*
+    strip_parent_binary_folder: true
 source:
   enabled: true
   name_template: '{{ .ProjectName }}_v{{ .Version }}_source_code'


### PR DESCRIPTION
# Description

The bin/ parent folder caused the install.sh script to fail.

Fixes #628 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
