### PR TITLE
fix: Shorten prepare errors to avoid killing k9s and friends

### DIFF
--- a/e2e/gitops_git_include_test.go
+++ b/e2e/gitops_git_include_test.go
@@ -45,7 +45,7 @@ func (suite *GitOpsIncludesSuite) TestGitOpsGitIncludeDeprecatedSecret() {
 		g.Expect(readinessCondition).ToNot(BeNil())
 		g.Expect(readinessCondition.Status).To(Equal(v1.ConditionFalse))
 		g.Expect(readinessCondition.Reason).To(Equal("PrepareFailed"))
-		g.Expect(readinessCondition.Message).To(Equal("failed to clone git source: authentication required"))
+		g.Expect(kd.Status.LastPrepareError).To(Equal("failed to clone git source: authentication required"))
 	})
 
 	secret := corev1.Secret{
@@ -102,7 +102,7 @@ func (suite *GitOpsIncludesSuite) testGitOpsGitIncludeCredentials(legacyGitSourc
 		g.Expect(readinessCondition).ToNot(BeNil())
 		g.Expect(readinessCondition.Status).To(Equal(v1.ConditionFalse))
 		g.Expect(readinessCondition.Reason).To(Equal("PrepareFailed"))
-		g.Expect(readinessCondition.Message).To(Equal("failed to clone git source: authentication required"))
+		g.Expect(kd.Status.LastPrepareError).To(Equal("failed to clone git source: authentication required"))
 	})
 
 	createSecret := func(username string, password string) string {

--- a/e2e/gitops_misc_test.go
+++ b/e2e/gitops_misc_test.go
@@ -39,7 +39,7 @@ func (suite *GitOpsMiscSuite) TestGitSourceWithPath() {
 		kd := suite.waitForCommit(key, getHeadRevision(suite.T(), p))
 		status := suite.getReadiness(kd)
 		assert.Equal(suite.T(), metav1.ConditionFalse, status.Status)
-		assert.Equal(suite.T(), "target target1 not existent in kluctl project config", status.Message)
+		assert.Equal(suite.T(), "target target1 not existent in kluctl project config", kd.Status.LastPrepareError)
 	})
 
 	suite.Run("deployment with path succeeds", func() {
@@ -85,7 +85,7 @@ func (suite *GitOpsMiscSuite) TestOciSourceWithPath() {
 		kd := suite.waitForCommit(key, getHeadRevision(suite.T(), p))
 		status := suite.getReadiness(kd)
 		assert.Equal(suite.T(), metav1.ConditionFalse, status.Status)
-		assert.Equal(suite.T(), "target target1 not existent in kluctl project config", status.Message)
+		assert.Equal(suite.T(), "target target1 not existent in kluctl project config", kd.Status.LastPrepareError)
 	})
 
 	suite.Run("deployment with path succeeds", func() {
@@ -134,6 +134,6 @@ func (suite *GitOpsMiscSuite) TestNoTargetError() {
 
 		g.Expect(readinessCondition.Status).To(Equal(metav1.ConditionFalse))
 		g.Expect(readinessCondition.Reason).To(Equal(kluctlv1.PrepareFailedReason))
-		g.Expect(readinessCondition.Message).To(ContainSubstring("a target must be explicitly selected when targets are defined in the Kluctl project"))
+		g.Expect(kd.Status.LastPrepareError).To(ContainSubstring("a target must be explicitly selected when targets are defined in the Kluctl project"))
 	})
 }

--- a/e2e/gitops_oci_include_test.go
+++ b/e2e/gitops_oci_include_test.go
@@ -93,7 +93,7 @@ func (suite *GitOpsOciIncludeSuite) TestGitOpsOciIncludeCredentials() {
 		g.Expect(readinessCondition).ToNot(BeNil())
 		g.Expect(readinessCondition.Status).To(Equal(v1.ConditionFalse))
 		g.Expect(readinessCondition.Reason).To(Equal("PrepareFailed"))
-		g.Expect(readinessCondition.Message).To(ContainSubstring("401 Unauthorized"))
+		g.Expect(kd.Status.LastPrepareError).To(ContainSubstring("401 Unauthorized"))
 	})
 
 	createSecret := func(secretName string, username string, password string) {

--- a/e2e/helm_test.go
+++ b/e2e/helm_test.go
@@ -38,7 +38,8 @@ type helmTestCase struct {
 	argPassCA         bool
 	argPassClientCert bool
 
-	expectedError string
+	expectedReadyError   string
+	expectedPrepareError string
 }
 
 var helmTests = []helmTestCase{
@@ -48,9 +49,10 @@ var helmTests = []helmTestCase{
 	// tls tests
 	{
 		name: "helm-tls-missing-ca", testTLS: true,
-		argPassCA:     false,
-		argCredsHost:  "<host>",
-		expectedError: "failed to verify certificate",
+		argPassCA:            false,
+		argCredsHost:         "<host>",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "failed to verify certificate",
 	},
 	{
 		name: "helm-tls-valid-ca", testTLS: true,
@@ -59,10 +61,11 @@ var helmTests = []helmTestCase{
 	},
 	{
 		name: "helm-tls-missing-cert", testTLS: true, testTLSClientCert: true,
-		argPassCA:         true,
-		argPassClientCert: false,
-		argCredsHost:      "<host>",
-		expectedError:     "certificate required",
+		argPassCA:            true,
+		argPassClientCert:    false,
+		argCredsHost:         "<host>",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "certificate required",
 	},
 	{
 		name: "helm-tls-valid-cert", testTLS: true, testTLSClientCert: true,
@@ -73,9 +76,10 @@ var helmTests = []helmTestCase{
 
 	{
 		name: "oci-tls-missing-ca", oci: true, testTLS: true,
-		argPassCA:     false,
-		argCredsHost:  "<host>",
-		expectedError: "failed to verify certificate",
+		argPassCA:            false,
+		argCredsHost:         "<host>",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "failed to verify certificate",
 	},
 	{
 		name: "oci-tls-valid-ca", oci: true, testTLS: true,
@@ -84,10 +88,11 @@ var helmTests = []helmTestCase{
 	},
 	{
 		name: "oci-tls-missing-cert", oci: true, testTLS: true, testTLSClientCert: true,
-		argPassCA:         true,
-		argPassClientCert: false,
-		argCredsHost:      "<host>",
-		expectedError:     "certificate required",
+		argPassCA:            true,
+		argPassClientCert:    false,
+		argCredsHost:         "<host>",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "certificate required",
 	},
 	{
 		name: "oci-tls-valid-cert", oci: true, testTLS: true, testTLSClientCert: true,
@@ -99,12 +104,14 @@ var helmTests = []helmTestCase{
 	// deprecated helm credentials flags
 	{
 		name: "dep-helm-creds-missing", oci: false, testAuth: true, credsId: "test-creds",
-		expectedError: "401 Unauthorized",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "401 Unauthorized",
 	},
 	{
 		name: "dep-helm-creds-invalid", oci: false, testAuth: true, credsId: "test-creds",
 		argCredsId: "test-creds", argUsername: "test-user", argPassword: "invalid",
-		expectedError: "401 Unauthorized",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "401 Unauthorized",
 	},
 	{
 		name: "dep-helm-creds-valid", oci: false, testAuth: true, credsId: "test-creds",
@@ -113,19 +120,22 @@ var helmTests = []helmTestCase{
 	{
 		name: "dep-oci-creds-fail", oci: true, testAuth: true, credsId: "test-creds",
 		argCredsId: "test-creds", argUsername: "test-user", argPassword: "secret-password",
-		expectedError: "OCI charts can currently only be authenticated via registry login and environment variables but not via cli arguments",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "OCI charts can currently only be authenticated via registry login and environment variables but not via cli arguments",
 	},
 
 	// new helm credentials flags
 	{
 		name: "helm-creds-missing", oci: false, testAuth: true,
 		argCredsHost: "<host>-invalid", argUsername: "test-user", argPassword: "secret-password",
-		expectedError: "401 Unauthorized",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "401 Unauthorized",
 	},
 	{
 		name: "helm-creds-invalid", oci: false, testAuth: true,
 		argCredsHost: "<host>", argUsername: "test-user", argPassword: "invalid",
-		expectedError: "401 Unauthorized",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "401 Unauthorized",
 	},
 	{
 		name: "helm-creds-valid", oci: false, testAuth: true,
@@ -134,12 +144,14 @@ var helmTests = []helmTestCase{
 	{
 		name: "helm-creds-missing-path", oci: false, testAuth: true, path: "path1",
 		argCredsHost: "<host>", argCredsPath: "path2", argUsername: "test-user", argPassword: "secret-password",
-		expectedError: "401 Unauthorized",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "401 Unauthorized",
 	},
 	{
 		name: "helm-creds-invalid-path", oci: false, testAuth: true, path: "path1",
 		argCredsHost: "<host>", argCredsPath: "path1", argUsername: "test-user", argPassword: "invalid",
-		expectedError: "401 Unauthorized",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "401 Unauthorized",
 	},
 	{
 		name: "helm-creds-valid-path", oci: false, testAuth: true, path: "path1",
@@ -150,12 +162,14 @@ var helmTests = []helmTestCase{
 	{
 		name: "oci-creds-missing", oci: true, testAuth: true,
 		argCredsHost: "<host>-invalid", argUsername: "test-user", argPassword: "secret-password",
-		expectedError: "no basic auth credentials",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "no basic auth credentials",
 	},
 	{
 		name: "oci-creds-invalid", oci: true, testAuth: true,
 		argCredsHost: "<host>", argUsername: "test-user", argPassword: "invalid",
-		expectedError: "401 Unauthorized",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "401 Unauthorized",
 	},
 	{
 		name: "oci-creds-valid", oci: true, testAuth: true,
@@ -164,12 +178,14 @@ var helmTests = []helmTestCase{
 	{
 		name: "oci-creds-missing-path", oci: true, testAuth: true,
 		argCredsHost: "<host>", argCredsPath: "test-chart2", argUsername: "test-user", argPassword: "secret-password",
-		expectedError: "no basic auth credentials",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "no basic auth credentials",
 	},
 	{
 		name: "oci-creds-invalid-path", oci: true, testAuth: true,
 		argCredsHost: "<host>", argCredsPath: "test-chart1", argUsername: "test-user", argPassword: "invalid",
-		expectedError: "401 Unauthorized",
+		expectedReadyError:   "prepare failed with 1 errors. Check status.lastPrepareError for details",
+		expectedPrepareError: "401 Unauthorized",
 	},
 	{
 		name: "oci-creds-valid-path", oci: true, testAuth: true,
@@ -361,9 +377,9 @@ func prepareHelmTestCase(t *testing.T, k *test_utils.EnvTestCluster, tc helmTest
 		args = append(args, extraArgs...)
 
 		_, stderr, err := p.Kluctl(t, args...)
-		if tc.expectedError != "" {
+		if tc.expectedPrepareError != "" {
 			assert.Error(t, err)
-			assert.Contains(t, stderr, tc.expectedError)
+			assert.Contains(t, stderr, tc.expectedPrepareError)
 			return p, repo, err
 		} else {
 			assert.NoError(t, err)
@@ -394,7 +410,7 @@ func testHelmPull(t *testing.T, tc helmTestCase, prePull bool, credsViaEnv bool)
 	k := defaultCluster1
 	p, repo, err := prepareHelmTestCase(t, k, tc, prePull, useProcess)
 	if err != nil {
-		if tc.expectedError == "" {
+		if tc.expectedPrepareError == "" {
 			assert.Fail(t, "did not expect error")
 		}
 		return
@@ -414,11 +430,11 @@ func testHelmPull(t *testing.T, tc helmTestCase, prePull bool, credsViaEnv bool)
 	} else {
 		assert.Contains(t, stderr, pullMessage)
 	}
-	if tc.expectedError != "" {
+	if tc.expectedPrepareError != "" {
 		if useProcess {
-			assert.Contains(t, stderr, tc.expectedError)
+			assert.Contains(t, stderr, tc.expectedPrepareError)
 		} else {
-			assert.ErrorContains(t, err, tc.expectedError)
+			assert.ErrorContains(t, err, tc.expectedPrepareError)
 		}
 	} else {
 		assert.NoError(t, err)

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -418,6 +418,11 @@ func (a *ApplyUtil) ApplyObject(x *uo.UnstructuredObject, replaced bool, hook bo
 
 			_, _, tmpErr := a.k.GetSingleObjectMetadata(crdRef)
 			if tmpErr == nil {
+				// CRD might be so fresh that it is not accepted/ready yet, so lets wait for readiness
+				if !a.WaitReadiness(crdRef, 5*time.Second) {
+					a.HandleError(ref, err)
+					return
+				}
 				status.Tracef(a.ctx, "resource unknown, and CRD %s is available, retrying with invalidated caches", crdName)
 				// retry with invalidated discovery
 				a.k.ResetMapper()


### PR DESCRIPTION
# Description

k9s easily dies when columns get too long. This avoids writing too long statuses into the Ready condition.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
