### PR TITLE
feat: Allow to set service account annotations

### DIFF
--- a/docs/kluctl/templating/variable-sources.md
+++ b/docs/kluctl/templating/variable-sources.md
@@ -286,16 +286,16 @@ vars:
       secretName: "projects/my-project/secrets/secret/versions/latest"
 ```
 
-It is recommended to use [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) when you are using kluctl controller. You will need to annotate kluctl controller service account with service account name created in k8s:
+It is recommended to use [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) when you are using kluctl controller. You will need to annotate kluctl controller service account with service account name created in your google project:
 
 ```
     args:
       controller_service_account_annotations:
         iam.gke.io/gcp-service-account: kluctl-controller@PROJECT-NAME.iam.gserviceaccount.com
 ```
-substitute PROJECT-NAME with your real project name in google.
+substitute PROJECT-NAME with your real project name in google. Service account in your google project should have role `roles/secretmanager.secretAccessor` to access secrets.
 
-To run it locally refer to [setting local development environment](https://cloud.google.com/docs/authentication/provide-credentials-adc#local-dev) article.
+To run kluctl locally with gcpSecretManager enabled refer to [setting local development environment](https://cloud.google.com/docs/authentication/provide-credentials-adc#local-dev) article.
 
 ### vault
 

--- a/docs/kluctl/templating/variable-sources.md
+++ b/docs/kluctl/templating/variable-sources.md
@@ -275,7 +275,7 @@ writing the configuration) doesn't have to be specified.
 
 ### gcpSecretManager
 [Google Secret Manager](https://cloud.google.com/secret-manager) integration. Loads a variables YAML from a Google Secrets
-Manager secret. The secret can be specified via full resource name.
+Manager secret. The secret name should be specified in `projects/*/secrets/*/versions/*` [format](https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets.versions/get#path-parameters).
 
 The secrets stored in Google Secrets manager must contain a valid yaml or json file.
 
@@ -286,7 +286,16 @@ vars:
       secretName: "projects/my-project/secrets/secret/versions/latest"
 ```
 
-It is recommended to use [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) when you are using kluctl controller. To run it locally provide path to service account json file by setting environment variable `GOOGLE_APPLICATION_CREDENTIALS`.
+It is recommended to use [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) when you are using kluctl controller. You will need to annotate kluctl controller service account with service account name created in k8s:
+
+```
+    args:
+      controller_service_account_annotations:
+        iam.gke.io/gcp-service-account: kluctl-controller@PROJECT-NAME.iam.gserviceaccount.com
+```
+substitute PROJECT-NAME with your real project name in google.
+
+To run it locally refer to [setting local development environment](https://cloud.google.com/docs/authentication/provide-credentials-adc#local-dev) article.
 
 ### vault
 

--- a/install/controller/.kluctl.yaml
+++ b/install/controller/.kluctl.yaml
@@ -17,3 +17,5 @@ args:
     default: []
   - name: controller_priority_class_name
     default: {}
+  - name: controller_service_account_annotations
+    default: {}

--- a/install/controller/controller/kustomization.yaml
+++ b/install/controller/controller/kustomization.yaml
@@ -53,3 +53,12 @@ patches:
         path: /spec/template/spec/priorityClassName
         value: {{ get_var("args.controller_priority_class_name", none) | to_json }}
 {% endif %}
+{% if get_var("args.controller_service_account_annotations", none) %}
+  - target:
+      kind: ServiceAccount
+      name: kluctl-controller
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value: {{ get_var("args.controller_service_account_annotations", none) | to_json }}
+{% endif %}


### PR DESCRIPTION
# Description

In order to use gcpSecretManager in kluctl controller with [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) kluctl service account should be annotated with `iam.gke.io/gcp-service-account` meta information.

This PR adds `controller_service_account_annotations` arg and documentation with example on how to use that. 

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
