### PR TITLE
fix: Ignore delete hooks on validation

### DIFF
--- a/cmd/kluctl/commands/cmd_validate.go
+++ b/cmd/kluctl/commands/cmd_validate.go
@@ -44,7 +44,7 @@ func (cmd *validateCmd) Run(ctx context.Context) error {
 	}
 
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
-		cmd2 := commands.NewValidateCommand("", cmdCtx.targetCtx, nil)
+		cmd2 := commands.NewValidateCommand("", cmdCtx.targetCtx)
 		return cmd.doValidate(cmdCtx, cmd2)
 	})
 }

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -44,9 +44,19 @@ func getHeadRevision(t *testing.T, p *test_project.TestProject) string {
 func assertObjectExists(t *testing.T, k *test_utils.EnvTestCluster, gvr schema.GroupVersionResource, namespace string, name string) *uo.UnstructuredObject {
 	x, err := k.Get(gvr, namespace, name)
 	if err != nil {
-		t.Fatalf("unexpected error '%v' while getting ConfigMap %s/%s", err, namespace, name)
+		t.Fatalf("unexpected error '%v' while getting %s %s/%s", err, gvr.GroupResource().String(), namespace, name)
 	}
 	return x
+}
+
+func assertObjectNotExists(t *testing.T, k *test_utils.EnvTestCluster, gvr schema.GroupVersionResource, namespace string, name string) {
+	_, err := k.Get(gvr, namespace, name)
+	if err == nil {
+		t.Fatalf("expected %s/%s to not exist", namespace, name)
+	}
+	if !errors.IsNotFound(err) {
+		t.Fatalf("unexpected error '%v' for %s/%s, expected a NotFound error", err, namespace, name)
+	}
 }
 
 func assertConfigMapExists(t *testing.T, k *test_utils.EnvTestCluster, namespace string, name string) *uo.UnstructuredObject {
@@ -54,13 +64,7 @@ func assertConfigMapExists(t *testing.T, k *test_utils.EnvTestCluster, namespace
 }
 
 func assertConfigMapNotExists(t *testing.T, k *test_utils.EnvTestCluster, namespace string, name string) {
-	_, err := k.Get(v1.SchemeGroupVersion.WithResource("configmaps"), namespace, name)
-	if err == nil {
-		t.Fatalf("expected %s/%s to not exist", namespace, name)
-	}
-	if !errors.IsNotFound(err) {
-		t.Fatalf("unexpected error '%v' for %s/%s, expected a NotFound error", err, namespace, name)
-	}
+	assertObjectNotExists(t, k, v1.SchemeGroupVersion.WithResource("configmaps"), namespace, name)
 }
 
 func assertSecretExists(t *testing.T, k *test_utils.EnvTestCluster, namespace string, name string) *uo.UnstructuredObject {

--- a/e2e/validate_test.go
+++ b/e2e/validate_test.go
@@ -160,3 +160,19 @@ func TestValidateSkipDeleteHooks(t *testing.T) {
 
 	assertValidate(t, p, true)
 }
+
+func TestValidateSkipRollbackHooks(t *testing.T) {
+	t.Parallel()
+
+	k := defaultCluster1
+
+	p := prepareValidateTest(t, k, map[string]string{
+		"helm.sh/hook":        "post-rollback",
+		"kluctl.io/hook-wait": "false",
+	})
+
+	p.KluctlMust(t, "deploy", "--yes", "-t", "test")
+	assertObjectNotExists(t, k, appsv1.SchemeGroupVersion.WithResource("deployments"), p.TestSlug(), "d1")
+
+	assertValidate(t, p, true)
+}

--- a/pkg/controllers/kluctl_project.go
+++ b/pkg/controllers/kluctl_project.go
@@ -833,11 +833,11 @@ func (pt *preparedTarget) kluctlDiff(targetContext *target_context.TargetContext
 	return cmdResult
 }
 
-func (pt *preparedTarget) kluctlValidate(targetContext *target_context.TargetContext, cmdResult *result.CommandResult) *result.ValidateResult {
+func (pt *preparedTarget) kluctlValidate(targetContext *target_context.TargetContext) *result.ValidateResult {
 	timer := prometheus.NewTimer(internal_metrics.NewKluctlValidateDuration(pt.pp.obj.ObjectMeta.Namespace, pt.pp.obj.ObjectMeta.Name))
 	defer timer.ObserveDuration()
 
-	cmd := commands.NewValidateCommand(targetContext.Target.Discriminator, targetContext, cmdResult)
+	cmd := commands.NewValidateCommand(targetContext.Target.Discriminator, targetContext)
 
 	validateResult := cmd.Run(targetContext.SharedContext.Ctx)
 	return validateResult

--- a/pkg/controllers/kluctldeployment_controller_reconcile.go
+++ b/pkg/controllers/kluctldeployment_controller_reconcile.go
@@ -353,7 +353,7 @@ func (r *KluctlDeploymentReconciler) reconcileValidateRequest(ctx context.Contex
 		"validate", kluctlv1.KluctlRequestValidateAnnotation,
 		getResultPtr, false,
 		func(rr *kluctlv1.ManualRequestResult, targetContext *target_context.TargetContext, pt *preparedTarget, reconcileID string, objectsHash string) (any, string, error) {
-			cmdResult := pt.kluctlValidate(targetContext, nil)
+			cmdResult := pt.kluctlValidate(targetContext)
 			err := pt.writeValidateResult(ctx, cmdResult, rr, reconcileId, objectsHash)
 			if err != nil {
 				log.Error(err, "Failed to write validate result")
@@ -484,7 +484,7 @@ func (r *KluctlDeploymentReconciler) reconcileFullRequest2(rr *kluctlv1.ManualRe
 		if err != nil {
 			return nil, kluctlv1.ValidateFailedReason, err
 		}
-		validateResult := pt.kluctlValidate(targetContext, deployResult)
+		validateResult := pt.kluctlValidate(targetContext)
 		err = pt.writeValidateResult(ctx, validateResult, rr, reconcileId, objectsHash)
 		if err != nil {
 			log.Error(err, "Failed to write deploy result")

--- a/pkg/deployment/commands/validate.go
+++ b/pkg/deployment/commands/validate.go
@@ -98,9 +98,15 @@ func (cmd *ValidateCommand) Run(ctx context.Context) *result.ValidateResult {
 
 		au := ad.NewApplyUtil(ctx, nil)
 		h := utils2.NewHooksUtil(au)
-		hook := h.GetHook(o)
-		if hook != nil && !hook.IsPersistent() {
-			continue
+		if hook := h.GetHook(o); hook != nil {
+			if !hook.IsPersistent() {
+				// the hook is not expected to exist after deployment
+				continue
+			}
+			if hook.IsOnlyDelete() {
+				// the hook is not expected to be executed
+				continue
+			}
 		}
 
 		ref := o.GetK8sRef()

--- a/pkg/deployment/commands/validate.go
+++ b/pkg/deployment/commands/validate.go
@@ -78,7 +78,7 @@ func (cmd *ValidateCommand) Run(ctx context.Context) *result.ValidateResult {
 				// the hook is not expected to exist after deployment
 				continue
 			}
-			if hook.IsOnlyDelete() {
+			if hook.IsOnlyDelete() || hook.IsOnlyRollback() {
 				// the hook is not expected to be executed
 				continue
 			}

--- a/pkg/deployment/utils/hooks_util.go
+++ b/pkg/deployment/utils/hooks_util.go
@@ -24,12 +24,11 @@ var supportedKluctlDeletePolicies = []string{
 	"hook-failed",
 }
 
-// delete/rollback hooks are actually not supported, but we won't show warnings about that to not spam the user
 var supportedHelmHooks = []string{
 	"pre-install", "post-install",
 	"pre-upgrade", "post-upgrade",
-	"pre-delete", "post-delete",
-	"pre-rollback", "post-rollback",
+	//"pre-delete", "post-delete", TODO re-add this when we actually support delete
+	//"pre-rollback", "post-rollback", TODO re-add this when we actually support rollback
 }
 
 type HooksUtil struct {

--- a/pkg/deployment/utils/hooks_util.go
+++ b/pkg/deployment/utils/hooks_util.go
@@ -268,3 +268,15 @@ func (h *hook) IsPersistent() bool {
 	}
 	return true
 }
+
+func (h *hook) IsOnlyDelete() bool {
+	found := false
+	for x := range h.hooks {
+		if x == "pre-delete" || x == "post-delete" {
+			found = true
+		} else {
+			return false
+		}
+	}
+	return found
+}

--- a/pkg/deployment/utils/hooks_util.go
+++ b/pkg/deployment/utils/hooks_util.go
@@ -182,11 +182,11 @@ func (u *HooksUtil) GetHook(o *uo.UnstructuredObject) *hook {
 	}
 
 	helmCompatibility("pre-install", "pre-deploy-initial")
-	helmCompatibility("pre-upgrade", "pre-deploy-upgrade")
 	helmCompatibility("post-install", "post-deploy-initial")
-	helmCompatibility("post-upgrade", "post-deploy-upgrade")
 	helmCompatibility("pre-delete", "pre-delete")
 	helmCompatibility("post-delete", "post-delete")
+	helmCompatibility("pre-upgrade", "pre-deploy-upgrade")
+	helmCompatibility("post-upgrade", "post-deploy-upgrade")
 
 	weightStr := o.GetK8sAnnotation("kluctl.io/hook-weight")
 	if weightStr == nil {

--- a/pkg/deployment/utils/hooks_util.go
+++ b/pkg/deployment/utils/hooks_util.go
@@ -182,10 +182,12 @@ func (u *HooksUtil) GetHook(o *uo.UnstructuredObject) *hook {
 
 	helmCompatibility("pre-install", "pre-deploy-initial")
 	helmCompatibility("post-install", "post-deploy-initial")
-	helmCompatibility("pre-delete", "pre-delete")
-	helmCompatibility("post-delete", "post-delete")
+	helmCompatibility("pre-delete", "pre-delete")   // actually not implemented, so it will be ignored
+	helmCompatibility("post-delete", "post-delete") // actually not implemented, so it will be ignored
 	helmCompatibility("pre-upgrade", "pre-deploy-upgrade")
 	helmCompatibility("post-upgrade", "post-deploy-upgrade")
+	helmCompatibility("pre-rollback", "pre-rollback")   // actually not implemented, so it will be ignored
+	helmCompatibility("post-rollback", "post-rollback") // actually not implemented, so it will be ignored
 
 	weightStr := o.GetK8sAnnotation("kluctl.io/hook-weight")
 	if weightStr == nil {

--- a/pkg/deployment/utils/hooks_util.go
+++ b/pkg/deployment/utils/hooks_util.go
@@ -281,3 +281,15 @@ func (h *hook) IsOnlyDelete() bool {
 	}
 	return found
 }
+
+func (h *hook) IsOnlyRollback() bool {
+	found := false
+	for x := range h.hooks {
+		if x == "pre-rollback" || x == "post-rollback" {
+			found = true
+		} else {
+			return false
+		}
+	}
+	return found
+}


### PR DESCRIPTION
# Description

This causes `validate` to ignore hooks when they are only meant to be run on deletion. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
