### PR TITLE
Support nodeSelector, tolerations and priorityClassName when installing the controller and/or webui

### DIFF
--- a/install/controller/.kluctl.yaml
+++ b/install/controller/.kluctl.yaml
@@ -11,3 +11,9 @@ args:
     default: []
   - name: controller_resources
     default: {}
+  - name: controller_node_selectors
+    default: {}
+  - name: controller_tolerations
+    default: []
+  - name: controller_priority_class
+    default: {}

--- a/install/controller/controller/kustomization.yaml
+++ b/install/controller/controller/kustomization.yaml
@@ -38,3 +38,18 @@ patches:
         path: /spec/template/spec/containers/0/resources
         value: {{ get_var("args.controller_resources", none) | to_json }}
 {% endif %}
+{% if get_var("args.controller_node_selectors", none) %}
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value: {{ get_var("args.controller_node_selectors", none) | to_json }}
+{% endif %}
+{% if get_var("args.controller_tolerations", none) %}
+      - op: add
+        path: /spec/template/spec/tolerations
+        value: {{ get_var("args.controller_tolerations", none) | to_json }}
+{% endif %}
+{% if get_var("args.controller_priority_class_name", none) %}
+      - op: add
+        path: /spec/template/spec/priorityClassName
+        value: {{ get_var("args.controller_priority_class_name", none) | to_json }}
+{% endif %}

--- a/install/webui/.kluctl.yaml
+++ b/install/webui/.kluctl.yaml
@@ -11,3 +11,9 @@ args:
     default: []
   - name: webui_resources
     default: {}
+  - name: webui_node_selectors
+    default: {}
+  - name: webui_tolerations
+    default: []
+  - name: webui_priority_class
+    default: {}

--- a/install/webui/webui/deployment.yaml
+++ b/install/webui/webui/deployment.yaml
@@ -1,7 +1,3 @@
-{% set kluctl_image = get_var("args.kluctl_image", "ghcr.io/kluctl/kluctl") %}
-{% set kluctl_version = get_var("args.kluctl_version", "v2.20.8") %}
-{% set pull_policy = "Always" if ("-devel" in kluctl_version or "-snapshot" in kluctl_version) else "IfNotPresent" %}
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,14 +25,12 @@ spec:
     spec:
       containers:
       - name: webui
-        image: {{ kluctl_image }}:{{ kluctl_version }}
-        imagePullPolicy: {{ pull_policy }}
+        image: ghcr.io/kluctl/kluctl:latest
+        imagePullPolicy: IfNotPresent
         command:
           - kluctl
           - webui
           - --in-cluster
-        args: {{ get_var(["args.webui_args", "webui_args"], []) | to_json }}
-        env: {{ get_var(["args.webui_envs", "webui_envs"], []) | to_json }}
         ports:
           - containerPort: 8080
             name: http
@@ -52,9 +46,6 @@ spec:
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
-        {% if get_var(["args.webui_resources", "webui_resources"], {}) %}
-        resources: {{ get_var(["args.webui_resources", "webui_resources"], {}) | to_json }}
-        {% else %}
         resources:
           limits:
             cpu: 2000m
@@ -62,7 +53,6 @@ spec:
           requests:
             cpu: 500m
             memory: 512Mi
-        {% endif %}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/install/webui/webui/kustomization.yaml
+++ b/install/webui/webui/kustomization.yaml
@@ -39,3 +39,18 @@ patches:
         path: /spec/template/spec/containers/0/resources
         value: {{ get_var("args.webui_resources", none) | to_json }}
 {% endif %}
+{% if get_var("args.webui_node_selectors", none) %}
+      - op: add
+        path: /spec/template/spec/nodeSelector
+        value: {{ get_var("args.webui_node_selectors", none) | to_json }}
+{% endif %}
+{% if get_var("args.webui_tolerations", none) %}
+      - op: add
+        path: /spec/template/spec/tolerations
+        value: {{ get_var("args.webui_tolerations", none) | to_json }}
+{% endif %}
+{% if get_var("args.webui_priority_class_name", none) %}
+      - op: add
+        path: /spec/template/spec/priorityClassName
+        value: {{ get_var("args.webui_priority_class_name", none) | to_json }}
+{% endif %}

--- a/install/webui/webui/kustomization.yaml
+++ b/install/webui/webui/kustomization.yaml
@@ -1,0 +1,41 @@
+{% set kluctl_image = get_var("args.kluctl_image", "ghcr.io/kluctl/kluctl") %}
+{% set kluctl_version = get_var("args.kluctl_version", "v2.20.8") %}
+{% set pull_policy = "Always" if ("-devel" in kluctl_version or "-snapshot" in kluctl_version) else "IfNotPresent" %}
+
+resources:
+- admin-rbac.yaml
+- webui-rbac.yaml
+- viewer-rbac.yaml
+- deployment.yaml
+- service.yaml
+
+patches:
+  - target:
+      kind: Deployment
+      name: kluctl-webui
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/image
+        value: {{ kluctl_image }}:{{ kluctl_version }}
+  - target:
+      kind: Deployment
+      name: kluctl-webui
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/imagePullPolicy
+        value: {{ pull_policy }}
+{% for a in get_var("args.webui_args", []) %}
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: "{{ a }}"
+{% endfor %}
+{% for a in get_var("args.webui_envs", []) %}
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value: {{ a | to_json }}
+{% endfor %}
+{% if get_var("args.webui_resources", none) %}
+      - op: replace
+        path: /spec/template/spec/containers/0/resources
+        value: {{ get_var("args.webui_resources", none) | to_json }}
+{% endif %}


### PR DESCRIPTION
# Description

In order to be able to schedule the controller and/or the webui on specific nodes with higher priority when installing them, this PR adds the support for nodeSelector, tolerations and the priorityClassName as arguments for the deployment.

Fixes # None

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [x] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
