### PR TITLE
fix: Fix CheckSubInDir inside ListSealedSecrets

### DIFF
--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -253,7 +253,7 @@ func (di *DeploymentItem) ListSealedSecrets(subdir string) ([]string, error) {
 	renderedDir := filepath.Join(di.RenderedDir, subdir)
 
 	// ensure we're not leaving the project
-	err := utils.CheckSubInDir(di.Project.source.dir, subdir)
+	err := utils.CheckSubInDir(di.Project.source.dir, filepath.Join(di.RelRenderedDir, subdir))
 	if err != nil {
 		return nil, err
 	}
@@ -291,7 +291,7 @@ func (di *DeploymentItem) ListSealedSecrets(subdir string) ([]string, error) {
 		relPath = filepath.Clean(relPath)
 
 		// ensure we're not leaving the project
-		err = utils.CheckSubInDir(di.Project.source.dir, relPath)
+		err = utils.CheckSubInDir(di.Project.source.dir, filepath.Join(di.RelRenderedDir, relPath))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
# Description

This fixes a bug that caused kustomize bases to not work anymore due to errors reported by CheckSubInDir.

Fixes #684

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
