### PR TITLE
feat: Use users cache dir for everything cache related

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk update && apk add git tzdata
 
 # Ensure helm is not trying to access /
 ENV HELM_CACHE_HOME=/tmp/helm-cache
+ENV KLUCTL_CACHE_DIR=/tmp/kluctl-cache
 
 COPY bin/kluctl /usr/bin/
 

--- a/cmd/kluctl/commands/root.go
+++ b/cmd/kluctl/commands/root.go
@@ -187,7 +187,7 @@ func checkNewVersion(ctx context.Context) {
 		return
 	}
 
-	versionCheckPath := filepath.Join(utils.GetTmpBaseDir(ctx), "version_check.yaml")
+	versionCheckPath := filepath.Join(utils.GetCacheDir(ctx), "version_check.yaml")
 	var versionCheckState VersionCheckState
 	err := yaml.ReadYamlFile(versionCheckPath, &versionCheckState)
 	if err == nil {

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -30,7 +30,7 @@ import (
 )
 
 func withKluctlProjectFromArgs(ctx context.Context, kubeconfigFlags *args.KubeconfigFlags, projectFlags args.ProjectFlags, argsFlags *args.ArgsFlags, helmCredentials *args.HelmCredentials, registryCredentials *args.RegistryCredentials, internalDeploy bool, strictTemplates bool, forCompletion bool, cb func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error) error {
-	j2, err := kluctl_jinja2.NewKluctlJinja2(strictTemplates)
+	j2, err := kluctl_jinja2.NewKluctlJinja2(ctx, strictTemplates)
 	if err != nil {
 		return err
 	}

--- a/e2e/deployment_items_test.go
+++ b/e2e/deployment_items_test.go
@@ -244,7 +244,7 @@ func testLocalIncludes(t *testing.T, projectDir string) {
 		return nil
 	}, "")
 
-	baseDir, _ := filepath.Rel(filepath.Join(p.LocalProjectDir(), projectDir), filepath.Join(p.LocalRepoDir(), "base"))
+	baseDir, _ := filepath.Rel(filepath.Join(p.LocalProjectDir(), projectDir), filepath.Join(p.LocalWorkDir(), "base"))
 	baseDir = filepath.ToSlash(baseDir)
 
 	p.UpdateDeploymentYaml(projectDir, func(o *uo.UnstructuredObject) error {

--- a/e2e/gitops_git_include_test.go
+++ b/e2e/gitops_git_include_test.go
@@ -120,7 +120,7 @@ func (suite *GitOpsIncludesSuite) testGitOpsGitIncludeCredentials(legacyGitSourc
 			var credentials []v1beta1.ProjectCredentialsGitDeprecated
 			credentials = append(credentials, v1beta1.ProjectCredentialsGitDeprecated{
 				Host:       gs1.GitHost(),
-				PathPrefix: ip1.GitRepoName(),
+				PathPrefix: ip1.GitUrlPath(),
 				SecretRef:  v1beta1.LocalObjectReference{Name: secret2},
 			})
 			credentials = append(credentials, v1beta1.ProjectCredentialsGitDeprecated{
@@ -137,7 +137,7 @@ func (suite *GitOpsIncludesSuite) testGitOpsGitIncludeCredentials(legacyGitSourc
 			var credentials []v1beta1.ProjectCredentialsGit
 			credentials = append(credentials, v1beta1.ProjectCredentialsGit{
 				Host:      gs1.GitHost(),
-				Path:      ip1.GitRepoName(),
+				Path:      ip1.GitUrlPath(),
 				SecretRef: v1beta1.LocalObjectReference{Name: secret2},
 			})
 			credentials = append(credentials, v1beta1.ProjectCredentialsGit{

--- a/e2e/gitops_misc_test.go
+++ b/e2e/gitops_misc_test.go
@@ -71,7 +71,7 @@ func (suite *GitOpsMiscSuite) TestOciSourceWithPath() {
 
 	repoUrl := repo.URL.String() + "/org/repo"
 
-	p.KluctlMust(suite.T(), "oci", "push", "--url", repoUrl, "--project-dir", p.LocalRepoDir())
+	p.KluctlMust(suite.T(), "oci", "push", "--url", repoUrl, "--project-dir", p.LocalWorkDir())
 
 	p.AddExtraArgs("--controller-namespace", suite.gitopsNamespace+"-system")
 

--- a/e2e/gitops_oci_include_test.go
+++ b/e2e/gitops_oci_include_test.go
@@ -54,7 +54,7 @@ func (suite *GitOpsOciIncludeSuite) TestGitOpsOciIncludeCredentials() {
 	repoUrl3 := repo3.URL.String() + "/org3/repo3"
 
 	ip1.KluctlMust(suite.T(), "oci", "push", "--url", repoUrl1, "--registry-creds", fmt.Sprintf("%s=user1:pass1", repo1.URL.Host))
-	ip2.KluctlMust(suite.T(), "oci", "push", "--url", repoUrl2, "--project-dir", ip2.LocalRepoDir(), "--registry-creds", fmt.Sprintf("%s=user2:pass2", repo2.URL.Host))
+	ip2.KluctlMust(suite.T(), "oci", "push", "--url", repoUrl2, "--project-dir", ip2.LocalWorkDir(), "--registry-creds", fmt.Sprintf("%s=user2:pass2", repo2.URL.Host))
 	ip3.KluctlMust(suite.T(), "oci", "push", "--url", repoUrl3, "--registry-creds", fmt.Sprintf("%s=user3:pass3", repo3.URL.Host))
 
 	p := test_project.NewTestProject(suite.T())

--- a/e2e/oci_include_test.go
+++ b/e2e/oci_include_test.go
@@ -31,7 +31,7 @@ func TestOciIncludeMultipleRepos(t *testing.T) {
 	repo2 := repo.URL.String() + "/org2/repo2"
 
 	ip1.KluctlMust(t, "oci", "push", "--url", repo1)
-	ip2.KluctlMust(t, "oci", "push", "--url", repo2, "--project-dir", ip2.LocalRepoDir())
+	ip2.KluctlMust(t, "oci", "push", "--url", repo2, "--project-dir", ip2.LocalWorkDir())
 
 	p := test_project.NewTestProject(t)
 
@@ -91,7 +91,7 @@ func TestOciIncludeWithCreds(t *testing.T) {
 
 	// now with valid creds
 	ip1.KluctlMust(t, "oci", "push", "--url", repoUrl1, "--registry-creds", fmt.Sprintf("%s=user1:pass1", repo1.URL.Host))
-	ip2.KluctlMust(t, "oci", "push", "--url", repoUrl2, "--project-dir", ip2.LocalRepoDir(), "--registry-creds", fmt.Sprintf("%s=user2:pass2", repo2.URL.Host))
+	ip2.KluctlMust(t, "oci", "push", "--url", repoUrl2, "--project-dir", ip2.LocalWorkDir(), "--registry-creds", fmt.Sprintf("%s=user2:pass2", repo2.URL.Host))
 	ip3.KluctlMust(t, "oci", "push", "--url", repoUrl3, "--registry-creds", fmt.Sprintf("%s=user3:pass3", repo3.URL.Host))
 
 	p := test_project.NewTestProject(t)

--- a/e2e/source_override_test.go
+++ b/e2e/source_override_test.go
@@ -48,7 +48,7 @@ func prepareLocalSourceOverrideTest(t *testing.T, k *test_utils.EnvTestCluster, 
 
 	if oci {
 		ip1.KluctlMust(t, "oci", "push", "--url", repo1)
-		ip2.KluctlMust(t, "oci", "push", "--url", repo2, "--project-dir", ip2.LocalRepoDir())
+		ip2.KluctlMust(t, "oci", "push", "--url", repo2, "--project-dir", ip2.LocalWorkDir())
 	}
 
 	if oci {

--- a/e2e/test_project/kluctl_execute.go
+++ b/e2e/test_project/kluctl_execute.go
@@ -33,6 +33,7 @@ func KluctlExecute(t *testing.T, ctx context.Context, logFn func(args ...any), a
 	})
 
 	ctx = utils.WithTmpBaseDir(ctx, t.TempDir())
+	ctx = utils.WithCacheDir(ctx, t.TempDir())
 	ctx = commands.WithStdStreams(ctx, stdout, stderr)
 	sh := status.NewSimpleStatusHandler(func(level status.Level, message string) {
 		_, _ = stderr.Write([]byte(message + "\n"))

--- a/e2e/test_project/project.go
+++ b/e2e/test_project/project.go
@@ -7,6 +7,7 @@ import (
 	"github.com/huandu/xstrings"
 	"github.com/jinzhu/copier"
 	git2 "github.com/kluctl/kluctl/v2/e2e/test-utils"
+	"github.com/kluctl/kluctl/v2/pkg/types"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
@@ -452,12 +453,20 @@ func (p *TestProject) GitUrl() string {
 	return p.gitServer.GitRepoUrl(p.gitRepoName)
 }
 
-func (p *TestProject) LocalRepoDir() string {
-	return p.gitServer.LocalRepoDir(p.gitRepoName)
+func (p *TestProject) GitUrlPath() string {
+	u, err := types.ParseGitUrl(p.GitUrl())
+	if err != nil {
+		panic(err)
+	}
+	return strings.TrimPrefix(u.Path, "/")
+}
+
+func (p *TestProject) LocalWorkDir() string {
+	return p.gitServer.LocalWorkDir(p.gitRepoName)
 }
 
 func (p *TestProject) LocalProjectDir() string {
-	return path.Join(p.LocalRepoDir(), p.gitSubDir)
+	return path.Join(p.LocalWorkDir(), p.gitSubDir)
 }
 
 func (p *TestProject) GetGitRepo() *git.Repository {
@@ -473,7 +482,7 @@ func (p *TestProject) GetGitWorktree() *git.Worktree {
 }
 
 func (p *TestProject) CopyProjectSourceTo(dst string) string {
-	err := cp.Copy(p.LocalRepoDir(), dst)
+	err := cp.Copy(p.LocalWorkDir(), dst)
 	if err != nil {
 		panic(err)
 	}

--- a/e2e/test_project/project.go
+++ b/e2e/test_project/project.go
@@ -507,6 +507,7 @@ func (p *TestProject) KluctlProcess(t *testing.T, argsIn ...string) (string, str
 	// this will cause the init() function from call_kluctl_hack.go to invoke the kluctl root command and then exit
 	env = append(env, "CALL_KLUCTL=true")
 	env = append(env, fmt.Sprintf("KLUCTL_BASE_TMP_DIR=%s", t.TempDir()))
+	env = append(env, fmt.Sprintf("KLUCTL_CACHE_DIR=%s", t.TempDir()))
 
 	t.Logf("Runnning kluctl: %s", strings.Join(args, " "))
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jinzhu/copier v0.4.0
 	github.com/kevinburke/ssh_config v1.2.0
 	github.com/kluctl/go-embed-python v0.0.0-3.11.6-20231002-1
-	github.com/kluctl/go-jinja2 v0.0.0-20231212133626-a0ab9d228150
+	github.com/kluctl/go-jinja2 v0.0.0-20240108142937-8839259d2537
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-runewidth v0.0.15

--- a/go.sum
+++ b/go.sum
@@ -445,8 +445,8 @@ github.com/klauspost/cpuid/v2 v2.2.6 h1:ndNyv040zDGIDh8thGkXYjnFtiN02M1PVVF+JE/4
 github.com/klauspost/cpuid/v2 v2.2.6/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kluctl/go-embed-python v0.0.0-3.11.6-20231002-1 h1:L+ZH/eN5gE7eh3BTye/Z8td8YjbhEs6hzybVByz2twQ=
 github.com/kluctl/go-embed-python v0.0.0-3.11.6-20231002-1/go.mod h1:2/V+QZL7VyhTXtKHorARyA7UYOizVV37M8kkXMEk+Kg=
-github.com/kluctl/go-jinja2 v0.0.0-20231212133626-a0ab9d228150 h1:Iz6c78GzlaRhazmV9rO10+bxk8Nh+v3aAZ60ulnGKPs=
-github.com/kluctl/go-jinja2 v0.0.0-20231212133626-a0ab9d228150/go.mod h1:7FmUmt2zgHJfJE82ZNY/AHNGsGdyHBaF3OA12r4Zj+8=
+github.com/kluctl/go-jinja2 v0.0.0-20240108142937-8839259d2537 h1:oG9FYqprfbAI9kQtec4D0gPwJqLJlS+euknEVz25gp0=
+github.com/kluctl/go-jinja2 v0.0.0-20240108142937-8839259d2537/go.mod h1:7FmUmt2zgHJfJE82ZNY/AHNGsGdyHBaF3OA12r4Zj+8=
 github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgShxwh4x8M=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/pkg/controllers/kluctl_project.go
+++ b/pkg/controllers/kluctl_project.go
@@ -91,7 +91,7 @@ func prepareProject(ctx context.Context,
 	}()
 
 	var err error
-	pp.j2, err = kluctl_jinja2.NewKluctlJinja2(true)
+	pp.j2, err = kluctl_jinja2.NewKluctlJinja2(ctx, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/kluctldeployment_controller_source.go
+++ b/pkg/controllers/kluctldeployment_controller_source.go
@@ -18,8 +18,6 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"net/url"
-	"os"
-	"path/filepath"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
@@ -443,19 +441,6 @@ func (r *KluctlDeploymentReconciler) buildOciRepoCacheKey(secrets []ociRepoSecre
 }
 
 func (r *KluctlDeploymentReconciler) buildGitRepoCache(ctx context.Context, secrets []gitRepoSecrets, soClient sourceoverride.Resolver) (*repocache.GitRepoCache, error) {
-	key, err := r.buildGitRepoCacheKey(secrets)
-	if err != nil {
-		return nil, err
-	}
-
-	tmpBaseDir := filepath.Join(utils.GetTmpBaseDir(ctx), "kluctl-controller-git-cache", key)
-	err = os.MkdirAll(tmpBaseDir, 0o700)
-	if err != nil {
-		return nil, err
-	}
-
-	ctx = utils.WithTmpBaseDir(ctx, tmpBaseDir)
-
 	ga, err := r.buildGitAuth(ctx, secrets)
 	if err != nil {
 		return nil, err
@@ -466,19 +451,6 @@ func (r *KluctlDeploymentReconciler) buildGitRepoCache(ctx context.Context, secr
 }
 
 func (r *KluctlDeploymentReconciler) buildOciRepoCache(ctx context.Context, secrets []ociRepoSecrets, soClient sourceoverride.Resolver) (*repocache.OciRepoCache, *auth_provider.OciAuthProviders, error) {
-	key, err := r.buildOciRepoCacheKey(secrets)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	tmpBaseDir := filepath.Join(utils.GetTmpBaseDir(ctx), "kluctl-controller-oci-cache", key)
-	err = os.MkdirAll(tmpBaseDir, 0o700)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	ctx = utils.WithTmpBaseDir(ctx, tmpBaseDir)
-
 	ociAuthProvider, err := r.buildOciAuth(ctx, secrets)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -321,7 +321,7 @@ func (c *Chart) Pull(ctx context.Context, pc *PulledChart) error {
 }
 
 func (c *Chart) doPullCached(ctx context.Context, version string) (*PulledChart, *lockedfile.File, error) {
-	baseDir := filepath.Join(utils.GetTmpBaseDir(ctx), "helm-charts")
+	baseDir := filepath.Join(utils.GetCacheDir(ctx), "helm-charts")
 	cacheDir, err := c.BuildPulledChartDir(baseDir, version)
 	_ = os.MkdirAll(cacheDir, 0o755)
 

--- a/pkg/k8s/discovery.go
+++ b/pkg/k8s/discovery.go
@@ -20,7 +20,7 @@ func CreateDiscoveryAndMapper(ctx context.Context, config *rest.Config) (discove
 	if err != nil {
 		return nil, nil, err
 	}
-	discoveryCacheDir := filepath.Join(utils.GetTmpBaseDir(ctx), "kube-cache/discovery", strings.ReplaceAll(apiHost.Host, ":", "-"))
+	discoveryCacheDir := filepath.Join(utils.GetCacheDir(ctx), "kube-cache", "discovery", strings.ReplaceAll(apiHost.Host, ":", "-"))
 	discovery2, err := disk.NewCachedDiscoveryClientForConfig(dynamic.ConfigFor(config), discoveryCacheDir, "", time.Hour*24)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/kluctl_jinja2/jinja2.go
+++ b/pkg/kluctl_jinja2/jinja2.go
@@ -1,14 +1,18 @@
 package kluctl_jinja2
 
 import (
+	"context"
 	"github.com/kluctl/go-embed-python/embed_util"
 	x "github.com/kluctl/go-jinja2"
+	"github.com/kluctl/kluctl/v2/pkg/utils"
+	"path/filepath"
 )
 
 const parallelism = 4
 
-func NewKluctlJinja2(strict bool) (*x.Jinja2, error) {
-	extSrc, err := embed_util.NewEmbeddedFiles(ExtSource, "kluctl-ext")
+func NewKluctlJinja2(ctx context.Context, strict bool) (*x.Jinja2, error) {
+	tmpDir := filepath.Join(utils.GetCacheDir(ctx), "go-embed-jinja2")
+	extSrc, err := embed_util.NewEmbeddedFilesWithTmpDir(ExtSource, filepath.Join(tmpDir, "kluctl-ext"), true)
 	if err != nil {
 		return nil, err
 	}
@@ -20,5 +24,7 @@ func NewKluctlJinja2(strict bool) (*x.Jinja2, error) {
 		x.WithExtension("go_jinja2.ext.kluctl"),
 		x.WithExtension("go_jinja2.ext.time"),
 		x.WithExtension("ext.images_ext.ImagesExtension"),
-		x.WithPythonPath(extSrc.GetExtractedPath()))
+		x.WithPythonPath(extSrc.GetExtractedPath()),
+		x.WithEmbeddedExtractDir(tmpDir),
+	)
 }

--- a/pkg/kluctl_jinja2/jinja2.go
+++ b/pkg/kluctl_jinja2/jinja2.go
@@ -5,13 +5,22 @@ import (
 	"github.com/kluctl/go-embed-python/embed_util"
 	x "github.com/kluctl/go-jinja2"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
+	"os"
 	"path/filepath"
+	"testing"
 )
 
 const parallelism = 4
 
 func NewKluctlJinja2(ctx context.Context, strict bool) (*x.Jinja2, error) {
 	tmpDir := filepath.Join(utils.GetCacheDir(ctx), "go-embed-jinja2")
+
+	if testing.Testing() {
+		// we share the cache for all tests, even though WithCacheDir is used in tests
+		// otherwise things get really slow
+		tmpDir = filepath.Join(os.TempDir(), "kluctl-tests-jinja2")
+	}
+
 	extSrc, err := embed_util.NewEmbeddedFilesWithTmpDir(ExtSource, filepath.Join(tmpDir, "kluctl-ext"), true)
 	if err != nil {
 		return nil, err

--- a/pkg/oci/auth_provider/docker_config_auth_provider.go
+++ b/pkg/oci/auth_provider/docker_config_auth_provider.go
@@ -24,7 +24,7 @@ func (o OciDockerConfigAuthProvider) FindAuthEntry(ctx context.Context, ociUrl s
 	}
 
 	auth, err := authn.DefaultKeychain.Resolve(ociRef.Context())
-	status.Infof(ctx, "login ociRef=%s, auth=%v, err=%s", ociRef.String(), auth, err)
+	status.Tracef(ctx, "login ociRef=%s, auth=%v, err=%s", ociRef.String(), auth, err)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/repocache/git_cache.go
+++ b/pkg/repocache/git_cache.go
@@ -116,7 +116,7 @@ func (rp *GitRepoCache) GetEntry(url string) (*GitCacheEntry, error) {
 
 	e, ok := rp.repos[repoKey]
 	if !ok {
-		mr, err := git.NewMirroredGitRepo(rp.ctx, *u, filepath.Join(utils.GetTmpBaseDir(rp.ctx), "git-cache"), rp.sshPool, rp.authProviders)
+		mr, err := git.NewMirroredGitRepo(rp.ctx, *u, filepath.Join(utils.GetCacheDir(rp.ctx), "git-cache"), rp.sshPool, rp.authProviders)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/repocache/oci_cache.go
+++ b/pkg/repocache/oci_cache.go
@@ -109,7 +109,7 @@ func (rp *OciRepoCache) GetEntry(urlIn string) (*OciCacheEntry, error) {
 		return e, nil
 	}
 
-	hostOciCacheDir := filepath.Join(utils.GetTmpBaseDir(rp.ctx), "oci")
+	hostOciCacheDir := filepath.Join(utils.GetCacheDir(rp.ctx), "oci")
 	hostOciCacheDir = filepath.Join(hostOciCacheDir, strings.ReplaceAll(urlN.Host, ":", "-"))
 
 	ociCacheDir := filepath.Join(hostOciCacheDir, urlN.Path)

--- a/pkg/sourceoverride/proxyclient_cli.go
+++ b/pkg/sourceoverride/proxyclient_cli.go
@@ -292,17 +292,12 @@ func (c *ProxyClientCli) handleRequest(req *ResolveOverrideRequest) ([]byte, err
 
 	status.Infof(c.ctx, "Controller requested override for %s", req.RepoKey)
 
-	cleanup := false
 	f, err := os.CreateTemp(utils.GetTmpBaseDir(ctx), "so-*.tgz")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temp file: %w", err)
 	}
 	f.Close()
-	defer func() {
-		if cleanup {
-			_ = os.Remove(f.Name())
-		}
-	}()
+	defer os.Remove(f.Name())
 
 	absPath, err := filepath.Abs(p)
 	if err != nil {

--- a/pkg/types/git_url.go
+++ b/pkg/types/git_url.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	"net/url"
+	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -112,19 +113,22 @@ func (u *GitUrl) NormalizePort() string {
 }
 
 func (u *GitUrl) Normalize() *GitUrl {
-	path := strings.ToLower(u.Path)
-	path = strings.TrimSuffix(path, ".git")
-	path = strings.TrimSuffix(path, "/")
+	p := strings.ToLower(u.Path)
+	if path.Base(p) != ".git" {
+		// we only trim it with it does not end with /.git
+		p = strings.TrimSuffix(p, ".git")
+	}
+	p = strings.TrimSuffix(p, "/")
 
 	hostname := strings.ToLower(u.Hostname())
 	port := u.NormalizePort()
 
-	if path != "" && hostname != "" && !strings.HasPrefix(path, "/") {
-		path = "/" + path
+	if p != "" && hostname != "" && !strings.HasPrefix(p, "/") {
+		p = "/" + p
 	}
 
 	u2 := *u
-	u2.Path = path
+	u2.Path = p
 	u2.Host = hostname
 	if port != "" {
 		u2.Host += ":" + port

--- a/pkg/utils/tmpdir.go
+++ b/pkg/utils/tmpdir.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"k8s.io/client-go/util/homedir"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -11,33 +12,53 @@ import (
 	"sync"
 )
 
-type tmpBaseDirKey int
-type tmpBaseDirValue struct {
+type tmpBaseDirKey struct{}
+type cacheDirKey struct{}
+
+type dirValue struct {
 	dir      string
 	initOnce sync.Once
 }
 
-var tmpBaseDirKeyInst tmpBaseDirKey
-var tmpBaseDirValueDefault = &tmpBaseDirValue{
+var tmpBaseDirValueDefault = &dirValue{
 	dir: getDefaultTmpBaseDir(),
 }
 
 func WithTmpBaseDir(ctx context.Context, tmpBaseDir string) context.Context {
-	return context.WithValue(ctx, tmpBaseDirKeyInst, &tmpBaseDirValue{
+	return context.WithValue(ctx, &tmpBaseDirKey{}, &dirValue{
 		dir: tmpBaseDir,
 	})
 }
 
+func WithCacheDir(ctx context.Context, cacheDir string) context.Context {
+	return context.WithValue(ctx, cacheDirKey{}, &dirValue{
+		dir: cacheDir,
+	})
+}
+
 func GetTmpBaseDir(ctx context.Context) string {
-	v := ctx.Value(tmpBaseDirKeyInst)
+	v := ctx.Value(tmpBaseDirKey{})
 	if v == nil {
 		v = tmpBaseDirValueDefault
 	}
-	v2 := v.(*tmpBaseDirValue)
+	v2 := v.(*dirValue)
 	v2.initOnce.Do(func() {
 		v2.dir = createTmpBaseDir(v2.dir)
 	})
 	return v2.dir
+}
+
+func GetCacheDir(ctx context.Context) string {
+	v := ctx.Value(cacheDirKey{})
+	var dir string
+	if v == nil {
+		dir = getDefaultCacheDir(ctx)
+	} else {
+		v2 := v.(*dirValue)
+		dir = v2.dir
+	}
+	ensureDir(dir, 0o700, true)
+	return dir
 }
 
 func getDefaultTmpBaseDir() string {
@@ -47,6 +68,31 @@ func getDefaultTmpBaseDir() string {
 	}
 
 	return filepath.Join(os.TempDir(), "kluctl-workdir")
+}
+
+func getDefaultCacheDir(ctx context.Context) string {
+	p := os.Getenv("KLUCTL_CACHE_DIR")
+	if p != "" {
+		return p
+	}
+	p = os.Getenv("XDG_CACHE_HOME")
+	if p != "" {
+		return filepath.Join(p, "kluctl")
+	}
+	h := homedir.HomeDir()
+	switch runtime.GOOS {
+	case "linux":
+		if h != "" {
+			return filepath.Join(h, ".cache", "kluctl")
+		}
+	case "darwin":
+		if h != "" {
+			return filepath.Join(h, "Library", "Caches", "kluctl")
+		}
+	case "windows":
+		break
+	}
+	return filepath.Join(GetTmpBaseDir(ctx), "cache")
 }
 
 func createTmpBaseDir(dir string) string {

--- a/pkg/vars/vars_test.go
+++ b/pkg/vars/vars_test.go
@@ -1,6 +1,7 @@
 package vars
 
 import (
+	"context"
 	"github.com/kluctl/go-jinja2"
 	"github.com/kluctl/kluctl/v2/pkg/kluctl_jinja2"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
@@ -9,7 +10,7 @@ import (
 )
 
 func newJinja2Must(t *testing.T) *jinja2.Jinja2 {
-	j2, err := kluctl_jinja2.NewKluctlJinja2(true)
+	j2, err := kluctl_jinja2.NewKluctlJinja2(context.Background(), true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
# Description

Instead of storing everything in the kluctl-workdir inside the tmp dir, use the users cache dirs.

Fixes #389

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
