### PR TITLE
fix: Also consider deleted namespaces when filtering orphans

### DIFF
--- a/pkg/deployment/commands/deploy.go
+++ b/pkg/deployment/commands/deploy.go
@@ -102,17 +102,7 @@ func (cmd *DeployCommand) Run(diffResultCb func(diffResult *result.CommandResult
 		deleted = utils2.DeleteObjects(cmd.targetCtx.SharedContext.Ctx, cmd.targetCtx.SharedContext.K, orphanObjects, dew, cmd.WaitPrune)
 
 		// now clean up the list of orphan objects (remove the ones that got deleted)
-		ds := map[k8s2.ObjectRef]bool{}
-		for _, x := range deleted {
-			ds[x] = true
-		}
-		var tmp []k8s2.ObjectRef
-		for _, x := range orphanObjects {
-			if _, ok := ds[x]; !ok {
-				tmp = append(tmp, x)
-			}
-		}
-		orphanObjects = tmp
+		orphanObjects = filterDeletedOrphans(orphanObjects, deleted)
 	}
 
 	r := &result.CommandResult{

--- a/pkg/deployment/commands/utils.go
+++ b/pkg/deployment/commands/utils.go
@@ -121,3 +121,18 @@ func collectObjects(c *deployment.DeploymentCollection, ru *utils.RemoteObjectUt
 	})
 	return ret
 }
+
+func filterDeletedOrphans(orphans []k8s.ObjectRef, deleted []k8s.ObjectRef) []k8s.ObjectRef {
+	deletedMap := map[k8s.ObjectRef]bool{}
+	for _, x := range deleted {
+		deletedMap[x] = true
+	}
+	var tmp []k8s.ObjectRef
+	for _, x := range orphans {
+		_, isDeleted := deletedMap[x]
+		if !isDeleted {
+			tmp = append(tmp, x)
+		}
+	}
+	return tmp
+}

--- a/pkg/deployment/commands/utils.go
+++ b/pkg/deployment/commands/utils.go
@@ -124,13 +124,18 @@ func collectObjects(c *deployment.DeploymentCollection, ru *utils.RemoteObjectUt
 
 func filterDeletedOrphans(orphans []k8s.ObjectRef, deleted []k8s.ObjectRef) []k8s.ObjectRef {
 	deletedMap := map[k8s.ObjectRef]bool{}
+	deletedNamespacesMap := map[string]bool{}
 	for _, x := range deleted {
 		deletedMap[x] = true
+		if x.Group == "" && x.Kind == "Namespace" {
+			deletedNamespacesMap[x.Name] = true
+		}
 	}
 	var tmp []k8s.ObjectRef
 	for _, x := range orphans {
 		_, isDeleted := deletedMap[x]
-		if !isDeleted {
+		_, isDeletedNs := deletedNamespacesMap[x.Namespace]
+		if !isDeleted && !isDeletedNs {
 			tmp = append(tmp, x)
 		}
 	}


### PR DESCRIPTION
# Description

Don't treat object as orphan when they actually got deleted via namespace pruning.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
