### PR TITLE
fix: Fix crash in GetFirstObject that happens if a nil list is encountered

### DIFF
--- a/pkg/utils/uo/jsonpath.go
+++ b/pkg/utils/uo/jsonpath.go
@@ -129,6 +129,10 @@ func (j *MyJsonPath) GetFirstListOfObjects(o *UnstructuredObject) ([]*Unstructur
 	if !found {
 		return nil, false, nil
 	}
+	if x == nil {
+		// nil is a valid list of zero elements, so treat it as 'found'
+		return nil, true, nil
+	}
 	v := reflect.ValueOf(x)
 	if v.Type().Kind() != reflect.Slice {
 		return nil, false, fmt.Errorf("child is not a list")


### PR DESCRIPTION
# Description

This fixes a crash reported in Slack.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
