### PR TITLE
fix: Use digests for wolfi-base images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,7 +88,8 @@ dockers:
     goarch: amd64
     build_flag_templates:
       - "--pull"
-      - "--build-arg=ARCH=linux-amd64"
+      # use https://registry-ui.chainguard.app/?image=cgr.dev/chainguard/wolfi-base to find the latest one
+      - "--build-arg=WOLFI_DIGEST=sha256:e8411b9629bd13123a978a2d1a27c3ee64c7751d3032ce80ad6e673e329ef964"
       - "--build-arg=BIN_PATH=kluctl"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.name={{ .ProjectName }}"
@@ -103,7 +104,8 @@ dockers:
     goarch: arm64
     build_flag_templates:
       - "--pull"
-      - "--build-arg=ARCH=linux-arm64"
+      # use https://registry-ui.chainguard.app/?image=cgr.dev/chainguard/wolfi-base to find the latest one
+      - "--build-arg=WOLFI_DIGEST=sha256:05a4280b4c5b5cafc7eb2a012983bc79e3ddca938f01ddc3deb797ca3fddd399"
       - "--build-arg=BIN_PATH=kluctl"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.name={{ .ProjectName }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # We must use a glibc based distro due to embedded python not supporting musl libc for aarch64 (only amd64+musl is supported)
 # see https://github.com/indygreg/python-build-standalone/issues/87
-FROM cgr.dev/chainguard/wolfi-base
+ARG WOLFI_DIGEST
+FROM cgr.dev/chainguard/wolfi-base@$WOLFI_DIGEST
 
 # We need git for kustomize to support overlays from git
 RUN apk add git


### PR DESCRIPTION
# Description

Chainguard will forbid using latest tags in the future, so we should switch to digests asap. This will hopefull also fix recent CI failures for the nightly build.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
