### PR TITLE
feat: Add --concurrency flag to controller run

### DIFF
--- a/cmd/kluctl/commands/cmd_controller_run.go
+++ b/cmd/kluctl/commands/cmd_controller_run.go
@@ -142,9 +142,7 @@ func (cmd *controllerRunCmd) Run(ctx context.Context) error {
 		r.ResultStore = resultStore
 	}
 
-	if err = r.SetupWithManager(ctx, mgr, controllers.KluctlDeploymentReconcilerOpts{
-		HTTPRetry: 9,
-	}); err != nil {
+	if err = r.SetupWithManager(ctx, mgr, controllers.KluctlDeploymentReconcilerOpts{}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", kluctlv1.KluctlDeploymentKind)
 		os.Exit(1)
 	}

--- a/cmd/kluctl/commands/cmd_controller_run.go
+++ b/cmd/kluctl/commands/cmd_controller_run.go
@@ -42,6 +42,7 @@ type controllerRunCmd struct {
 	MetricsBindAddress     string `group:"misc" help:"The address the metric endpoint binds to." default:":8080"`
 	HealthProbeBindAddress string `group:"misc" help:"The address the probe endpoint binds to." default:":8081"`
 	LeaderElect            bool   `group:"misc" help:"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager."`
+	Concurrency            int    `group:"misc" help:"Configures how many KluctlDeployments can be be reconciled concurrently." default:"4"`
 
 	DefaultServiceAccount string `group:"misc" help:"Default service account used for impersonation."`
 	DryRun                bool   `group:"misc" help:"Run all deployments in dryRun=true mode."`
@@ -142,7 +143,9 @@ func (cmd *controllerRunCmd) Run(ctx context.Context) error {
 		r.ResultStore = resultStore
 	}
 
-	if err = r.SetupWithManager(ctx, mgr, controllers.KluctlDeploymentReconcilerOpts{}); err != nil {
+	if err = r.SetupWithManager(ctx, mgr, controllers.KluctlDeploymentReconcilerOpts{
+		Concurrency: cmd.Concurrency,
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", kluctlv1.KluctlDeploymentKind)
 		os.Exit(1)
 	}

--- a/docs/reference/commands/controller-run.md
+++ b/docs/reference/commands/controller-run.md
@@ -26,6 +26,8 @@ The following arguments are available:
 Misc arguments:
   Command specific arguments.
 
+      --concurrency int                    Configures how many KluctlDeployments can be be reconciled
+                                           concurrently. (default 4)
       --context string                     Override the context to use.
       --default-service-account string     Default service account used for impersonation.
       --dry-run                            Run all deployments in dryRun=true mode.

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,6 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/huandu/xstrings v1.4.0
 	github.com/onsi/gomega v1.27.8
 	github.com/otiai10/copy v1.12.0
@@ -166,6 +165,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.4.0 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.4 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect

--- a/pkg/controllers/kluctldeployment_controller.go
+++ b/pkg/controllers/kluctldeployment_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	errors2 "errors"
 	"fmt"
-	"github.com/hashicorp/go-retryablehttp"
 	kluctlv1 "github.com/kluctl/kluctl/v2/api/v1beta1"
 	internal_metrics "github.com/kluctl/kluctl/v2/pkg/controllers/metrics"
 	ssh_pool "github.com/kluctl/kluctl/v2/pkg/git/ssh-pool"
@@ -36,8 +35,6 @@ import (
 type KluctlDeploymentReconciler struct {
 	client.Client
 	RestConfig            *rest.Config
-	httpClient            *retryablehttp.Client
-	requeueDependency     time.Duration
 	Scheme                *runtime.Scheme
 	EventRecorder         kuberecorder.EventRecorder
 	MetricsRecorder       *metrics.Recorder
@@ -52,7 +49,6 @@ type KluctlDeploymentReconciler struct {
 
 // KluctlDeploymentReconcilerOpts contains options for the BaseReconciler.
 type KluctlDeploymentReconcilerOpts struct {
-	HTTPRetry int
 }
 
 // +kubebuilder:rbac:groups=gitops.kluctl.io,resources=kluctldeployments,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controllers/kluctldeployment_controller.go
+++ b/pkg/controllers/kluctldeployment_controller.go
@@ -49,6 +49,7 @@ type KluctlDeploymentReconciler struct {
 
 // KluctlDeploymentReconcilerOpts contains options for the BaseReconciler.
 type KluctlDeploymentReconcilerOpts struct {
+	Concurrency int
 }
 
 // +kubebuilder:rbac:groups=gitops.kluctl.io,resources=kluctldeployments,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controllers/kluctldeployment_controller_setup.go
+++ b/pkg/controllers/kluctldeployment_controller_setup.go
@@ -5,12 +5,16 @@ import (
 	kluctlv1 "github.com/kluctl/kluctl/v2/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KluctlDeploymentReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opts KluctlDeploymentReconcilerOpts) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: opts.Concurrency,
+		}).
 		For(&kluctlv1.KluctlDeployment{}, builder.WithPredicates(
 			predicate.Or(predicate.GenerationChangedPredicate{}, ReconcileRequestedPredicate{}),
 		)).

--- a/pkg/controllers/kluctldeployment_controller_setup.go
+++ b/pkg/controllers/kluctldeployment_controller_setup.go
@@ -2,25 +2,14 @@ package controllers
 
 import (
 	"context"
-	"github.com/hashicorp/go-retryablehttp"
 	kluctlv1 "github.com/kluctl/kluctl/v2/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"time"
 )
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *KluctlDeploymentReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opts KluctlDeploymentReconcilerOpts) error {
-	// Configure the retryable http client used for fetching artifacts.
-	// By default it retries 10 times within a 3.5 minutes window.
-	httpClient := retryablehttp.NewClient()
-	httpClient.RetryWaitMin = 5 * time.Second
-	httpClient.RetryWaitMax = 30 * time.Second
-	httpClient.RetryMax = opts.HTTPRetry
-	httpClient.Logger = nil
-	r.httpClient = httpClient
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kluctlv1.KluctlDeployment{}, builder.WithPredicates(
 			predicate.Or(predicate.GenerationChangedPredicate{}, ReconcileRequestedPredicate{}),


### PR DESCRIPTION
# Description

This re-enables concurrent reconciliation and defaults it to 4.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
