### PR TITLE
feat: Unconditionally assume an object is managed by Kluctl if kluctl.io/force-managed=true

### DIFF
--- a/docs/kluctl/deployments/annotations/all-resources.md
+++ b/docs/kluctl/deployments/annotations/all-resources.md
@@ -72,7 +72,8 @@ they most likely don't match exclusion tags, but cascaded deletion would still c
 
 ### kluctl.io/force-managed
 If set to "true", Kluctl will always treat the annotated resource as being managed by Kluctl, meaning that it will
-consider it for deletion and pruning even if a foreign field manager resets/removes the Kluctl field manager.
+consider it for deletion and pruning even if a foreign field manager resets/removes the Kluctl field manager or if
+foreign controllers add `ownerReferences` even though they do not really own the resources.
 
 ## Control diff behavior
 

--- a/e2e/prune_test.go
+++ b/e2e/prune_test.go
@@ -2,6 +2,10 @@ package e2e
 
 import (
 	test_utils "github.com/kluctl/kluctl/v2/e2e/test_project"
+	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"testing"
 )
 
@@ -70,4 +74,54 @@ func TestDeployWithPrune(t *testing.T) {
 	assertConfigMapExists(t, k, p.TestSlug(), "cm1")
 	assertConfigMapNotExists(t, k, p.TestSlug(), "cm2")
 	assertConfigMapExists(t, k, p.TestSlug(), "cm3")
+}
+
+func TestPruneForceManaged(t *testing.T) {
+	t.Parallel()
+
+	k := defaultCluster1
+
+	p := test_utils.NewTestProject(t)
+
+	createNamespace(t, k, p.TestSlug())
+
+	p.UpdateTarget("test", nil)
+
+	addConfigMapDeployment(p, "cm1", map[string]string{}, resourceOpts{
+		name:      "cm1",
+		namespace: p.TestSlug(),
+	})
+	addConfigMapDeployment(p, "cm2", map[string]string{}, resourceOpts{
+		name:      "cm2",
+		namespace: p.TestSlug(),
+	})
+
+	p.KluctlMust(t, "deploy", "--yes", "-t", "test")
+	cm1 := assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm2")
+
+	p.DeleteKustomizeDeployment("cm2")
+
+	patchObject(t, k, v1.SchemeGroupVersion.WithResource("configmaps"), p.TestSlug(), "cm2", func(o *uo.UnstructuredObject) {
+		// objects with owner references are not considered when pruning...
+		o.SetK8sOwnerReferences([]*uo.UnstructuredObject{
+			uo.FromStructMust(&metav1.OwnerReference{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Name:       "cm1",
+				UID:        types.UID(cm1.GetK8sUid()),
+			}),
+		})
+	})
+
+	p.KluctlMust(t, "prune", "--yes", "-t", "test")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm2") // not pruned because of owner ref
+
+	patchObject(t, k, v1.SchemeGroupVersion.WithResource("configmaps"), p.TestSlug(), "cm2", func(o *uo.UnstructuredObject) {
+		// ... except when force-managed=true
+		o.SetK8sAnnotation("kluctl.io/force-managed", "true")
+	})
+	p.KluctlMust(t, "prune", "--yes", "-t", "test")
+	assertConfigMapNotExists(t, k, p.TestSlug(), "cm2")
 }

--- a/pkg/deployment/utils/delete_utils.go
+++ b/pkg/deployment/utils/delete_utils.go
@@ -66,6 +66,10 @@ func isSkipDelete(o *uo.UnstructuredObject) bool {
 }
 
 func isManagedByKluctl(o *uo.UnstructuredObject) bool {
+	if o.GetK8sAnnotationBoolNoError("kluctl.io/force-managed", false) {
+		return true
+	}
+
 	ownerRefs := o.GetK8sOwnerReferences()
 	managedFields := o.GetK8sManagedFields()
 
@@ -88,7 +92,7 @@ func isManagedByKluctl(o *uo.UnstructuredObject) bool {
 			break
 		}
 	}
-	if !found && !o.GetK8sAnnotationBoolNoError("kluctl.io/force-managed", false) {
+	if !found {
 		// This object is not managed by kluctl, so we shouldn't delete it
 		return false
 	}

--- a/pkg/utils/uo/k8s_fields.go
+++ b/pkg/utils/uo/k8s_fields.go
@@ -261,6 +261,10 @@ func (uo *UnstructuredObject) GetK8sOwnerReferences() []*UnstructuredObject {
 	return ret
 }
 
+func (uo *UnstructuredObject) SetK8sOwnerReferences(l []*UnstructuredObject) {
+	_ = uo.SetNestedField(l, "metadata", "ownerReferences")
+}
+
 func (uo *UnstructuredObject) GetK8sManagedFields() []*UnstructuredObject {
 	ret, _, _ := uo.GetNestedObjectList("metadata", "managedFields")
 	return ret

--- a/pkg/utils/uo/uo.go
+++ b/pkg/utils/uo/uo.go
@@ -56,6 +56,14 @@ func FromStruct(o interface{}) (*UnstructuredObject, error) {
 	return FromMap(m), nil
 }
 
+func FromStructMust(o interface{}) *UnstructuredObject {
+	x, err := FromStruct(o)
+	if err != nil {
+		panic(err)
+	}
+	return x
+}
+
 func (uo *UnstructuredObject) ToStruct(out interface{}) error {
 	b, err := yaml.WriteYamlBytes(uo.Object)
 	if err != nil {


### PR DESCRIPTION
# Description

This allows to instruct Kluctl to force handling of an object as "managed by Kluctl", even if all field ownership is lost or ownerReferences have been added to an object.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
