### PR TITLE
feat: Print warning at the bottom of the pretty command result output

### DIFF
--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -19,11 +19,6 @@ import (
 func formatCommandResultText(cr *result.CommandResult, short bool) string {
 	buf := bytes.NewBuffer(nil)
 
-	if len(cr.Warnings) != 0 {
-		buf.WriteString("\nWarnings:\n")
-		prettyErrors(buf, cr.Warnings)
-	}
-
 	var newObjects []k8s.ObjectRef
 	var changedObjects []k8s.ObjectRef
 	var deletedObjects []k8s.ObjectRef
@@ -82,6 +77,11 @@ func formatCommandResultText(cr *result.CommandResult, short bool) string {
 	if len(orphanObjects) != 0 {
 		buf.WriteString("\nOrphan objects:\n")
 		prettyObjectRefs(buf, orphanObjects)
+	}
+
+	if len(cr.Warnings) != 0 {
+		buf.WriteString("\nWarnings:\n")
+		prettyErrors(buf, cr.Warnings)
 	}
 
 	if len(cr.Errors) != 0 {


### PR DESCRIPTION
# Description

This makes it easier to spot warnings. If they are printed at the top, its easy to miss warnings completely if many changes are present.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
