### PR TITLE
Expose metrics port to use with PodMonitoring

### DIFF
--- a/install/controller/controller/manager.yaml
+++ b/install/controller/controller/manager.yaml
@@ -47,6 +47,9 @@ spec:
         env: []
         image: ghcr.io/kluctl/kluctl:latest
         imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 8080
+          name: metrics
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
# Description

This is needed to scrape metrics from kluctl-controller with PodMonitoring resource

```
apiVersion: monitoring.googleapis.com/v1
kind: PodMonitoring
metadata:
  name: kluctl-controller
spec:
  selector:
    matchLabels:
      control-plane: kluctl-controller
  endpoints:
  - port: metrics
    interval: 30s
```

Fixes #658 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
