### PR TITLE
tests: Skip gitops tests on windows

### DIFF
--- a/e2e/gitops_suite.go
+++ b/e2e/gitops_suite.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	runtime2 "runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
@@ -53,6 +54,10 @@ type GitopsTestSuite struct {
 }
 
 func (suite *GitopsTestSuite) SetupSuite() {
+	if runtime2.GOOS == "windows" {
+		suite.T().Skip("skipping gitops tests on windows")
+	}
+
 	suite.k = gitopsCluster
 
 	n := suite.T().Name()


### PR DESCRIPTION
These are so slow that they easily timeout. Also, no one would ever run the controller on windows...right?