### PR TITLE
tests: Call ctrl.SetLogger at init() time

### DIFF
--- a/e2e/gitops_test.go
+++ b/e2e/gitops_test.go
@@ -15,9 +15,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
 	"math/rand"
 	"os"
 	"path/filepath"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 	"testing"
@@ -30,6 +32,11 @@ const (
 	timeout  = time.Second * 300
 	interval = time.Second * 5
 )
+
+func init() {
+	// this must be called in the first 30 seconds of startup, so we have to do it here at init() time
+	ctrl.SetLogger(klog.NewKlogr())
+}
 
 type GitopsTestSuite struct {
 	suite.Suite


### PR DESCRIPTION
# Description

This fixes swallowed logs in tests.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
