### PR TITLE
fix: Do not use slices of struct pointers in yaml related structs

### DIFF
--- a/pkg/deployment/deployment_collection.go
+++ b/pkg/deployment/deployment_collection.go
@@ -93,7 +93,9 @@ func (c *DeploymentCollection) collectAllDeployments(project *DeploymentProject,
 		return nil, err
 	}
 
-	for i, diConfig := range project.Config.Deployments {
+	for i, _ := range project.Config.Deployments {
+		diConfig := &project.Config.Deployments[i]
+
 		whenTrue, err := project.VarsCtx.CheckConditional(diConfig.When)
 		if err != nil {
 			return nil, err

--- a/pkg/deployment/deployment_project.go
+++ b/pkg/deployment/deployment_project.go
@@ -73,7 +73,7 @@ func NewDeploymentProject(ctx SharedContext, varsCtx *vars.VarsCtx, source Sourc
 	return dp, nil
 }
 
-func (p *DeploymentProject) loadVarsList(varsCtx *vars.VarsCtx, varsList []*types.VarsSource) error {
+func (p *DeploymentProject) loadVarsList(varsCtx *vars.VarsCtx, varsList []types.VarsSource) error {
 	return p.ctx.VarsLoader.LoadVarsList(p.ctx.Ctx, varsCtx, varsList, p.getRenderSearchDirs(), "")
 }
 
@@ -101,7 +101,7 @@ func (p *DeploymentProject) loadConfig() error {
 }
 
 func (p *DeploymentProject) generateSingleKustomizeProject() error {
-	p.Config.Deployments = append(p.Config.Deployments, &types.DeploymentItemConfig{
+	p.Config.Deployments = append(p.Config.Deployments, types.DeploymentItemConfig{
 		Path: utils.StrPtr("."),
 	})
 	return nil
@@ -127,7 +127,8 @@ func (p *DeploymentProject) processConfig() error {
 
 	// If there are no explicit tags set, interpret the path as a tag, which allows to
 	// enable/disable single deployments via included/excluded tags
-	for _, item := range p.Config.Deployments {
+	for i, _ := range p.Config.Deployments {
+		item := &p.Config.Deployments[i]
 		if len(item.Tags) != 0 {
 			continue
 		}
@@ -180,7 +181,8 @@ func (p *DeploymentProject) CheckWhenTrue() (bool, error) {
 }
 
 func (p *DeploymentProject) loadIncludes() error {
-	for i, inc := range p.Config.Deployments {
+	for i, _ := range p.Config.Deployments {
+		inc := &p.Config.Deployments[i]
 		var err error
 		var newProject *DeploymentProject
 
@@ -380,19 +382,19 @@ func (p *DeploymentProject) getTags() *utils.OrderedMap[string, bool] {
 	return &tags
 }
 
-func (p *DeploymentProject) GetIgnoreForDiffs(ignoreTags, ignoreLabels, ignoreAnnotations bool) []*types.IgnoreForDiffItemConfig {
-	var ret []*types.IgnoreForDiffItemConfig
+func (p *DeploymentProject) GetIgnoreForDiffs(ignoreTags, ignoreLabels, ignoreAnnotations bool) []types.IgnoreForDiffItemConfig {
+	var ret []types.IgnoreForDiffItemConfig
 	for _, e := range p.getParents() {
 		ret = append(ret, e.p.Config.IgnoreForDiff...)
 	}
 	if ignoreTags {
-		ret = append(ret, &types.IgnoreForDiffItemConfig{FieldPathRegex: []string{`metadata\.labels\["kluctl\.io/tag-.*"\]`}})
+		ret = append(ret, types.IgnoreForDiffItemConfig{FieldPathRegex: []string{`metadata\.labels\["kluctl\.io/tag-.*"\]`}})
 	}
 	if ignoreLabels {
-		ret = append(ret, &types.IgnoreForDiffItemConfig{FieldPath: []string{`metadata.labels.*`}})
+		ret = append(ret, types.IgnoreForDiffItemConfig{FieldPath: []string{`metadata.labels.*`}})
 	}
 	if ignoreAnnotations {
-		ret = append(ret, &types.IgnoreForDiffItemConfig{FieldPath: []string{`metadata.annotations.*`}})
+		ret = append(ret, types.IgnoreForDiffItemConfig{FieldPath: []string{`metadata.annotations.*`}})
 	}
 	return ret
 }

--- a/pkg/deployment/utils/diff_utils.go
+++ b/pkg/deployment/utils/diff_utils.go
@@ -61,7 +61,7 @@ func (u *DiffUtil) sortChanges() {
 	})
 }
 
-func (u *DiffUtil) diffObjects(objects []*uo.UnstructuredObject, ignoreForDiffs []*types.IgnoreForDiffItemConfig, wg *sync.WaitGroup) {
+func (u *DiffUtil) diffObjects(objects []*uo.UnstructuredObject, ignoreForDiffs []types.IgnoreForDiffItemConfig, wg *sync.WaitGroup) {
 	for _, o := range objects {
 		o := o
 		ref := o.GetK8sRef()
@@ -84,7 +84,7 @@ func (u *DiffUtil) diffObjects(objects []*uo.UnstructuredObject, ignoreForDiffs 
 	}
 }
 
-func (u *DiffUtil) diffObject(lo *uo.UnstructuredObject, diffRef k8s2.ObjectRef, ao *uo.UnstructuredObject, ro *uo.UnstructuredObject, ignoreForDiffs []*types.IgnoreForDiffItemConfig) {
+func (u *DiffUtil) diffObject(lo *uo.UnstructuredObject, diffRef k8s2.ObjectRef, ao *uo.UnstructuredObject, ro *uo.UnstructuredObject, ignoreForDiffs []types.IgnoreForDiffItemConfig) {
 	if ao != nil && ro == nil {
 		// new?
 		return

--- a/pkg/diff/normalize.go
+++ b/pkg/diff/normalize.go
@@ -132,7 +132,7 @@ var ignoreDiffFieldAnnotationRegex = regexp.MustCompile(`^kluctl.io/ignore-diff-
 var ignoreDiffFieldRegexAnnotationRegex = regexp.MustCompile(`^kluctl.io/ignore-diff-field-regex(-\d*)?$`)
 
 // NormalizeObject Performs some deterministic sorting and other normalizations to avoid ugly diffs due to order changes
-func NormalizeObject(o_ *uo.UnstructuredObject, ignoreForDiffs []*types.IgnoreForDiffItemConfig, localObject *uo.UnstructuredObject) (*uo.UnstructuredObject, error) {
+func NormalizeObject(o_ *uo.UnstructuredObject, ignoreForDiffs []types.IgnoreForDiffItemConfig, localObject *uo.UnstructuredObject) (*uo.UnstructuredObject, error) {
 	gvk := o_.GetK8sGVK()
 	name := o_.GetK8sName()
 	ns := o_.GetK8sNamespace()
@@ -163,14 +163,14 @@ func NormalizeObject(o_ *uo.UnstructuredObject, ignoreForDiffs []*types.IgnoreFo
 		return v == *m
 	}
 
-	ignoreForDiffs = append([]*types.IgnoreForDiffItemConfig{}, ignoreForDiffs...)
+	ignoreForDiffs = append([]types.IgnoreForDiffItemConfig{}, ignoreForDiffs...)
 	for _, v := range localObject.GetK8sAnnotationsWithRegex(ignoreDiffFieldAnnotationRegex) {
-		ignoreForDiffs = append(ignoreForDiffs, &types.IgnoreForDiffItemConfig{
+		ignoreForDiffs = append(ignoreForDiffs, types.IgnoreForDiffItemConfig{
 			FieldPath: []string{v},
 		})
 	}
 	for _, v := range localObject.GetK8sAnnotationsWithRegex(ignoreDiffFieldRegexAnnotationRegex) {
-		ignoreForDiffs = append(ignoreForDiffs, &types.IgnoreForDiffItemConfig{
+		ignoreForDiffs = append(ignoreForDiffs, types.IgnoreForDiffItemConfig{
 			FieldPathRegex: []string{v},
 		})
 	}

--- a/pkg/diff/normalize_test.go
+++ b/pkg/diff/normalize_test.go
@@ -40,7 +40,7 @@ type testCase struct {
 	remote         *uo.UnstructuredObject
 	local          *uo.UnstructuredObject
 	result         *uo.UnstructuredObject
-	ignoreForDiffs []*types.IgnoreForDiffItemConfig
+	ignoreForDiffs []types.IgnoreForDiffItemConfig
 }
 
 func runTests(t *testing.T, tests []testCase) {
@@ -112,7 +112,7 @@ func TestNormalizeIgnoreForDiffs(t *testing.T) {
 			remote: buildObject(`{"metadata": {"labels": {"l1": "v1", "l2": "l2", "good": "keep"}}}`),
 			local:  buildObject(),
 			result: buildResultObject(`{"metadata": {"labels": {"good": "keep"}}}`),
-			ignoreForDiffs: []*types.IgnoreForDiffItemConfig{
+			ignoreForDiffs: []types.IgnoreForDiffItemConfig{
 				{FieldPath: []string{"metadata.labels.l1", "metadata.labels.l2"}},
 			},
 		},
@@ -120,7 +120,7 @@ func TestNormalizeIgnoreForDiffs(t *testing.T) {
 			remote: buildObject(`{"metadata": {"labels": {"l1": "v1", "l2": "l2"}}}`),
 			local:  buildObject(),
 			result: buildResultObject(`{"metadata": {"labels": {}}}`),
-			ignoreForDiffs: []*types.IgnoreForDiffItemConfig{
+			ignoreForDiffs: []types.IgnoreForDiffItemConfig{
 				{FieldPath: []string{"metadata.labels.*"}},
 			},
 		},
@@ -128,7 +128,7 @@ func TestNormalizeIgnoreForDiffs(t *testing.T) {
 			remote: buildObject(`{"metadata": {"labels": {"l1": "v1", "l2": "l2", "good": "keep"}}}`),
 			local:  buildObject(),
 			result: buildResultObject(`{"metadata": {"labels": {"good": "keep"}}}`),
-			ignoreForDiffs: []*types.IgnoreForDiffItemConfig{
+			ignoreForDiffs: []types.IgnoreForDiffItemConfig{
 				{FieldPathRegex: []string{`metadata\.labels\.l.*`}},
 			},
 		},
@@ -136,7 +136,7 @@ func TestNormalizeIgnoreForDiffs(t *testing.T) {
 			remote: buildObject(`{"metadata": {"labels": {"l1": "v1", "l2": "l2", "good": "keep"}}}`),
 			local:  buildObject(),
 			result: buildResultObject(`{"metadata": {"labels": {"l1": "v1", "l2": "l2", "good": "keep"}}}`),
-			ignoreForDiffs: []*types.IgnoreForDiffItemConfig{
+			ignoreForDiffs: []types.IgnoreForDiffItemConfig{
 				{FieldPath: []string{"metadata.labels.*"}, Group: utils.StrPtr("Nope")},
 			},
 		},
@@ -144,7 +144,7 @@ func TestNormalizeIgnoreForDiffs(t *testing.T) {
 			remote: buildObject(`{"metadata": {"labels": {"l1": "v1", "l2": "l2", "good": "keep"}}}`),
 			local:  buildObject(),
 			result: buildResultObject(`{"metadata": {"labels": {"l1": "v1", "l2": "l2", "good": "keep"}}}`),
-			ignoreForDiffs: []*types.IgnoreForDiffItemConfig{
+			ignoreForDiffs: []types.IgnoreForDiffItemConfig{
 				{FieldPath: []string{"metadata.labels.*"}, Kind: utils.StrPtr("Nope")},
 			},
 		},
@@ -152,7 +152,7 @@ func TestNormalizeIgnoreForDiffs(t *testing.T) {
 			remote: buildObject(`{"metadata": {"labels": {"l1": "v1", "l2": "l2", "good": "keep"}}}`),
 			local:  buildObject(),
 			result: buildResultObject(`{"metadata": {"labels": {"l1": "v1", "l2": "l2", "good": "keep"}}}`),
-			ignoreForDiffs: []*types.IgnoreForDiffItemConfig{
+			ignoreForDiffs: []types.IgnoreForDiffItemConfig{
 				{FieldPath: []string{"metadata.labels.*"}, Name: utils.StrPtr("Nope")},
 			},
 		},
@@ -160,7 +160,7 @@ func TestNormalizeIgnoreForDiffs(t *testing.T) {
 			remote: buildObject(`{"metadata": {"labels": {"l1": "v1", "l2": "l2", "good": "keep"}}}`),
 			local:  buildObject(),
 			result: buildResultObject(`{"metadata": {"labels": {"l1": "v1", "l2": "l2", "good": "keep"}}}`),
-			ignoreForDiffs: []*types.IgnoreForDiffItemConfig{
+			ignoreForDiffs: []types.IgnoreForDiffItemConfig{
 				{FieldPath: []string{"metadata.labels.*"}, Namespace: utils.StrPtr("Nope")},
 			},
 		},
@@ -168,7 +168,7 @@ func TestNormalizeIgnoreForDiffs(t *testing.T) {
 			remote: buildObject(`{"metadata": {"labels": {"l1": "v1", "l2": "l2"}}}`),
 			local:  buildObject(),
 			result: buildResultObject(`{"metadata": {"labels": {}}}`),
-			ignoreForDiffs: []*types.IgnoreForDiffItemConfig{
+			ignoreForDiffs: []types.IgnoreForDiffItemConfig{
 				{FieldPath: []string{"metadata.labels.*"}, Group: utils.StrPtr("apps"), Kind: utils.StrPtr("Deployment"), Name: utils.StrPtr("test"), Namespace: utils.StrPtr("ns")},
 			},
 		},

--- a/pkg/kluctl_project/external_args.go
+++ b/pkg/kluctl_project/external_args.go
@@ -54,7 +54,7 @@ func ConvertArgsToVars(args map[string]string, allowLoadFromFiles bool) (*uo.Uns
 	return vars, nil
 }
 
-func LoadDefaultArgs(args []*types.DeploymentArg, deployArgs *uo.UnstructuredObject) error {
+func LoadDefaultArgs(args []types.DeploymentArg, deployArgs *uo.UnstructuredObject) error {
 	// load defaults
 	defaults := uo.New()
 	for _, a := range args {
@@ -80,7 +80,7 @@ func LoadDefaultArgs(args []*types.DeploymentArg, deployArgs *uo.UnstructuredObj
 	return nil
 }
 
-func checkRequiredArgs(argsDef []*types.DeploymentArg, args *uo.UnstructuredObject) error {
+func checkRequiredArgs(argsDef []types.DeploymentArg, args *uo.UnstructuredObject) error {
 	for _, a := range argsDef {
 		var p []interface{}
 		for _, x := range strings.Split(a.Name, ".") {

--- a/pkg/kluctl_project/targets.go
+++ b/pkg/kluctl_project/targets.go
@@ -21,7 +21,7 @@ func (c *LoadedKluctlProject) loadTargets(ctx context.Context) error {
 			continue
 		}
 
-		target, err := c.buildTarget(configTarget)
+		target, err := c.buildTarget(&configTarget)
 		if err != nil {
 			status.Warningf(ctx, "Failed to load target config for project: %v", err)
 			continue

--- a/pkg/types/deployment.go
+++ b/pkg/types/deployment.go
@@ -23,7 +23,7 @@ type DeploymentItemConfig struct {
 
 	Args     *uo.UnstructuredObject `json:"args,omitempty"`
 	PassVars bool                   `json:"passVars,omitempty"`
-	Vars     []*VarsSource          `json:"vars,omitempty"`
+	Vars     []VarsSource           `json:"vars,omitempty"`
 
 	SkipDeleteIfTags bool   `json:"skipDeleteIfTags,omitempty"`
 	OnlyRender       bool   `json:"onlyRender,omitempty"`
@@ -137,19 +137,19 @@ func ValidateIgnoreForDiffItemConfig(sl validator.StructLevel) {
 }
 
 type DeploymentProjectConfig struct {
-	Vars          []*VarsSource        `json:"vars,omitempty"`
+	Vars          []VarsSource         `json:"vars,omitempty"`
 	SealedSecrets *SealedSecretsConfig `json:"sealedSecrets,omitempty"`
 
 	When string `json:"when,omitempty"`
 
-	Deployments []*DeploymentItemConfig `json:"deployments,omitempty"`
+	Deployments []DeploymentItemConfig `json:"deployments,omitempty"`
 
 	CommonLabels      map[string]string `json:"commonLabels,omitempty"`
 	CommonAnnotations map[string]string `json:"commonAnnotations,omitempty"`
 	OverrideNamespace *string           `json:"overrideNamespace,omitempty"`
 	Tags              []string          `json:"tags,omitempty"`
 
-	IgnoreForDiff []*IgnoreForDiffItemConfig `json:"ignoreForDiff,omitempty"`
+	IgnoreForDiff []IgnoreForDiffItemConfig `json:"ignoreForDiff,omitempty"`
 }
 
 func init() {

--- a/pkg/types/kluctl_project.go
+++ b/pkg/types/kluctl_project.go
@@ -37,8 +37,8 @@ type DeploymentArg struct {
 }
 
 type SecretSet struct {
-	Name string        `json:"name" validate:"required"`
-	Vars []*VarsSource `json:"vars,omitempty"`
+	Name string       `json:"name" validate:"required"`
+	Vars []VarsSource `json:"vars,omitempty"`
 }
 
 type GlobalSealedSecretsConfig struct {
@@ -53,13 +53,13 @@ type SecretsConfig struct {
 }
 
 type KluctlProject struct {
-	Targets       []*Target        `json:"targets,omitempty"`
-	Args          []*DeploymentArg `json:"args,omitempty"`
-	SecretsConfig *SecretsConfig   `json:"secretsConfig,omitempty"`
-	Discriminator string           `json:"discriminator,omitempty"`
-	Aws           *AwsConfig       `json:"aws,omitempty"`
+	Targets       []Target        `json:"targets,omitempty"`
+	Args          []DeploymentArg `json:"args,omitempty"`
+	SecretsConfig *SecretsConfig  `json:"secretsConfig,omitempty"`
+	Discriminator string          `json:"discriminator,omitempty"`
+	Aws           *AwsConfig      `json:"aws,omitempty"`
 }
 
 type KluctlLibraryProject struct {
-	Args []*DeploymentArg `json:"args,omitempty"`
+	Args []DeploymentArg `json:"args,omitempty"`
 }

--- a/pkg/types/zz_generated.deepcopy.go
+++ b/pkg/types/zz_generated.deepcopy.go
@@ -140,13 +140,9 @@ func (in *DeploymentItemConfig) DeepCopyInto(out *DeploymentItemConfig) {
 	}
 	if in.Vars != nil {
 		in, out := &in.Vars, &out.Vars
-		*out = make([]*VarsSource, len(*in))
+		*out = make([]VarsSource, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(VarsSource)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.RenderedHelmChartConfig != nil {
@@ -181,13 +177,9 @@ func (in *DeploymentProjectConfig) DeepCopyInto(out *DeploymentProjectConfig) {
 	*out = *in
 	if in.Vars != nil {
 		in, out := &in.Vars, &out.Vars
-		*out = make([]*VarsSource, len(*in))
+		*out = make([]VarsSource, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(VarsSource)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.SealedSecrets != nil {
@@ -197,13 +189,9 @@ func (in *DeploymentProjectConfig) DeepCopyInto(out *DeploymentProjectConfig) {
 	}
 	if in.Deployments != nil {
 		in, out := &in.Deployments, &out.Deployments
-		*out = make([]*DeploymentItemConfig, len(*in))
+		*out = make([]DeploymentItemConfig, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(DeploymentItemConfig)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.CommonLabels != nil {
@@ -232,13 +220,9 @@ func (in *DeploymentProjectConfig) DeepCopyInto(out *DeploymentProjectConfig) {
 	}
 	if in.IgnoreForDiff != nil {
 		in, out := &in.IgnoreForDiff, &out.IgnoreForDiff
-		*out = make([]*IgnoreForDiffItemConfig, len(*in))
+		*out = make([]IgnoreForDiffItemConfig, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(IgnoreForDiffItemConfig)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }
@@ -582,13 +566,9 @@ func (in *KluctlLibraryProject) DeepCopyInto(out *KluctlLibraryProject) {
 	*out = *in
 	if in.Args != nil {
 		in, out := &in.Args, &out.Args
-		*out = make([]*DeploymentArg, len(*in))
+		*out = make([]DeploymentArg, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(DeploymentArg)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }
@@ -608,24 +588,16 @@ func (in *KluctlProject) DeepCopyInto(out *KluctlProject) {
 	*out = *in
 	if in.Targets != nil {
 		in, out := &in.Targets, &out.Targets
-		*out = make([]*Target, len(*in))
+		*out = make([]Target, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Target)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Args != nil {
 		in, out := &in.Args, &out.Args
-		*out = make([]*DeploymentArg, len(*in))
+		*out = make([]DeploymentArg, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(DeploymentArg)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.SecretsConfig != nil {
@@ -779,13 +751,9 @@ func (in *SecretSet) DeepCopyInto(out *SecretSet) {
 	*out = *in
 	if in.Vars != nil {
 		in, out := &in.Vars, &out.Vars
-		*out = make([]*VarsSource, len(*in))
+		*out = make([]VarsSource, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(VarsSource)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/pkg/vars/vars_loader.go
+++ b/pkg/vars/vars_loader.go
@@ -58,8 +58,9 @@ func NewVarsLoader(ctx context.Context, k *k8s.K8sCluster, sops *decryptor.Decry
 	}
 }
 
-func (v *VarsLoader) LoadVarsList(ctx context.Context, varsCtx *VarsCtx, varsList []*types.VarsSource, searchDirs []string, rootKey string) error {
-	for _, source := range varsList {
+func (v *VarsLoader) LoadVarsList(ctx context.Context, varsCtx *VarsCtx, varsList []types.VarsSource, searchDirs []string, rootKey string) error {
+	for i, _ := range varsList {
+		source := &varsList[i]
 		err := v.LoadVars(ctx, varsCtx, source, searchDirs, rootKey)
 		if err != nil {
 			return err

--- a/pkg/webui/server.go
+++ b/pkg/webui/server.go
@@ -296,13 +296,13 @@ func (s *CommandResultsServer) redactSensitiveVars(user *User, d *types.Deployme
 		}
 	}
 
-	for _, v := range d.Vars {
-		doRedact(v)
+	for i, _ := range d.Vars {
+		doRedact(&d.Vars[i])
 	}
 
 	for _, di := range d.Deployments {
-		for _, v := range di.Vars {
-			doRedact(v)
+		for i, _ := range di.Vars {
+			doRedact(&di.Vars[i])
 		}
 		s.redactSensitiveVars(user, di.RenderedInclude)
 	}


### PR DESCRIPTION
# Description

Otherwise stuff like this results in crashes:
```yaml
targets:
- null
```

Fixes #325

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
