### PR TITLE
fix: Also deep-clone aws config in buildTarget

### DIFF
--- a/pkg/kluctl_project/targets.go
+++ b/pkg/kluctl_project/targets.go
@@ -67,8 +67,7 @@ func (c *LoadedKluctlProject) RenderTarget(target *types.Target) error {
 }
 
 func (c *LoadedKluctlProject) buildTarget(configTarget *types.Target) (*types.Target, error) {
-	var target types.Target
-	err := utils.DeepCopy(&target, configTarget)
+	target, err := utils.DeepClone(configTarget)
 	if err != nil {
 		return nil, err
 	}
@@ -89,5 +88,8 @@ func (c *LoadedKluctlProject) buildTarget(configTarget *types.Target) (*types.Ta
 			target.Aws.ServiceAccount = c.Config.Aws.ServiceAccount
 		}
 	}
-	return &target, nil
+	// just to make sure we don't later overwrite stuff from c.Config, which we might have copied into the target a few
+	// lines above this
+	target, err = utils.DeepClone(target)
+	return target, nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,6 +22,15 @@ func DeepCopy(dst interface{}, src interface{}) error {
 	})
 }
 
+func DeepClone[T any](src *T) (*T, error) {
+	ret := new(T)
+	err := DeepCopy(ret, src)
+	if err != nil {
+		return ret, err
+	}
+	return ret, nil
+}
+
 func FindStrInSlice(a []string, s string) int {
 	for i, v := range a {
 		if v == s {


### PR DESCRIPTION
# Description

This fixes issues when templating is used inside the global aws config. Without deep cloning, the config gets rendered for the first target and then causes all targets to share the same config, even though rendering was supposed to give different results per target.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
