### PR TITLE
fix: Panic when deadline is exceeded too much while fetching from git

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/getsops/sops/v3 v3.8.1
 	github.com/gin-contrib/sessions v0.0.5
 	github.com/gin-gonic/gin v1.9.1
+	github.com/go-errors/errors v1.5.1
 	github.com/go-git/go-git/v5 v5.11.1-0.20240110114741-f7c30f52dca0
 	github.com/go-logr/logr v1.4.1
 	github.com/google/gops v0.3.28
@@ -163,7 +164,6 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/getsops/gopgagent v0.0.0-20170926210634-4d7ea76ff71a // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
-	github.com/go-errors/errors v1.5.1 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.5.0 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect

--- a/pkg/utils/watchdog.go
+++ b/pkg/utils/watchdog.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-errors/errors"
+	"sync/atomic"
+	"time"
+)
+
+func RunWithDeadlineAndPanic(ctx context.Context, extraDeadline time.Duration, f func() error) error {
+	deadline, hasDeadline := ctx.Deadline()
+
+	if !hasDeadline {
+		return f()
+	}
+
+	var finished atomic.Bool
+
+	wait := deadline.Sub(time.Now()) + extraDeadline
+	if wait < 0 {
+		return ctx.Err()
+	}
+
+	deadlineErr := errors.New(fmt.Errorf("deadline exceeded while calling function"))
+
+	t := time.AfterFunc(wait, func() {
+		if !finished.Load() {
+			panic(deadlineErr.ErrorStack())
+		}
+	})
+	defer t.Stop()
+
+	err := f()
+	finished.Store(true)
+
+	return err
+}


### PR DESCRIPTION
# Description

A user has reported repeatedly hanging Kluctl controllers. After looking at stack traced, it looks like go-git is not respecting timeouts/deadlines when errors happen. This MR has a workaround for go-git not respecting deadlines. Kluctl will now panic in that case to avoid hanging forever.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
