### PR TITLE
feat: Make -t mandatory when the project defines targets

### DIFF
--- a/e2e/args_test.go
+++ b/e2e/args_test.go
@@ -235,6 +235,11 @@ func testArgsInDiscriminator(t *testing.T, inDefaultDiscriminator bool) {
 
 	if inDefaultDiscriminator {
 		// now without targets
+		p.UpdateKluctlYaml(func(o *uo.UnstructuredObject) error {
+			_ = o.RemoveNestedField("targets")
+			return nil
+		})
+
 		p.KluctlMust(t, "deploy", "--yes")
 		cm = assertConfigMapExists(t, k, p.TestSlug(), "cm")
 		assertNestedFieldEquals(t, cm, "discriminator-default", "metadata", "labels", "kluctl.io/discriminator")

--- a/e2e/gitops_suite_test.go
+++ b/e2e/gitops_suite_test.go
@@ -231,6 +231,11 @@ func (suite *GitopsTestSuite) createKluctlDeployment2(p *test_project.TestProjec
 		suite.T().Fatal(err)
 	}
 
+	var targetPtr *string
+	if target != "" {
+		targetPtr = &target
+	}
+
 	kluctlDeployment := &kluctlv1.KluctlDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      p.TestSlug(),
@@ -239,7 +244,7 @@ func (suite *GitopsTestSuite) createKluctlDeployment2(p *test_project.TestProjec
 		Spec: kluctlv1.KluctlDeploymentSpec{
 			Interval: metav1.Duration{Duration: interval},
 			Timeout:  &metav1.Duration{Duration: timeout},
-			Target:   &target,
+			Target:   targetPtr,
 			Args: &runtime.RawExtension{
 				Raw: jargs,
 			},

--- a/e2e/no_target_test.go
+++ b/e2e/no_target_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"github.com/kluctl/kluctl/v2/e2e/test_project"
+	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"path/filepath"
@@ -67,4 +68,15 @@ func TestNoTarget(t *testing.T) {
 
 func TestNoTargetNoDeployment(t *testing.T) {
 	testNoTarget(t, false)
+}
+
+func TestNoTargetWithTargetsInProject(t *testing.T) {
+	t.Parallel()
+
+	p := prepareNoTargetTest(t, true)
+	p.UpdateTarget("test", func(target *uo.UnstructuredObject) {
+	})
+
+	_, _, err := p.Kluctl(t, "deploy", "--yes")
+	assert.ErrorContains(t, err, "a target must be explicitly selected when targets are defined in the Kluctl project")
 }

--- a/e2e/no_target_test.go
+++ b/e2e/no_target_test.go
@@ -12,9 +12,6 @@ import (
 func prepareNoTargetTest(t *testing.T, withDeploymentYaml bool) *test_project.TestProject {
 	p := test_project.NewTestProject(t)
 
-	createNamespace(t, defaultCluster1, p.TestSlug())
-	createNamespace(t, defaultCluster2, p.TestSlug())
-
 	cm := createConfigMapObject(map[string]string{
 		"targetName":    `{{ target.name }}`,
 		"targetContext": `{{ target.context }}`,
@@ -38,6 +35,8 @@ func testNoTarget(t *testing.T, withDeploymentYaml bool) {
 	t.Parallel()
 
 	p := prepareNoTargetTest(t, withDeploymentYaml)
+	createNamespace(t, defaultCluster1, p.TestSlug())
+	createNamespace(t, defaultCluster2, p.TestSlug())
 
 	p.KluctlMust(t, "deploy", "--yes")
 	cm := assertConfigMapExists(t, defaultCluster1, p.TestSlug(), "cm")

--- a/pkg/kluctl_project/target-context/target_context.go
+++ b/pkg/kluctl_project/target-context/target_context.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/kluctl_project"
 	"github.com/kluctl/kluctl/v2/pkg/oci/auth_provider"
+	"github.com/kluctl/kluctl/v2/pkg/status"
 	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"github.com/kluctl/kluctl/v2/pkg/vars"
@@ -63,6 +64,10 @@ func NewTargetContext(ctx context.Context, p *kluctl_project.LoadedKluctlProject
 		}
 		target = &*t
 	} else {
+		if len(p.Targets) != 0 {
+			status.Deprecation(ctx, "no-target", "Warning, tried to use Kluctl without explicitly specifying a target, while the Kluctl project contains target definitions. This was allowed in older version of Kluctl, but is forbidden since v2.23.0. If mixing deployments with and without targets was actually intended, please switch to creating and using a dedicated target that serves as a replacement for no-target deployments.")
+			return nil, fmt.Errorf("a target must be explicitly selected when targets are defined in the Kluctl project")
+		}
 		target = &types.Target{
 			Discriminator: p.Config.Discriminator,
 		}


### PR DESCRIPTION
# Description

This makes `-t` mandatory when the `.kluctl.yaml` defines targets.

Fixes #470

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
