### PR TITLE
Allow wait readiness checks to run after all resource are applied

### DIFF
--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -609,6 +609,12 @@ func (a *ApplyUtil) applyDeploymentItem(d *deployment.DeploymentItem) {
 			startTime = time.Now()
 			didLog = true
 		}
+	}
+	// Wait for readiness if needed after we have applied all objects
+	for _, o := range applyObjects {
+		if a.abortSignal.Load().(bool) {
+			break
+		}
 
 		waitReadiness := d.Config.WaitReadiness || d.WaitReadiness || utils.ParseBoolOrFalse(o.GetK8sAnnotation("kluctl.io/wait-readiness"))
 		if !a.o.NoWait && waitReadiness {


### PR DESCRIPTION
# Description

The current `waitReadiness` logic happens serially as each object is applied. This can cause problems if there are dependencies between the resources.

The PR separates the wait for readiness to be done after applying all resources.

Fixes #776 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
