### PR TITLE
Fix: git cli failing on latest devel

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,8 +88,8 @@ dockers:
     goarch: amd64
     build_flag_templates:
       - "--pull"
-      # use https://registry-ui.chainguard.app/?image=cgr.dev/chainguard/wolfi-base to find the latest one
-      - "--build-arg=WOLFI_DIGEST=sha256:066409365aa20bb686fc08dc5692ab9358fe6f1cd7001c39b539561bf35e290f"
+      # use `docker buildx imagetools inspect  cgr.dev/chainguard/wolfi-base:latest` to find latest sha256 of linux/amd64 layer
+      - "--build-arg=WOLFI_DIGEST=sha256:3c41b0c5a5b09fb4e5fccdc9469c992cf489161989fcc3e17c7c394bbea4b215"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.name={{ .ProjectName }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
@@ -103,8 +103,8 @@ dockers:
     goarch: arm64
     build_flag_templates:
       - "--pull"
-      # use https://registry-ui.chainguard.app/?image=cgr.dev/chainguard/wolfi-base to find the latest one
-      - "--build-arg=WOLFI_DIGEST=sha256:25fe46783deb30d07921d05a1cbe21629a2f9e6256ecc9e1c52bc10e7d10afb1"
+      # use `docker buildx imagetools inspect  cgr.dev/chainguard/wolfi-base:latest` to find latest sha256 of linux/arm64 layer
+      - "--build-arg=WOLFI_DIGEST=sha256:f27d65564f05397c920f63fb81b485f829de3ee23fd32a4a0af1002ec7ead0d2"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.name={{ .ProjectName }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -89,7 +89,7 @@ dockers:
     build_flag_templates:
       - "--pull"
       # use https://registry-ui.chainguard.app/?image=cgr.dev/chainguard/wolfi-base to find the latest one
-      - "--build-arg=WOLFI_DIGEST=sha256:e8411b9629bd13123a978a2d1a27c3ee64c7751d3032ce80ad6e673e329ef964"
+      - "--build-arg=WOLFI_DIGEST=sha256:066409365aa20bb686fc08dc5692ab9358fe6f1cd7001c39b539561bf35e290f"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.name={{ .ProjectName }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
@@ -104,7 +104,7 @@ dockers:
     build_flag_templates:
       - "--pull"
       # use https://registry-ui.chainguard.app/?image=cgr.dev/chainguard/wolfi-base to find the latest one
-      - "--build-arg=WOLFI_DIGEST=sha256:05a4280b4c5b5cafc7eb2a012983bc79e3ddca938f01ddc3deb797ca3fddd399"
+      - "--build-arg=WOLFI_DIGEST=sha256:25fe46783deb30d07921d05a1cbe21629a2f9e6256ecc9e1c52bc10e7d10afb1"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.name={{ .ProjectName }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # We must use a glibc based distro due to embedded python not supporting musl libc for aarch64 (only amd64+musl is supported)
 # see https://github.com/indygreg/python-build-standalone/issues/87
-ARG WOLFI_DIGEST=sha256:e8411b9629bd13123a978a2d1a27c3ee64c7751d3032ce80ad6e673e329ef964
+ARG WOLFI_DIGEST=sha256:0f5ba4905ca6ea9c43660cca233e663eb9bb21cbc6993656936d2aef80c43310
 FROM cgr.dev/chainguard/wolfi-base@$WOLFI_DIGEST
 
 # We need git for kustomize to support overlays from git
-RUN apk add git tzdata
+RUN apk update && apk add git tzdata
 
 # Ensure helm is not trying to access /
 ENV HELM_CACHE_HOME=/tmp/helm-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # We must use a glibc based distro due to embedded python not supporting musl libc for aarch64 (only amd64+musl is supported)
 # see https://github.com/indygreg/python-build-standalone/issues/87
-ARG WOLFI_DIGEST=sha256:0f5ba4905ca6ea9c43660cca233e663eb9bb21cbc6993656936d2aef80c43310
+# use `docker buildx imagetools inspect  cgr.dev/chainguard/wolfi-base:latest` to find latest sha256 for multiarch image
+ARG WOLFI_DIGEST=sha256:ccc5551b5dd1fdcff5fc76ac1605b4c217f77f43410e0bd8a56599d6504dbbdd
 FROM cgr.dev/chainguard/wolfi-base@$WOLFI_DIGEST
 
 # We need git for kustomize to support overlays from git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # We must use a glibc based distro due to embedded python not supporting musl libc for aarch64 (only amd64+musl is supported)
 # see https://github.com/indygreg/python-build-standalone/issues/87
-# use `docker buildx imagetools inspect  cgr.dev/chainguard/wolfi-base:latest` to find latest sha256 for multiarch image
+# use `docker buildx imagetools inspect  cgr.dev/chainguard/wolfi-base:latest` to find latest sha256 of multiarch image
 ARG WOLFI_DIGEST=sha256:ccc5551b5dd1fdcff5fc76ac1605b4c217f77f43410e0bd8a56599d6504dbbdd
 FROM cgr.dev/chainguard/wolfi-base@$WOLFI_DIGEST
 


### PR DESCRIPTION
# Description

git cli is failing with error message `/usr/bin/git: /lib64/libc.so.6: version 'GLIBC_2.38' not found (required by /usr/bin/git)` on WOLFI_DIGEST=sha256:e8411b9629bd13123a978a2d1a27c3ee64c7751d3032ce80ad6e673e329ef964

Reproduce with:
```
docker run -it --platform linux/amd64 --entrypoint /bin/sh ghcr.io/kluctl/kluctl:v2.22.0-devel

~ $ git
/usr/bin/git: /lib64/libc.so.6: version `GLIBC_2.38' not found (required by /usr/bin/git)
```

Commit in wolfi that possibly related:
https://github.com/wolfi-dev/os/commit/a03efaa8be7f0e744795e98315a26ec9ee4222fb

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
