### PR TITLE
fix: Add empty env to webui install deployment

### DIFF
--- a/install/webui/webui/deployment.yaml
+++ b/install/webui/webui/deployment.yaml
@@ -31,6 +31,7 @@ spec:
           - kluctl
           - webui
           - --in-cluster
+        env: []
         ports:
           - containerPort: 8080
             name: http


### PR DESCRIPTION
# Description

This PR adds an empty env field to the webui deployment because the patch operation is not working without it.

Fixes None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
