### PR TITLE
fix: Fix spec.source.git.path to be actually respected

### DIFF
--- a/docs/gitops/spec/v1beta1/kluctldeployment.md
+++ b/docs/gitops/spec/v1beta1/kluctldeployment.md
@@ -313,22 +313,31 @@ interval at which forced deployments must be performed by the controller.
 The KluctlDeployment reconciliation can be suspended by setting `spec.suspend` to `true`. Suspension will however not
 prevent manual reconciliation requests via the `kluctl gitops` sub-commands.
 
+## Manual requests/reconciliation
+
 The controller can be told to reconcile the KluctlDeployment outside of the specified interval
-by annotating the KluctlDeployment object with `kluctl.io/request-reconcile`.
+by using the [`kluctl gitops`](../../../kluctl/commands/README.md) sub-commands.
 
 On-demand reconciliation example:
 
 ```bash
-kubectl annotate --overwrite kluctldeployment/microservices-demo-prod kluctl.io/request-reconcile="$(date +%s)"
+kluctl gitops deploy --namespace my-namespace --name my-deployment
 ```
 
-Similarly, a deployment can be forced even if the source has not changed by using the  `kluctl.io/request-deploy`
-annotation:
+You can also perform manual requests while temporarily overriding deployment configurations, e.g.:
 
 ```bash
-kubectl annotate --overwrite kluctldeployment/microservices-demo-prod kluctl.io/request-deploy="$(date +%s)"
+kluctl gitops deploy --namespace my-namespace --name my-deployment --force-apply
 ```
 
+Local source overrides are also possible, allowing you to test changes before pushing them:
+
+```bash
+kluctl gitops diff --namespace my-namespace --name my-deployment --local-git-override=github.com/exaple-org/example-project=/local/path/to/modified/repo
+```
+
+When `--namespace` and `--name` are omitted, the CLI will try to auto-detect the deployment on the current cluster
+and suggest the auto-detected deployment to you.
 
 ## Kubeconfigs and RBAC
 

--- a/e2e/gitops_misc_test.go
+++ b/e2e/gitops_misc_test.go
@@ -1,0 +1,97 @@
+package e2e
+
+import (
+	kluctlv1 "github.com/kluctl/kluctl/v2/api/v1beta1"
+	test_utils "github.com/kluctl/kluctl/v2/e2e/test-utils"
+	"github.com/kluctl/kluctl/v2/e2e/test_project"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+type GitOpsMiscSuite struct {
+	GitopsTestSuite
+}
+
+func TestGitOpsMisc(t *testing.T) {
+	t.Parallel()
+	suite.Run(t, new(GitOpsMiscSuite))
+}
+
+func (suite *GitOpsMiscSuite) TestGitSourceWithPath() {
+	p := test_project.NewTestProject(suite.T(), test_project.WithGitSubDir("subDir"))
+	p.AddExtraArgs("--controller-namespace", suite.gitopsNamespace+"-system")
+	createNamespace(suite.T(), suite.k, p.TestSlug())
+
+	p.UpdateTarget("target1", nil)
+	addConfigMapDeployment(p, "d1", nil, resourceOpts{
+		name:      "cm1",
+		namespace: p.TestSlug(),
+	})
+
+	key := suite.createKluctlDeployment(p, "target1", nil)
+
+	suite.Run("initial deployment fails", func() {
+		kd := suite.waitForCommit(key, getHeadRevision(suite.T(), p))
+		status := suite.getReadiness(kd)
+		assert.Equal(suite.T(), v1.ConditionFalse, status.Status)
+		assert.Equal(suite.T(), "target target1 not existent in kluctl project config", status.Message)
+	})
+
+	suite.Run("deployment with path succeeds", func() {
+		suite.updateKluctlDeployment(key, func(kd *kluctlv1.KluctlDeployment) {
+			kd.Spec.Source.Git.Path = "subDir"
+		})
+
+		kd := suite.waitForCommit(key, getHeadRevision(suite.T(), p))
+		status := suite.getReadiness(kd)
+		assert.Equal(suite.T(), v1.ConditionTrue, status.Status)
+	})
+}
+
+func (suite *GitOpsMiscSuite) TestOciSourceWithPath() {
+	p := test_project.NewTestProject(suite.T(), test_project.WithGitSubDir("subDir"))
+	createNamespace(suite.T(), suite.k, p.TestSlug())
+
+	p.UpdateTarget("target1", nil)
+	addConfigMapDeployment(p, "d1", nil, resourceOpts{
+		name:      "cm1",
+		namespace: p.TestSlug(),
+	})
+
+	repo := &test_utils.TestHelmRepo{
+		TestHttpServer: test_utils.TestHttpServer{},
+		Oci:            true,
+	}
+	repo.Start(suite.T())
+
+	repoUrl := repo.URL.String() + "/org/repo"
+
+	p.KluctlMust(suite.T(), "oci", "push", "--url", repoUrl, "--project-dir", p.LocalRepoDir())
+
+	p.AddExtraArgs("--controller-namespace", suite.gitopsNamespace+"-system")
+
+	key := suite.createKluctlDeployment2(p, "target1", nil, func(kd *kluctlv1.KluctlDeployment) {
+		kd.Spec.Source.Oci = &kluctlv1.ProjectSourceOci{
+			URL: repoUrl,
+		}
+	})
+
+	suite.Run("initial deployment fails", func() {
+		kd := suite.waitForCommit(key, getHeadRevision(suite.T(), p))
+		status := suite.getReadiness(kd)
+		assert.Equal(suite.T(), v1.ConditionFalse, status.Status)
+		assert.Equal(suite.T(), "target target1 not existent in kluctl project config", status.Message)
+	})
+
+	suite.Run("deployment with path succeeds", func() {
+		suite.updateKluctlDeployment(key, func(kd *kluctlv1.KluctlDeployment) {
+			kd.Spec.Source.Oci.Path = "subDir"
+		})
+
+		kd := suite.waitForCommit(key, getHeadRevision(suite.T(), p))
+		status := suite.getReadiness(kd)
+		assert.Equal(suite.T(), v1.ConditionTrue, status.Status)
+	})
+}

--- a/pkg/controllers/kluctl_project.go
+++ b/pkg/controllers/kluctl_project.go
@@ -144,7 +144,9 @@ func prepareProject(ctx context.Context,
 	}
 
 	if doCloneSource {
+		pth := ""
 		if pp.obj.Spec.Source.Git != nil {
+			pth = pp.obj.Spec.Source.Git.Path
 			rpEntry, err := pp.gitRP.GetEntry(pp.obj.Spec.Source.Git.URL)
 			if err != nil {
 				return nil, fmt.Errorf("failed to clone git source: %w", err)
@@ -155,6 +157,7 @@ func prepareProject(ctx context.Context,
 				return nil, err
 			}
 		} else if pp.obj.Spec.Source.Oci != nil {
+			pth = pp.obj.Spec.Source.Oci.Path
 			rpEntry, err := pp.ociRP.GetEntry(pp.obj.Spec.Source.Oci.URL)
 			if err != nil {
 				return nil, fmt.Errorf("failed to pull OCI source: %w", err)
@@ -165,6 +168,7 @@ func prepareProject(ctx context.Context,
 				return nil, err
 			}
 		} else if pp.obj.Spec.Source.URL != nil {
+			pth = pp.obj.Spec.Source.Path
 			rpEntry, err := pp.gitRP.GetEntry(*pp.obj.Spec.Source.URL)
 			if err != nil {
 				return nil, fmt.Errorf("failed to clone git source: %w", err)
@@ -179,7 +183,7 @@ func prepareProject(ctx context.Context,
 		}
 
 		// check kluctl project path exists
-		pp.projectDir, err = securejoin.SecureJoin(pp.repoDir, pp.obj.Spec.Source.Path)
+		pp.projectDir, err = securejoin.SecureJoin(pp.repoDir, pth)
 		if err != nil {
 			return pp, err
 		}


### PR DESCRIPTION
# Description

This fixes an issue reported on Slack. The controller ignored `spec.source.git.path` and `spec.source.oci.path` and instead only used the deprecated `spec.source.path`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
