### PR TITLE
fix: Partially fix access to loop variables in get_var/render

### DIFF
--- a/.github/workflows/check-links-cron.yml
+++ b/.github/workflows/check-links-cron.yml
@@ -12,8 +12,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          folder-path: 'docs, install'
-          file-path: './README.md'
+      - uses: actions/checkout@v3
+      - name: Check links on changed files
+        run: |
+          make markdown-link-check

--- a/Makefile
+++ b/Makefile
@@ -106,13 +106,9 @@ test-e2e-gitops: envtest ## Run gitops e2e tests.
 replace-commands-help: ## Replace commands help in docs
 	go run ./internal/replace-commands-help --docs-dir ./docs/kluctl/commands
 
-MARKDOWN_LINK_CHECK_VERSION=3.11.2
+LYCHEE_VERSION=0.14
 markdown-link-check: ## Check markdown files for dead links
-	find . -name '*.md' \
-		-and -not -path './docs/gitops/api/kluctl-controller.md' \
-		-and -not -path './pkg/webui/ui/node_modules/*' \
-		-and -not -path './pkg/webui/ui/build/*' | \
-		xargs docker run -v ${PWD}:/tmp:ro --rm -i -w /tmp ghcr.io/tcort/markdown-link-check:$(MARKDOWN_LINK_CHECK_VERSION)
+	docker run --init -i --rm -w /input -v ${PWD}:/input:ro lycheeverse/lychee:$(LYCHEE_VERSION) -- README.md docs install
 
 ##@ Build
 

--- a/docs/kluctl/templating/filters.md
+++ b/docs/kluctl/templating/filters.md
@@ -78,11 +78,8 @@ The required indention filter is the part that makes this error-prone and hard t
 whenever you can.
 
 ### render
-Renders the input string with the current Jinja2 context. Example:
-```
-{% set a="{{ my_var }}" %}
-{{ a | render }}
-```
+Same as the global [render function](./functions.md#rendertemplate), but deprecated now. `render` being a filter turned out to
+not work well with local variables, as these are not accessible in filters. Please only use the global function.
 
 ### sha256(digest_len)
 Calculates the sha256 digest of the input string. Example:

--- a/docs/kluctl/templating/functions.md
+++ b/docs/kluctl/templating/functions.md
@@ -24,6 +24,11 @@ Loads the given file into memory, renders it with the current Jinja2 context and
 
 `load_template` uses the same path searching rules as described in [includes/imports](../templating#includes-and-imports).
 
+Please note that there is a limitation in this (and other) functions in regard to loop variables. You can currently not
+use loop variables directly as they are not accessible inside Jinja2 extensions/filters. There is an open issue in 
+that regard [here](https://github.com/pallets/jinja/issues/1478). For a workaround, perform the same as in
+[get_var](#getvarfieldpath-default).
+
 ### load_sha256(file, digest_len)
 Loads the given file into memory, renders it and calculates the sha256 hash of the result.
 
@@ -57,6 +62,18 @@ The `field_path` parameter can also be a list of pathes, which are then tried on
 result that gives a value that is not None. For example, `{{ get_var(['non.existing.var', my.deep.var'], 'my-default') }}`
 would also return `value`.
 
+Please note that there is a limitation in this (and other) functions in regard to loop variables. You can currently not
+use loop variables directly as they are not accessible inside Jinja2 global functions or filters. There is an open issue in
+that regard [here](https://github.com/pallets/jinja/issues/1478). For a workaround, assign the loop variable to a local variable:
+
+```
+{% set list=[{x: "a"}, {x: "b"}, {x: "c"}] %}
+{% for e in list %}
+{% set e=e %} <-- this is the workaround
+{{ get_var('e.x') }}
+{% endfor %}
+```
+
 ### merge_dict(d1, d2)
 Clones d1 and then recursively merges d2 into it and returns the result. Values inside d2 will override values in d1.
 
@@ -65,6 +82,18 @@ Same as `merge_dict`, but merging is performed in-place into d1.
 
 ### raise(msg)
 Raises a python exception with the given message. This causes the current command to abort.
+
+### render(template)
+Renders the input string with the current Jinja2 context. Example:
+```
+{% set a="{{ my_var }}" %}
+{{ render(a) }}
+```
+
+Please note that there is a limitation in this (and other) functions in regard to loop variables. You can currently not
+use loop variables directly as they are not accessible inside Jinja2 global functions or filters. There is an open issue in
+that regard [here](https://github.com/pallets/jinja/issues/1478). For a workaround, perform the same as in
+[get_var](#getvarfieldpath-default).
 
 ### debug_print(msg)
 Prints a line to stderr.

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jinzhu/copier v0.4.0
 	github.com/kevinburke/ssh_config v1.2.0
 	github.com/kluctl/go-embed-python v0.0.0-3.11.7-20240107-1
-	github.com/kluctl/go-jinja2 v0.0.0-20240206085301-ad6f23980236
+	github.com/kluctl/go-jinja2 v0.0.0-20240304095917-f7191e3c936e
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-runewidth v0.0.15

--- a/go.sum
+++ b/go.sum
@@ -444,8 +444,8 @@ github.com/klauspost/cpuid/v2 v2.2.6 h1:ndNyv040zDGIDh8thGkXYjnFtiN02M1PVVF+JE/4
 github.com/klauspost/cpuid/v2 v2.2.6/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kluctl/go-embed-python v0.0.0-3.11.7-20240107-1 h1:FRjmtgCHeK4IcZTOosx5tJ8LZ4VDMzFaaXBylsMRAGQ=
 github.com/kluctl/go-embed-python v0.0.0-3.11.7-20240107-1/go.mod h1:nhLUuBr5jJ6TMy4RlZn0wEtGC/RuTfERNVHyP1t0joI=
-github.com/kluctl/go-jinja2 v0.0.0-20240206085301-ad6f23980236 h1:qHDKDrp92XNv1crPOMol5fZ3t1RzmuS452Ku7Hj3X0A=
-github.com/kluctl/go-jinja2 v0.0.0-20240206085301-ad6f23980236/go.mod h1:tf65M11BQMkV4k2ukb8dkxCho7VuG86LcJdzE8kuR3U=
+github.com/kluctl/go-jinja2 v0.0.0-20240304095917-f7191e3c936e h1:la0Z8jPORDnWN0qFuuJul9LfS9d71CB8rlecg3DcdXU=
+github.com/kluctl/go-jinja2 v0.0.0-20240304095917-f7191e3c936e/go.mod h1:tf65M11BQMkV4k2ukb8dkxCho7VuG86LcJdzE8kuR3U=
 github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgShxwh4x8M=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,127 @@
+#############################  Display  #############################
+
+# Verbose program output
+# Accepts log level: "error", "warn", "info", "debug", "trace"
+verbose = "info"
+
+# Don't show interactive progress bar while checking links.
+no_progress = false
+
+# Path to summary output file.
+# output = ".config.dummy.report.md"
+
+#############################  Cache  ###############################
+
+# Enable link caching. This can be helpful to avoid checking the same links on
+# multiple runs.
+# cache = true
+
+# Discard all cached requests older than this duration.
+# max_cache_age = "2d"
+
+#############################  Runtime  #############################
+
+# Number of threads to utilize.
+# Defaults to number of cores available to the system if omitted.
+threads = 2
+
+# Maximum number of allowed redirects.
+max_redirects = 10
+
+# Maximum number of allowed retries before a link is declared dead.
+max_retries = 2
+
+# Maximum number of concurrent link checks.
+max_concurrency = 8
+
+#############################  Requests  ############################
+
+# User agent to send with each request.
+user_agent = "curl/7.83. 1"
+
+# Website timeout from connect to response finished.
+timeout = 20
+
+# Minimum wait time in seconds between retries of failed requests.
+retry_wait_time = 2
+
+# Comma-separated list of accepted status codes for valid links.
+# Supported values are:
+#
+# accept = ["200..=204", "429"]
+# accept = "200..=204, 429"
+# accept = ["200", "429"]
+# accept = "200, 429"
+# accept = ["200", "429"]
+
+# Proceed for server connections considered insecure (invalid TLS).
+insecure = false
+
+# Only test links with the given schemes (e.g. https).
+# Omit to check links with any other scheme.
+# At the moment, we support http, https, file, and mailto.
+# scheme = ["https"]
+
+# When links are available using HTTPS, treat HTTP links as errors.
+# require_https = false
+
+# Request method
+method = "get"
+
+# Custom request headers
+headers = []
+
+# Remap URI matching pattern to different URI.
+# remap = ["https://example.com http://example.invalid"]
+
+# Base URL or website root directory to check relative URLs.
+# base = "https://example.com"
+
+# HTTP basic auth support. This will be the username and password passed to the
+# authorization HTTP header. See
+# <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization>
+# basic_auth = ["example.com user:pwd"]
+
+#############################  Exclusions  ##########################
+
+# Skip missing input files (default is to error if they don't exist).
+# skip_missing = false
+
+# Check links inside `<code>` and `<pre>` blocks as well as Markdown code
+# blocks.
+# include_verbatim = false
+
+# Ignore case of paths when matching glob patterns.
+# glob_ignore_case = false
+
+# Exclude URLs and mail addresses from checking (supports regex).
+# exclude = ['^https://www\.linkedin\.com', '^https://web\.archive\.org/web/']
+exclude = [
+    '^https://kubernetes\.io/docs/reference/generated/kubernetes-api/v1\.18/',
+    '.*#getvarfieldpath-default', # lychee seems to not understand this one
+]
+
+# Exclude these filesystem paths from getting checked.
+# exclude_path = ["file/path/to/Ignore", "./other/file/path/to/Ignore"]
+
+# URLs to check (supports regex). Has preference over all excludes.
+# include = ['gist\.github\.com.*']
+
+# Exclude all private IPs from checking.
+# Equivalent to setting `exclude_private`, `exclude_link_local`, and
+# `exclude_loopback` to true.
+# exclude_all_private = false
+
+# Exclude private IP address ranges from checking.
+# exclude_private = false
+
+# Exclude link-local IP address range from checking.
+# exclude_link_local = false
+
+# Exclude loopback IP address range and localhost from checking.
+# exclude_loopback = false
+
+# Check mail addresses
+# include_mail = true
+
+include_fragments = true


### PR DESCRIPTION
# Description

This PR partially fixes `get_var` being unable to access local variables. The fix is in go-jinja2: https://github.com/kluctl/go-jinja2/pull/32. It is only a partial fix because loop variables can still not be accessed directly and need a workaround (see the docs). The Jinja2 issue in that regard can be found here: https://github.com/pallets/jinja/issues/1478

This PR also deprecates the render filter and introduces the render global function, as it turns out that filters do not have access to local variables at all.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
