### PR TITLE
fix: Use name as tie-breaker in calcRemoteObjectsForDiff

### DIFF
--- a/pkg/deployment/utils/diff_utils.go
+++ b/pkg/deployment/utils/diff_utils.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"sort"
 	"sync"
-	"time"
 )
 
 type DiffUtil struct {
@@ -128,11 +127,22 @@ func (u *DiffUtil) calcRemoteObjectsForDiff() {
 	u.remoteDiffObjects = make(map[k8s2.ObjectRef]*uo.UnstructuredObject)
 	for _, o := range u.ru.remoteObjects {
 		diffRef := u.GetDiffRef(o)
-		oldCreationTime := time.Time{}
-		if old, ok := u.remoteDiffObjects[diffRef]; ok {
-			oldCreationTime = old.GetK8sCreationTime()
+		old := u.remoteDiffObjects[diffRef]
+
+		replace := false
+		if old == nil {
+			replace = true
+		} else if old.GetK8sCreationTime() == o.GetK8sCreationTime() {
+			// unfortunately the creation time has only seconds resolution, meaning that we can easily get into a
+			// situation where two deployments happen in the same second resulting in a situation where it's unclear
+			// which of the two objects to use as the "diff-object". We have to resolve this tie in some way, and using
+			// the name of the real objects seems to be the most consistent way. Using the resourceVersion would be
+			// another option, but it would be unpredictable if other components start to modify resources in-between.
+			replace = o.GetK8sName() > old.GetK8sName()
+		} else {
+			replace = o.GetK8sCreationTime().After(old.GetK8sCreationTime())
 		}
-		if oldCreationTime.IsZero() || o.GetK8sCreationTime().After(oldCreationTime) {
+		if replace {
 			u.remoteDiffObjects[diffRef] = o
 		}
 	}


### PR DESCRIPTION
# Description

This fixes issues that mostly happen in tests, where deployments with different object names but same diff-name happen too fast.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
