### PR TITLE
fix: Bump wolfi image to latest

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -89,7 +89,7 @@ dockers:
     build_flag_templates:
       - "--pull"
       # use `docker buildx imagetools inspect  cgr.dev/chainguard/wolfi-base:latest` to find latest sha256 of linux/amd64 layer
-      - "--build-arg=WOLFI_DIGEST=sha256:3c41b0c5a5b09fb4e5fccdc9469c992cf489161989fcc3e17c7c394bbea4b215"
+      - "--build-arg=WOLFI_DIGEST=sha256:bf06e4be7e7fd13fda57290bc339022e1fdb34ecaa9beb07bad1b7f91038c6e4"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.name={{ .ProjectName }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
@@ -104,7 +104,7 @@ dockers:
     build_flag_templates:
       - "--pull"
       # use `docker buildx imagetools inspect  cgr.dev/chainguard/wolfi-base:latest` to find latest sha256 of linux/arm64 layer
-      - "--build-arg=WOLFI_DIGEST=sha256:f27d65564f05397c920f63fb81b485f829de3ee23fd32a4a0af1002ec7ead0d2"
+      - "--build-arg=WOLFI_DIGEST=sha256:98ff8900f4e2173fa2e32ba52c695b1b5c6b76c6e16914f6873f5aa6502e23d3"
       - "--label=org.opencontainers.image.created={{ .Date }}"
       - "--label=org.opencontainers.image.name={{ .ProjectName }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # We must use a glibc based distro due to embedded python not supporting musl libc for aarch64 (only amd64+musl is supported)
 # see https://github.com/indygreg/python-build-standalone/issues/87
 # use `docker buildx imagetools inspect  cgr.dev/chainguard/wolfi-base:latest` to find latest sha256 of multiarch image
-ARG WOLFI_DIGEST=sha256:ccc5551b5dd1fdcff5fc76ac1605b4c217f77f43410e0bd8a56599d6504dbbdd
+ARG WOLFI_DIGEST=sha256:5bab300be31cd472c6f45ba7c059415b0bdeb0a49b32ecc12060394d642fd192
 FROM cgr.dev/chainguard/wolfi-base@$WOLFI_DIGEST
 
 # We need git for kustomize to support overlays from git


### PR DESCRIPTION
# Description

Bump wolfi image to latest

Fixes git fetch in v.2.23.0

```
building kustomize objects for /xxx/infra/reloader failed. accumulating resources: accumulation err='accumulating resources from 'https://github.com/stakater/Reloader/deployments/kubernetes?submodules=false': URL is a git repository': failed to run '/usr/bin/git fetch --depth=1 https://github.com/stakater/Reloader HEAD': /usr/libexec/git-core/git-remote-https: /usr/lib/libssl.so.3: version `OPENSSL_3.2.0' not found (required by /usr/lib/libcurl.so.4)\n: exit status 128\n\t* prepare failed with 1 errors. Check status.lastPrepareError for details\n\n",
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

https://github.com/kluctl/kluctl/issues/952
