### PR TITLE
fix: Make namespace optional in clusterObject vars source

### DIFF
--- a/pkg/types/vars_source.go
+++ b/pkg/types/vars_source.go
@@ -67,7 +67,7 @@ type VarsSourceClusterObject struct {
 	Kind       string `json:"kind" validate:"required"`
 	ApiVersion string `json:"apiVersion,omitempty"`
 
-	Namespace string `json:"namespace" validate:"required"`
+	Namespace string `json:"namespace"`
 
 	Name   string            `json:"name,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`

--- a/pkg/vars/vars_loader_test.go
+++ b/pkg/vars/vars_loader_test.go
@@ -567,9 +567,10 @@ func (s *VarsLoaderTestSuite) TestClusterObject() {
 			Name:      "cm1",
 			Namespace: s.namespace(),
 			Labels: map[string]string{
-				"label1": "lv1",
-				"label2": "42",
-				"label3": "x",
+				"label1":    "lv1",
+				"label2":    "42",
+				"label3":    "x",
+				"namespace": s.namespace(),
 			},
 			Annotations: map[string]string{
 				"yaml":          `{"x": 45}`,
@@ -584,9 +585,10 @@ func (s *VarsLoaderTestSuite) TestClusterObject() {
 			Name:      "cm2",
 			Namespace: s.namespace(),
 			Labels: map[string]string{
-				"label1": "lv2",
-				"label2": "44",
-				"label3": "x",
+				"label1":    "lv2",
+				"label2":    "44",
+				"label3":    "x",
+				"namespace": s.namespace(),
 			},
 			Annotations: map[string]string{
 				"a1": "v1",
@@ -778,11 +780,27 @@ func (s *VarsLoaderTestSuite) TestClusterObject() {
 		}, nil, "")
 		assert.NoError(s.T(), err)
 
+		err = vl.LoadVars(context.TODO(), vc, &types.VarsSource{
+			ClusterObject: &types.VarsSourceClusterObject{
+				Kind: "ConfigMap",
+				Labels: map[string]string{
+					"namespace": s.namespace(),
+				},
+				List: true,
+				// no namespace
+				Path: `metadata.labels["label2"]`,
+			},
+			TargetPath: "my.target.d",
+		}, nil, "")
+		assert.NoError(s.T(), err)
+
 		v, _, _ := vc.Vars.GetNestedString("my", "target", "a")
 		assert.Equal(s.T(), "42", v)
 		v, _, _ = vc.Vars.GetNestedString("my", "target", "b")
 		assert.Equal(s.T(), "44", v)
 		l, _, _ := vc.Vars.GetNestedStringList("my", "target", "c")
+		assert.Equal(s.T(), []string{"42", "44"}, l)
+		l, _, _ = vc.Vars.GetNestedStringList("my", "target", "d")
 		assert.Equal(s.T(), []string{"42", "44"}, l)
 	})
 


### PR DESCRIPTION
# Description

This is especially useful when the object that one is trying to load is not namespaced.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
