### PR TITLE
ci: Use github.head_ref when waiting for preview-run to finish

### DIFF
--- a/.github/workflows/preview-proxy.yml
+++ b/.github/workflows/preview-proxy.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Wait for preview-run to exit
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.head_ref }}
           check-name: 'preview-run'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 10


### PR DESCRIPTION
# Description

Otherwise it tries to wait for the run on the main branch.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
