### PR TITLE
fix: Take deployed CRDs into account when fixing namespaces

### DIFF
--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -405,6 +405,8 @@ func (a *ApplyUtil) ApplyObject(x *uo.UnstructuredObject, replaced bool, hook bo
 }
 
 func (a *ApplyUtil) handleObservedCRD(r *uo.UnstructuredObject) {
+	status.Tracef(a.ctx, "observed CRD %s", r.GetK8sName())
+
 	y, err := yaml.WriteYamlBytes(r)
 	if err == nil {
 		var crd *apiextensionsv1.CustomResourceDefinition

--- a/pkg/deployment/utils/delete_utils.go
+++ b/pkg/deployment/utils/delete_utils.go
@@ -40,7 +40,11 @@ var deleteOrder = [][]string{
 }
 
 func objectRefForExclusion(k *k8s.K8sCluster, ref k8s2.ObjectRef) k8s2.ObjectRef {
-	ref = k.FixNamespaceInRef(ref)
+	namespaced := k.IsNamespaced(ref.GroupVersionKind())
+	if namespaced == nil {
+		return ref
+	}
+	ref = k8s.FixNamespaceInRef(ref, *namespaced, "default")
 	ref.Version = ""
 	return ref
 }

--- a/pkg/k8s/k8s_cluster.go
+++ b/pkg/k8s/k8s_cluster.go
@@ -440,19 +440,6 @@ func (k *K8sCluster) IsNamespaced(gvk schema.GroupVersionKind) *bool {
 	return &ret
 }
 
-func (k *K8sCluster) FixNamespace(o *uo.UnstructuredObject, def string) {
-	ref := o.GetK8sRef()
-	namespaced := k.IsNamespaced(ref.GroupVersionKind())
-	if namespaced == nil {
-		return
-	}
-	if !*namespaced && ref.Namespace != "" {
-		o.SetK8sNamespace("")
-	} else if *namespaced && ref.Namespace == "" {
-		o.SetK8sNamespace(def)
-	}
-}
-
 func (k *K8sCluster) FixNamespaceInRef(ref k8s.ObjectRef) k8s.ObjectRef {
 	namespaced := k.IsNamespaced(ref.GroupVersionKind())
 	if namespaced == nil {

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"github.com/kluctl/kluctl/v2/pkg/types/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -28,4 +29,22 @@ func UnwrapListItems(o *uo.UnstructuredObject, withListCallback bool, cb func(o 
 	} else {
 		return cb(o)
 	}
+}
+
+func FixNamespace(o *uo.UnstructuredObject, namespaced bool, def string) {
+	ref := o.GetK8sRef()
+	if !namespaced && ref.Namespace != "" {
+		o.SetK8sNamespace("")
+	} else if namespaced && ref.Namespace == "" {
+		o.SetK8sNamespace(def)
+	}
+}
+
+func FixNamespaceInRef(ref k8s.ObjectRef, namespaced bool, def string) k8s.ObjectRef {
+	if !namespaced && ref.Namespace != "" {
+		ref.Namespace = ""
+	} else if namespaced && ref.Namespace == "" {
+		ref.Namespace = def
+	}
+	return ref
 }

--- a/pkg/utils/uo/k8s_fields.go
+++ b/pkg/utils/uo/k8s_fields.go
@@ -184,6 +184,13 @@ func (uo *UnstructuredObject) SetK8sAnnotation(name string, value string) {
 	}
 }
 
+func (uo *UnstructuredObject) RemoveK8sAnnotation(name string) {
+	err := uo.RemoveNestedField("metadata", "annotations", name)
+	if err != nil {
+		panic(err)
+	}
+}
+
 func (uo *UnstructuredObject) GetK8sAnnotationsWithRegex(r interface{}) map[string]string {
 	p := uo.getRegexp(r)
 


### PR DESCRIPTION
# Description

When a deployment also contains CRDs, the k8s client will not know if an object is namespaced before the CRD is actually applied. This leads to flaky behaviour between the initial and all other deployments.

This commit delays fixing of namespaces until all objects are rendered. Then it takes CRDs into account when determining if an object is namespaced or not.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
