### PR TITLE
docs: Remove bogus Kustomize example and refer to deployment-yml.md

### DIFF
--- a/docs/reference/deployments/kustomize.md
+++ b/docs/reference/deployments/kustomize.md
@@ -21,23 +21,6 @@ We advise to read the kustomize
 [reference](https://kubectl.docs.kubernetes.io/references/kustomize/). You can also look into the official kustomize
 [example](https://github.com/kubernetes-sigs/kustomize/tree/master/examples).
 
-One way you might use this is to Kustomize a set of manifests from an external project.
+# Using the Kustomize Integration
 
-For example:
-```yaml
-# deployment.yml
-deployments:
-- git: git@github.com/example/example.git
-  onlyRender: true
-- path: kustomize_example
-```
-```yaml
-# kustomize_example/kustomization.yml
----
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-bases:
-  - ../example
-patches:
-  - # your patches here
-```
+Please refer to the [Kustomize Deployment Item](./deployment-yml.md#kustomize-deployments) documentation for details.


### PR DESCRIPTION
# Description

It looks like the example introduced in #421 does not work, which caused a lot of confusion and issue for multiple people. This PR removes the example and instead simply refers to the deployment-yml.md docs.

## Type of change

- [x] This change requires a documentation update

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
