### PR TITLE
feat: Introduce the kluctl.io/force-managed annotation

### DIFF
--- a/docs/kluctl/deployments/annotations/all-resources.md
+++ b/docs/kluctl/deployments/annotations/all-resources.md
@@ -70,6 +70,10 @@ This tag is especially useful and required on resources that would otherwise cau
 do not match the specified inclusion/exclusion tags. Namespaces are the most prominent example of such resources, as
 they most likely don't match exclusion tags, but cascaded deletion would still cause deletion of the excluded resources.
 
+### kluctl.io/force-managed
+If set to "true", Kluctl will always treat the annotated resource as being managed by Kluctl, meaning that it will
+consider it for deletion and pruning even if a foreign field manager resets/removes the Kluctl field manager.
+
 ## Control diff behavior
 
 The following annotations control how diffs are performed.

--- a/pkg/deployment/utils/delete_utils.go
+++ b/pkg/deployment/utils/delete_utils.go
@@ -122,7 +122,7 @@ func filterObjectsForDelete(k *k8s.K8sCluster, objects []*uo.UnstructuredObject,
 				break
 			}
 		}
-		if !found {
+		if !found && !o.GetK8sAnnotationBoolNoError("kluctl.io/force-managed", false) {
 			// This object is not managed by kluctl, so we shouldn't delete it
 			continue
 		}


### PR DESCRIPTION
# Description

If set to "true", Kluctl will always treat the annotated resource as being managed by Kluctl, meaning that it will
consider it for deletion and pruning even if a foreign field manager resets/removes the Kluctl field manager.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
