### PR TITLE
fix: Allow to retry with force-replace when conflict resolution fails

### DIFF
--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -329,12 +329,11 @@ func (a *ApplyUtil) retryApplyWithConflicts(x *uo.UnstructuredObject, hook bool,
 	}
 	r, apiWarnings, err := a.k.ApplyObject(x2, options)
 	a.handleApiWarnings(ref, apiWarnings)
-	if err != nil {
-		// We didn't manage to solve it, better to abort (and not retry with replace!)
-		a.HandleError(ref, err)
-		return
+	if err == nil {
+		a.handleResult(r, hook)
+	} else {
+		a.retryApplyForceReplace(x, hook, remoteObject, err)
 	}
-	a.handleResult(r, hook)
 }
 
 func (a *ApplyUtil) ApplyObject(x *uo.UnstructuredObject, replaced bool, hook bool) {


### PR DESCRIPTION
# Description

There are situations where conflict resolution fails. In that case, allow to use `--force-replace-on-error` to solve it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
