### PR TITLE
fix: Explicitely decide if status message is formatted or not

### DIFF
--- a/cmd/kluctl/commands/cmd_helm_pull.go
+++ b/cmd/kluctl/commands/cmd_helm_pull.go
@@ -78,7 +78,7 @@ func doHelmPull(ctx context.Context, projectDir string, helmCredentials *args.He
 			if _, ok := versionsToPull[de.Name()]; !ok {
 				actions++
 				if !dryRun {
-					status.Info(ctx, "Removing unused Chart with version %s", de.Name())
+					status.Infof(ctx, "Removing unused Chart with version %s", de.Name())
 					err = os.RemoveAll(filepath.Join(chartsDir, de.Name()))
 					if err != nil {
 						return actions, err
@@ -100,12 +100,12 @@ func doHelmPull(ctx context.Context, projectDir string, helmCredentials *args.He
 				continue
 			}
 			g.RunE(func() error {
-				s := status.Start(ctx, "%s: Pulling Chart with version %s", statusPrefix, version)
+				s := status.Startf(ctx, "%s: Pulling Chart with version %s", statusPrefix, version)
 				defer s.Failed()
 
 				_, err := chart.PullInProject(ctx, baseChartsDir, version)
 				if err != nil {
-					s.FailedWithMessage("%s: %s", statusPrefix, err.Error())
+					s.FailedWithMessagef("%s: %s", statusPrefix, err.Error())
 					return err
 				}
 

--- a/cmd/kluctl/commands/cmd_helm_update.go
+++ b/cmd/kluctl/commands/cmd_helm_update.go
@@ -53,11 +53,11 @@ func (cmd *helmUpdateCmd) Run(ctx context.Context) error {
 		}
 		for pth, s := range gitStatus {
 			if strings.HasPrefix(pth, ".helm-charts/") {
-				status.Trace(ctx, "gitStatus=%s", gitStatus.String())
+				status.Tracef(ctx, "gitStatus=%s", gitStatus.String())
 				return fmt.Errorf("--commit can only be used when .helm-chart directory is clean")
 			}
 			if (s.Staging != git.Untracked && s.Staging != git.Unmodified) || (s.Worktree != git.Untracked && s.Worktree != git.Unmodified) {
-				status.Trace(ctx, "gitStatus=%s", gitStatus.String())
+				status.Tracef(ctx, "gitStatus=%s", gitStatus.String())
 				return fmt.Errorf("--commit can only be used when the git worktree is unmodified")
 			}
 		}
@@ -85,11 +85,11 @@ func (cmd *helmUpdateCmd) Run(ctx context.Context) error {
 	for _, chart := range charts {
 		chart := chart
 		g.RunE(func() error {
-			s := status.Start(ctx, "%s: Querying versions", chart.GetChartName())
+			s := status.Startf(ctx, "%s: Querying versions", chart.GetChartName())
 			defer s.Failed()
 			err := chart.QueryVersions(ctx)
 			if err != nil {
-				s.FailedWithMessage("%s: %s", chart.GetChartName(), err.Error())
+				s.FailedWithMessagef("%s: %s", chart.GetChartName(), err.Error())
 				return err
 			}
 			s.Success()
@@ -115,11 +115,11 @@ func (cmd *helmUpdateCmd) Run(ctx context.Context) error {
 		for version, _ := range versionsToPull {
 			version := version
 			g.RunE(func() error {
-				s := status.Start(ctx, "%s: Downloading Chart with version %s into cache", chart.GetChartName(), version)
+				s := status.Startf(ctx, "%s: Downloading Chart with version %s into cache", chart.GetChartName(), version)
 				defer s.Failed()
 				_, err := chart.PullCached(ctx, version)
 				if err != nil {
-					s.FailedWithMessage("%s: %s", chart.GetChartName(), err.Error())
+					s.FailedWithMessagef("%s: %s", chart.GetChartName(), err.Error())
 					return err
 				}
 				s.Success()
@@ -154,11 +154,11 @@ func (cmd *helmUpdateCmd) Run(ctx context.Context) error {
 		}
 
 		if hr.Config.SkipUpdate {
-			status.Info(ctx, "%s: Skipped update to version %s", relDir, latestVersion)
+			status.Infof(ctx, "%s: Skipped update to version %s", relDir, latestVersion)
 			continue
 		}
 
-		status.Info(ctx, "%s: Chart %s has new version %s available", relDir, hr.Chart.GetChartName(), latestVersion)
+		status.Infof(ctx, "%s: Chart %s has new version %s available", relDir, hr.Chart.GetChartName(), latestVersion)
 
 		if !cmd.Upgrade {
 			continue
@@ -177,7 +177,7 @@ func (cmd *helmUpdateCmd) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		status.Info(ctx, "%s: Updated Chart version to %s", relDir, latestVersion)
+		status.Infof(ctx, "%s: Updated Chart version to %s", relDir, latestVersion)
 
 		k := helmUpgradeKey{
 			chartDir:   cd,
@@ -222,11 +222,11 @@ func (cmd *helmUpdateCmd) pullAndCommit(ctx context.Context, projectDir string, 
 	chart := hrs[0].Chart
 	newVersion := hrs[0].Config.ChartVersion
 
-	s := status.Start(ctx, "Upgrading Chart %s from version %s to %s", chart.GetChartName(), oldVersion, newVersion)
+	s := status.Startf(ctx, "Upgrading Chart %s from version %s to %s", chart.GetChartName(), oldVersion, newVersion)
 	defer s.Failed()
 
 	doError := func(err error) error {
-		s.FailedWithMessage("%s", err.Error())
+		s.FailedWithMessage(err.Error())
 		return err
 	}
 
@@ -311,7 +311,7 @@ func (cmd *helmUpdateCmd) pullAndCommit(ctx context.Context, projectDir string, 
 			return doError(fmt.Errorf("failed to commit: %w", err))
 		}
 
-		s.UpdateAndInfoFallback("Committed helm chart %s with version %s", chart.GetChartName(), newVersion)
+		s.UpdateAndInfoFallbackf("Committed helm chart %s with version %s", chart.GetChartName(), newVersion)
 	}
 	s.Success()
 

--- a/cmd/kluctl/commands/cmd_render.go
+++ b/cmd/kluctl/commands/cmd_render.go
@@ -64,7 +64,7 @@ func (cmd *renderCmd) Run(ctx context.Context) error {
 			status.Flush(cmdCtx.ctx)
 			return yaml.WriteYamlAllStream(getStdout(ctx), all)
 		} else {
-			status.Info(cmdCtx.ctx, "Rendered into %s", cmdCtx.targetCtx.SharedContext.RenderDir)
+			status.Infof(cmdCtx.ctx, "Rendered into %s", cmdCtx.targetCtx.SharedContext.RenderDir)
 		}
 		return nil
 	})

--- a/cmd/kluctl/commands/cmd_seal.go
+++ b/cmd/kluctl/commands/cmd_seal.go
@@ -34,8 +34,8 @@ If no '--target' is specified, sealing is performed for all targets.`
 }
 
 func (cmd *sealCmd) runCmdSealForTarget(ctx context.Context, p *kluctl_project.LoadedKluctlProject, targetName string) error {
-	s := status.Start(ctx, "%s: Sealing for target", targetName)
-	defer s.FailedWithMessage("%s: Sealing failed", targetName)
+	s := status.Startf(ctx, "%s: Sealing for target", targetName)
+	defer s.FailedWithMessagef("%s: Sealing failed", targetName)
 
 	doFail := func(err error) error {
 		s.FailedWithMessage(fmt.Sprintf("Sealing failed: %v", err))
@@ -164,7 +164,7 @@ func (cmd *sealCmd) Run(ctx context.Context) error {
 				continue
 			}
 			if target.SealingConfig == nil {
-				status.Info(ctx, "Target %s has no sealingConfig", target.Name)
+				status.Infof(ctx, "Target %s has no sealingConfig", target.Name)
 				continue
 			}
 			noTargetMatch = false

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -240,7 +240,7 @@ func outputCommandResult(ctx *commandCtx, flags args.OutputFormatFlags, cr *resu
 		defer s.Failed()
 		resultStoreErr = ctx.resultStore.WriteCommandResult(cr)
 		if resultStoreErr != nil {
-			s.FailedWithMessage("Failed to write result to result store: %s", resultStoreErr.Error())
+			s.FailedWithMessagef("Failed to write result to result store: %s", resultStoreErr.Error())
 		} else {
 			s.Success()
 		}

--- a/cmd/kluctl/commands/root.go
+++ b/cmd/kluctl/commands/root.go
@@ -204,16 +204,16 @@ func checkNewVersion(ctx context.Context) {
 	}
 	latestVersion, err := semver.NewVersion(latestVersionStr)
 	if err != nil {
-		s.FailedWithMessage("Failed to parse latest version: %v", err)
+		s.FailedWithMessagef("Failed to parse latest version: %v", err)
 		return
 	}
 	localVersion, err := semver.NewVersion(version.GetVersion())
 	if err != nil {
-		s.FailedWithMessage("Failed to parse local version: %v", err)
+		s.FailedWithMessagef("Failed to parse local version: %v", err)
 		return
 	}
 	if localVersion.LessThan(latestVersion) {
-		s.Update(fmt.Sprintf("You are using an outdated version (%v) of kluctl. You should update soon to version %v", localVersion.String(), latestVersion.String()))
+		s.Updatef("You are using an outdated version (%v) of kluctl. You should update soon to version %v", localVersion.String(), latestVersion.String())
 	} else {
 		s.Update("Your kluctl version is up-to-date")
 	}
@@ -324,7 +324,7 @@ composed of multiple smaller parts (Helm/Kustomize/...) in a manageable and unif
 
 	err = rootCmd.Execute()
 	if err != nil {
-		status.Error(ctx, "%s", err.Error())
+		status.Error(ctx, err.Error())
 		return err
 	}
 	return nil

--- a/pkg/deployment/utils/hooks_util.go
+++ b/pkg/deployment/utils/hooks_util.go
@@ -82,12 +82,12 @@ func (u *HooksUtil) RunHooks(hooks []*hook) {
 		for p := range h.deletePolicies {
 			dpStr = append(dpStr, p)
 		}
-		u.a.sctx.UpdateAndInfoFallback("Deleting hook %s due to hook-delete-policy %s (%d of %d)", ref.String(), strings.Join(dpStr, ","), i+1, cnt)
+		u.a.sctx.UpdateAndInfoFallbackf("Deleting hook %s due to hook-delete-policy %s (%d of %d)", ref.String(), strings.Join(dpStr, ","), i+1, cnt)
 		return u.a.DeleteObject(ref, true)
 	}
 
 	if len(deleteBeforeObjects) != 0 {
-		u.a.sctx.InfoFallback("Deleting %d hooks before hook execution", len(deleteBeforeObjects))
+		u.a.sctx.InfoFallbackf("Deleting %d hooks before hook execution", len(deleteBeforeObjects))
 	}
 	for i, h := range deleteBeforeObjects {
 		doDeleteForPolicy(h, i, len(deleteBeforeObjects))
@@ -95,12 +95,12 @@ func (u *HooksUtil) RunHooks(hooks []*hook) {
 
 	waitResults := make(map[k8s.ObjectRef]bool)
 	if len(applyObjects) != 0 {
-		u.a.sctx.InfoFallback("Applying %d hooks", len(applyObjects))
+		u.a.sctx.InfoFallbackf("Applying %d hooks", len(applyObjects))
 	}
 	for i, h := range applyObjects {
 		ref := h.object.GetK8sRef()
 		_, replaced := h.deletePolicies["before-hook-creation"]
-		u.a.sctx.UpdateAndInfoFallback("Applying hook %s (%d of %d)", ref.String(), i+1, len(applyObjects))
+		u.a.sctx.UpdateAndInfoFallbackf("Applying hook %s (%d of %d)", ref.String(), i+1, len(applyObjects))
 		u.a.ApplyObject(h.object, replaced, true)
 		u.a.sctx.Increment()
 
@@ -133,7 +133,7 @@ func (u *HooksUtil) RunHooks(hooks []*hook) {
 	}
 
 	if len(deleteAfterObjects) != 0 {
-		u.a.sctx.InfoFallback("Deleting %d hooks after hook execution", len(deleteAfterObjects))
+		u.a.sctx.InfoFallbackf("Deleting %d hooks after hook execution", len(deleteAfterObjects))
 	}
 	for i, h := range deleteAfterObjects {
 		doDeleteForPolicy(h, i, len(deleteAfterObjects))

--- a/pkg/deployment/utils/remote_objects_utils.go
+++ b/pkg/deployment/utils/remote_objects_utils.go
@@ -104,7 +104,7 @@ func (u *RemoteObjectUtils) getAllByDiscriminator(k *k8s.K8sCluster, discriminat
 	g.Wait()
 	if g.ErrorOrNil() == nil {
 		if errCount != 0 {
-			s.UpdateAndInfoFallback("%s: Failed with %d errors", baseStatus, errCount)
+			s.UpdateAndInfoFallbackf("%s: Failed with %d errors", baseStatus, errCount)
 			s.Warning()
 			if permissionErrCount != 0 {
 				u.dew.AddWarning(k8s2.ObjectRef{}, fmt.Errorf("at least one permission error was encountered while gathering objects by discriminator labels. This might result in orphan object detection to not work properly"))
@@ -165,7 +165,7 @@ func (u *RemoteObjectUtils) getMissingObjects(k *k8s.K8sCluster, refs []k8s2.Obj
 	g.Wait()
 	if g.ErrorOrNil() == nil {
 		if errCount != 0 {
-			s.UpdateAndInfoFallback("%s: Failed with %d errors", baseStatus, errCount)
+			s.UpdateAndInfoFallbackf("%s: Failed with %d errors", baseStatus, errCount)
 			s.Warning()
 			if permissionErrCount != 0 {
 				u.dew.AddWarning(k8s2.ObjectRef{}, fmt.Errorf("at least one permission error was encountered while gathering known objects. This might result in orphan object detection and diffs to not work properly"))

--- a/pkg/git/mirrored_repo.go
+++ b/pkg/git/mirrored_repo.go
@@ -314,7 +314,7 @@ func (g *MirroredGitRepo) cloneOrUpdate() error {
 			// in that case, retry a full clone which does hopefully not rely on multi_ack.
 			// See https://github.com/go-git/go-git/pull/613
 			// TODO remove this when https://github.com/go-git/go-git/issues/64 gets fully fixed
-			status.Trace(g.ctx, "Got multi_ack related error from remote. Retrying full clone: %v", err)
+			status.Tracef(g.ctx, "Got multi_ack related error from remote. Retrying full clone: %v", err)
 		} else {
 			return err
 		}

--- a/pkg/git/utils.go
+++ b/pkg/git/utils.go
@@ -70,7 +70,7 @@ func GetWorktreeStatus(ctx context.Context, path string) (git.Status, error) {
 
 	commandPath, err := exec.LookPath("git")
 	if err != nil {
-		status.Trace(ctx, "Failed to lookup git binary: %v", err)
+		status.Tracef(ctx, "Failed to lookup git binary: %v", err)
 		return nil, err
 	}
 
@@ -79,13 +79,13 @@ func GetWorktreeStatus(ctx context.Context, path string) (git.Status, error) {
 	cmd := &exec.Cmd{Path: commandPath, Dir: path, Env: os.Environ(), Args: []string{"git", "status", "--porcelain"}, Stdout: out, Stderr: out}
 	err = cmd.Run()
 	if err != nil {
-		status.Trace(ctx, "Failed to run git status --porcelain: err=%v, out=%s", err, out.String())
+		status.Tracef(ctx, "Failed to run git status --porcelain: err=%v, out=%s", err, out.String())
 		return gitStatus, nil
 	}
 
 	parsedStatus, err := parsePorcelainStatus(out.String())
 	if err != nil {
-		status.Trace(ctx, "Failed to parse output of git status --porcelain: %v", err)
+		status.Tracef(ctx, "Failed to parse output of git status --porcelain: %v", err)
 		return gitStatus, err
 	}
 

--- a/pkg/helm/helm_release.go
+++ b/pkg/helm/helm_release.go
@@ -135,7 +135,7 @@ func (hr *Release) getPulledChart(ctx context.Context) (*PulledChart, error) {
 				"Desired version is %s while pre-pulled version is %s", hr.Chart.GetChartName(), hr.Config.ChartVersion, prePulledVersion)
 		}
 
-		s := status.Start(ctx, "Pulling Helm Chart %s with version %s", hr.Chart.GetChartName(), hr.Config.ChartVersion)
+		s := status.Startf(ctx, "Pulling Helm Chart %s with version %s", hr.Chart.GetChartName(), hr.Config.ChartVersion)
 		defer s.Failed()
 
 		pc, err = hr.Chart.PullCached(ctx, hr.Config.ChartVersion)
@@ -231,7 +231,7 @@ func (hr *Release) doRender(ctx context.Context, k *k8s.K8sCluster, k8sVersion s
 	}
 
 	if chartRequested.Metadata.Deprecated {
-		status.Warning(ctx, "Chart %s is deprecated", hr.Config.ChartName)
+		status.Warningf(ctx, "Chart %s is deprecated", hr.Config.ChartName)
 	}
 
 	rel, err := client.Run(chartRequested, vals)

--- a/pkg/k8s/k8s_cluster.go
+++ b/pkg/k8s/k8s_cluster.go
@@ -308,7 +308,7 @@ type PatchOptions struct {
 }
 
 func (k *K8sCluster) doPatch(ref k8s.ObjectRef, obj client.Object, patch client.Patch, options PatchOptions) ([]ApiWarning, error) {
-	status.Trace(k.ctx, "patching %s", ref.String())
+	status.Tracef(k.ctx, "patching %s", ref.String())
 
 	k.crdCacheMutex.Lock()
 	delete(k.crdCache, ref)
@@ -350,7 +350,7 @@ func (k *K8sCluster) UpdateObject(o *uo.UnstructuredObject, options UpdateOption
 	ref := o.GetK8sRef()
 	obj := o.Clone().ToUnstructured()
 
-	status.Trace(k.ctx, "updating %s", ref.String())
+	status.Tracef(k.ctx, "updating %s", ref.String())
 
 	k.crdCacheMutex.Lock()
 	delete(k.crdCache, ref)
@@ -386,7 +386,7 @@ func (k *K8sCluster) envtestProxyGet(scheme, namespace, name, port, path string,
 			continue
 		}
 
-		status.Trace(k.ctx, "envtestProxyGet apiHost=%s, ns=%s, name=%s, port=%s, path=%s, envUrl=%s", apiHost, namespace, name, port, path, envUrl)
+		status.Tracef(k.ctx, "envtestProxyGet apiHost=%s, ns=%s, name=%s, port=%s, path=%s, envUrl=%s", apiHost, namespace, name, port, path, envUrl)
 
 		envUrl = fmt.Sprintf("%s%s", envUrl, path)
 		resp, err := http.Get(envUrl)

--- a/pkg/kluctl_project/targets.go
+++ b/pkg/kluctl_project/targets.go
@@ -16,24 +16,24 @@ func (c *LoadedKluctlProject) loadTargets() error {
 
 	for i, configTarget := range c.Config.Targets {
 		if configTarget.Name == "" {
-			status.Error(c.ctx, "Target at index %d has no name", i)
+			status.Errorf(c.ctx, "Target at index %d has no name", i)
 			continue
 		}
 
 		target, err := c.buildTarget(configTarget)
 		if err != nil {
-			status.Warning(c.ctx, "Failed to load target config for project: %v", err)
+			status.Warningf(c.ctx, "Failed to load target config for project: %v", err)
 			continue
 		}
 
 		err = c.renderTarget(target)
 		if err != nil {
-			status.Warning(c.ctx, "Failed to load target %s: %v", target.Name, err)
+			status.Warningf(c.ctx, "Failed to load target %s: %v", target.Name, err)
 			continue
 		}
 
 		if _, ok := targetNames[target.Name]; ok {
-			status.Warning(c.ctx, "Duplicate target %s", target.Name)
+			status.Warningf(c.ctx, "Duplicate target %s", target.Name)
 		} else {
 			targetNames[target.Name] = true
 			c.Targets = append(c.Targets, target)

--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -114,7 +114,7 @@ func (rh *RegistryHelper) AddAuthEntry(e AuthEntry) {
 func (rh *RegistryHelper) isDefaultInsecure() bool {
 	defaultInsecure, err := utils.ParseEnvBool("KLUCTL_REGISTRY_DEFAULT_INSECURE", false)
 	if err != nil {
-		status.Warning(rh.ctx, "Failed to parse KLUCTL_REGISTRY_DEFAULT_INSECURE: %s", err)
+		status.Warningf(rh.ctx, "Failed to parse KLUCTL_REGISTRY_DEFAULT_INSECURE: %s", err)
 		return false
 	}
 	return defaultInsecure
@@ -123,7 +123,7 @@ func (rh *RegistryHelper) isDefaultInsecure() bool {
 func (rh *RegistryHelper) isDefaultSkipTlsVerify() bool {
 	defaultTlsVerify, err := utils.ParseEnvBool("KLUCTL_REGISTRY_DEFAULT_TLSVERIFY", true)
 	if err != nil {
-		status.Warning(rh.ctx, "Failed to parse KLUCTL_REGISTRY_DEFAULT_TLSVERIFY: %s", err)
+		status.Warningf(rh.ctx, "Failed to parse KLUCTL_REGISTRY_DEFAULT_TLSVERIFY: %s", err)
 		return false
 	}
 	return !defaultTlsVerify
@@ -327,7 +327,7 @@ func (rh *RegistryHelper) readCachedResponse(key string) []byte {
 
 	f, err := lockedfile.OpenFile(cachePath, os.O_RDONLY, 0)
 	if err != nil {
-		status.Warning(rh.ctx, "readCachedResponse failed: %v", err)
+		status.Warningf(rh.ctx, "readCachedResponse failed: %v", err)
 		return nil
 	}
 	b, err := io.ReadAll(f)
@@ -338,7 +338,7 @@ func (rh *RegistryHelper) readCachedResponse(key string) []byte {
 
 	res, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(b)), nil)
 	if err != nil {
-		status.Warning(rh.ctx, "readCachedResponse failed: %v", err)
+		status.Warningf(rh.ctx, "readCachedResponse failed: %v", err)
 		return nil
 	}
 
@@ -361,21 +361,21 @@ func (rh *RegistryHelper) writeCachedResponse(key string, data []byte) {
 	if !utils.Exists(cacheDir) {
 		err := os.MkdirAll(cacheDir, 0o700)
 		if err != nil {
-			status.Warning(rh.ctx, "writeCachedResponse failed: %v", err)
+			status.Warningf(rh.ctx, "writeCachedResponse failed: %v", err)
 			return
 		}
 	}
 
 	f, err := lockedfile.OpenFile(cachePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
-		status.Warning(rh.ctx, "writeCachedResponse failed: %v", err)
+		status.Warningf(rh.ctx, "writeCachedResponse failed: %v", err)
 		return
 	}
 	defer f.Close()
 
 	_, err = f.Write(data)
 	if err != nil {
-		status.Warning(rh.ctx, "writeCachedResponse failed: %v", err)
+		status.Warningf(rh.ctx, "writeCachedResponse failed: %v", err)
 		return
 	}
 }

--- a/pkg/repocache/cache.go
+++ b/pkg/repocache/cache.go
@@ -124,7 +124,7 @@ func (rp *GitRepoCache) GetEntry(url types.GitUrl) (*CacheEntry, error) {
 			return nil, fmt.Errorf("can not override repo %s. %s is not a directory", url.String(), overridePath)
 		}
 
-		status.WarningOnce(rp.ctx, fmt.Sprintf("git-override-%s", repoKey), "Overriding git repo %s with local directory %s", url.String(), overridePath)
+		status.WarningOncef(rp.ctx, fmt.Sprintf("git-override-%s", repoKey), "Overriding git repo %s with local directory %s", url.String(), overridePath)
 
 		e := &CacheEntry{
 			rp:           rp,
@@ -177,7 +177,7 @@ func (e *CacheEntry) Update() error {
 			e.mr.SetUpdated(true)
 		} else {
 			url := e.mr.Url()
-			s := status.Start(e.rp.ctx, "Updating git cache for %s", url.String())
+			s := status.Startf(e.rp.ctx, "Updating git cache for %s", url.String())
 			defer s.Failed()
 			err := e.mr.Update()
 			if err != nil {

--- a/pkg/results/result-store-secrets.go
+++ b/pkg/results/result-store-secrets.go
@@ -273,9 +273,9 @@ func (s *ResultStoreSecrets) cleanupCommandResults(project result.ProjectKey, ta
 				"kluctl.io/command-result-id": rs.Id,
 			})
 			if err != nil {
-				status.Warning(s.ctx, "Failed to delete old command result %s: %s", rs.Id, err)
+				status.Warningf(s.ctx, "Failed to delete old command result %s: %s", rs.Id, err)
 			} else {
-				status.Info(s.ctx, "Deleted old command result %s", rs.Id)
+				status.Infof(s.ctx, "Deleted old command result %s", rs.Id)
 			}
 		}
 	}
@@ -304,9 +304,9 @@ func (s *ResultStoreSecrets) cleanupValidateResults(project result.ProjectKey, t
 				"kluctl.io/validate-result-id": rs.Id,
 			})
 			if err != nil {
-				status.Warning(s.ctx, "Failed to delete old validate result %s: %s", rs.Id, err)
+				status.Warningf(s.ctx, "Failed to delete old validate result %s: %s", rs.Id, err)
 			} else {
-				status.Info(s.ctx, "Deleted old validate result %s", rs.Id)
+				status.Infof(s.ctx, "Deleted old validate result %s", rs.Id)
 			}
 		}
 	}

--- a/pkg/seal/sealer.go
+++ b/pkg/seal/sealer.go
@@ -262,10 +262,10 @@ func (s *Sealer) sealSecret(o *uo.UnstructuredObject, existing *sealedSecret) (*
 	resealAll := false
 	if s.forceReseal {
 		resealAll = true
-		status.Info(s.ctx, "Forcing reseal of secrets in %s", secretName)
+		status.Infof(s.ctx, "Forcing reseal of secrets in %s", secretName)
 	} else if existing == nil || existing.certHash != s.certHash {
 		resealAll = true
-		status.Info(s.ctx, "Cert for secret %s has changed, forcing reseal", secretName)
+		status.Infof(s.ctx, "Cert for secret %s has changed, forcing reseal", secretName)
 	}
 
 	for k, v := range secrets {
@@ -278,19 +278,19 @@ func (s *Sealer) sealSecret(o *uo.UnstructuredObject, existing *sealedSecret) (*
 
 		doEncrypt := existing == nil || resealAll
 		if !doEncrypt && hash != existingHash {
-			status.Info(s.ctx, "Secret %s and key %s has changed, resealing", secretName, k)
+			status.Infof(s.ctx, "Secret %s and key %s has changed, resealing", secretName, k)
 			doEncrypt = true
 		}
 
 		if !doEncrypt {
 			e, ok, _ := existing.content.GetNestedString("spec", "encryptedData", k)
 			if ok {
-				status.Trace(s.ctx, "Secret %s and key %s is unchanged", secretName, k)
+				status.Tracef(s.ctx, "Secret %s and key %s is unchanged", secretName, k)
 				result.content.SetNestedField(e, "spec", "encryptedData", k)
 				resultSecretHashes[k] = hash
 				continue
 			} else {
-				status.Info(s.ctx, "Old encrypted secret %s and key %s not found", secretName, k)
+				status.Infof(s.ctx, "Old encrypted secret %s and key %s not found", secretName, k)
 				doEncrypt = true
 			}
 		}

--- a/pkg/status/promts.go
+++ b/pkg/status/promts.go
@@ -25,7 +25,7 @@ func isTerminal(ctx context.Context) bool {
 // before calling askForConfirmation. E.g. fmt.Println("WARNING: Are you sure? (yes/no)")
 func AskForConfirmation(ctx context.Context, prompt string) bool {
 	if !isTerminal(ctx) {
-		Warning(ctx, "Not a terminal, suppressed prompt: %s", prompt)
+		Warningf(ctx, "Not a terminal, suppressed prompt: %s", prompt)
 		return false
 	}
 

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -163,9 +163,9 @@ func (s *CommandResultsServer) startUpdateLogs() error {
 
 		printEvent := func(id string, type_ string, deleted bool) {
 			if deleted {
-				status.Info(s.ctx, "Deleted %s result summary for %s", type_, id)
+				status.Infof(s.ctx, "Deleted %s result summary for %s", type_, id)
 			} else {
-				status.Info(s.ctx, "Updated %s result summary for %s", type_, id)
+				status.Infof(s.ctx, "Updated %s result summary for %s", type_, id)
 			}
 		}
 		for _, x := range l1 {


### PR DESCRIPTION
# Description

This should avoid `%(MISSING)` inside messages when a `%` is part of the message.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
