### PR TITLE
ci: Stop using lewagon/wait-on-check-action and instead ping the ipfs node in a loop

### DIFF
--- a/.github/workflows/preview-proxy.yml
+++ b/.github/workflows/preview-proxy.yml
@@ -122,12 +122,20 @@ jobs:
           message-path: |
             comment.md
       - name: Wait for preview-run to exit
-        uses: lewagon/wait-on-check-action@v1.3.1
-        with:
-          ref: ${{ github.head_ref }}
-          check-name: 'preview-run'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
+        run: |
+          failures=0
+          while true; do
+            if ! ipfs ping $(cat ipfs_id) -n1; then
+              failures=$(($failures+1))
+              if [ "$failures" -ge "5" ]; then
+                break
+              fi
+              sleep 5
+            else
+              sleep 10
+              failures=0
+            fi
+          done
       - name: Cleanup cloudflare tunnel
         if: ${{ always() }}
         run: |

--- a/.github/workflows/preview-run.yml
+++ b/.github/workflows/preview-run.yml
@@ -148,7 +148,7 @@ jobs:
             -pr-number ${{ github.event.pull_request.number }} \
             -age-pub-key age1dhueesr5qj8e8uy298k7z8x3ntv620rde89phumg0kvjx2t32elsm759z7
         env:
-          # we send the GITHUB_TOKEN to the preview-comment workflow. This token is then verified to be from a workflow
+          # we send the GITHUB_TOKEN to the preview-proxy workflow. This token is then verified to be from a workflow
           # that runs inside this repo, which can only be a workflow that got manually approved. The token is encrypted
           # via age
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

I did not find a way to reliably get the ref of the head from the source PR. This solution is an alternative and should be good enough.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
