### PR TITLE
fix: Skip hooks when determining objects to wait for readiness

### DIFF
--- a/e2e/readiness_test.go
+++ b/e2e/readiness_test.go
@@ -103,3 +103,18 @@ func TestWaitReadinessViaKustomization(t *testing.T) {
 		}, "")
 	})
 }
+
+func TestWaitReadinessViaKustomizationWithHook(t *testing.T) {
+	testWaitReadiness(t, func(p *test_project.TestProject) {
+		// the kustomization.yaml wait-readiness should actually be ignored in this case...
+		p.UpdateYaml("cm2/kustomization.yml", func(o *uo.UnstructuredObject) error {
+			o.SetK8sAnnotation("kluctl.io/wait-readiness", "true")
+			return nil
+		}, "")
+		// because the hook object is what is waited for instead
+		p.UpdateYaml("cm2/configmap-cm2.yml", func(o *uo.UnstructuredObject) error {
+			o.SetK8sAnnotation("kluctl.io/hook", "post-deploy")
+			return nil
+		}, "")
+	})
+}


### PR DESCRIPTION
# Description

hooks have their own waitReadiness logic, so we must skip them here. Otherwise we'd wait for an object didn't even get deployed yet (e.g. post-deploy hooks).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
