### PR TITLE
fix: Reimplement GetFilteredPreferredGVKs to account for resources without PV

### DIFF
--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -129,6 +129,9 @@ func (di *DeploymentItem) render(forSeal bool) error {
 	excludePatterns = append(excludePatterns, "**/.git")
 
 	err = filepath.WalkDir(*di.dir, func(p string, d fs.DirEntry, err error) error {
+		if d == nil {
+			return nil
+		}
 		if d.IsDir() {
 			relDir, err := filepath.Rel(*di.dir, p)
 			if err != nil {

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -573,12 +573,12 @@ func (a *ApplyUtil) WaitReadiness(ref k8s2.ObjectRef, timeout time.Duration) boo
 }
 
 func (a *ApplyUtil) convertObjectRef(x types2.ObjectRefItem, refs map[k8s2.ObjectRef]bool) {
-	gvks, err := a.k.GetFilteredPreferredGVKs(k8s.BuildGVKFilter(x.Group, nil, x.Kind))
+	ars, err := a.k.GetFilteredPreferredAPIResources(k8s.BuildGVKFilter(x.Group, nil, x.Kind))
 	if err != nil {
 		a.HandleError(k8s2.ObjectRef{}, err)
 		return
 	}
-	if len(gvks) == 0 {
+	if len(ars) == 0 {
 		nameAndNs := x.Name
 		if x.Namespace != "" {
 			nameAndNs = x.Namespace + "/" + x.Name
@@ -593,11 +593,11 @@ func (a *ApplyUtil) convertObjectRef(x types2.ObjectRefItem, refs map[k8s2.Objec
 		a.HandleError(k8s2.ObjectRef{}, fmt.Errorf("failed to wait for readiness of %s. resource with group/kind %s not found", nameAndNs, gk.String()))
 		return
 	}
-	for _, gvk := range gvks {
+	for _, ar := range ars {
 		ref := k8s2.ObjectRef{
-			Group:     gvk.Group,
-			Version:   gvk.Version,
-			Kind:      gvk.Kind,
+			Group:     ar.Group,
+			Version:   ar.Version,
+			Kind:      ar.Kind,
 			Name:      x.Name,
 			Namespace: x.Namespace,
 		}

--- a/pkg/deployment/utils/delete_utils.go
+++ b/pkg/deployment/utils/delete_utils.go
@@ -114,12 +114,16 @@ func filterObjectsForDelete(k *k8s.K8sCluster, objects []*uo.UnstructuredObject,
 	}
 
 	filteredResources := make(map[schema.GroupKind]bool)
-	gvks, err := k.GetFilteredPreferredGVKs(filterFunc)
+	ars, err := k.GetFilteredPreferredAPIResources(filterFunc)
 	if err != nil {
 		return nil, err
 	}
-	for _, gvk := range gvks {
-		filteredResources[gvk.GroupKind()] = true
+	for _, ar := range ars {
+		gk := schema.GroupKind{
+			Group: ar.Group,
+			Kind:  ar.Kind,
+		}
+		filteredResources[gk] = true
 	}
 
 	var ret []*uo.UnstructuredObject

--- a/pkg/deployment/utils/remote_objects_utils.go
+++ b/pkg/deployment/utils/remote_objects_utils.go
@@ -54,7 +54,7 @@ func (u *RemoteObjectUtils) getAllByDiscriminator(k *k8s.K8sCluster, discriminat
 	errCount := 0
 	permissionErrCount := 0
 
-	gvks, err := k.GetFilteredPreferredGVKs(func(ar *v1.APIResource) bool {
+	ars, err := k.GetFilteredPreferredAPIResources(func(ar *v1.APIResource) bool {
 		if onlyUsedGKs != nil {
 			gk := schema.GroupKind{
 				Group: ar.Group,
@@ -71,8 +71,13 @@ func (u *RemoteObjectUtils) getAllByDiscriminator(k *k8s.K8sCluster, discriminat
 	}
 
 	g := utils.NewGoHelper(u.ctx, 0)
-	for _, gvk := range gvks {
-		gvk := gvk
+	for _, ar := range ars {
+		ar := ar
+		gvk := schema.GroupVersionKind{
+			Group:   ar.Group,
+			Version: ar.Version,
+			Kind:    ar.Kind,
+		}
 		g.Run(func() {
 			l, apiWarnings, err := k.ListObjects(gvk, "", labels)
 			u.dew.AddApiWarnings(k8s2.ObjectRef{

--- a/pkg/helm/helm_release.go
+++ b/pkg/helm/helm_release.go
@@ -295,14 +295,17 @@ func (hr *Release) getApiVersions(k *k8s.K8sCluster) (chartutil.VersionSet, erro
 
 	m := map[string]bool{}
 
-	gvks, err := k.GetFilteredGVKs(nil)
+	ars, err := k.GetAllAPIResources()
 	if err != nil {
 		return nil, err
 	}
-	for _, gvk := range gvks {
-		gvStr := gvk.GroupVersion().String()
+	for _, ar := range ars {
+		gvStr := ar.Version
+		if ar.Group != "" {
+			gvStr = ar.Group + "/" + ar.Version
+		}
 		m[gvStr] = true
-		gvkStr := fmt.Sprintf("%s/%s", gvStr, gvk.Kind)
+		gvkStr := fmt.Sprintf("%s/%s", gvStr, ar.Kind)
 		m[gvkStr] = true
 	}
 

--- a/pkg/k8s/resources.go
+++ b/pkg/k8s/resources.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/restmapper"
 	"strings"
 )
 
 var (
-	deprecatedResources = map[schema.GroupKind]bool{
-		{Group: "extensions", Kind: "Ingress"}: true,
-		{Group: "", Kind: "ComponentStatus"}:   true,
+	deprecatedResources = map[schema.GroupResource]bool{
+		{Group: "extensions", Resource: "ingresses"}: true,
+		{Group: "", Resource: "componentstatuses"}:   true,
 	}
 )
 
@@ -47,57 +48,111 @@ func (k *K8sCluster) doGetApiGroupResources() ([]*restmapper.APIGroupResources, 
 	return ret, nil
 }
 
-func (k *K8sCluster) doGetFilteredGVKs(ret *[]schema.GroupVersionKind, g v1.APIGroup, v string, vrs []v1.APIResource, filter func(ar *v1.APIResource) bool) {
-	for _, vr := range vrs {
-		vr.Group = g.Name
-		vr.Version = v
-		if strings.Index(vr.Name, "/") != -1 {
-			// skip sub-resources
-			continue
-		}
-		gvk := schema.GroupVersionKind{
-			Group:   g.Name,
-			Version: v,
-			Kind:    vr.Kind,
-		}
-		if _, ok := deprecatedResources[gvk.GroupKind()]; ok {
-			continue
-		}
-		if filter != nil && !filter(&vr) {
-			continue
-		}
-		*ret = append(*ret, gvk)
+func (k *K8sCluster) filterResource(ar *v1.APIResource) bool {
+	if strings.Index(ar.Name, "/") != -1 {
+		// skip sub-resources
+		return false
 	}
+
+	gr := schema.GroupResource{
+		Group:    ar.Group,
+		Resource: ar.Name,
+	}
+	if _, ok := deprecatedResources[gr]; ok {
+		return false
+	}
+
+	return true
 }
 
-func (k *K8sCluster) GetFilteredGVKs(filter func(ar *v1.APIResource) bool) ([]schema.GroupVersionKind, error) {
+func (k *K8sCluster) GetAllAPIResources() ([]v1.APIResource, error) {
 	agrs, err := k.doGetApiGroupResources()
 	if err != nil {
 		return nil, err
 	}
 
-	var ret []schema.GroupVersionKind
+	var ret []v1.APIResource
 	for _, agr := range agrs {
-		for v, vrs := range agr.VersionedResources {
-			k.doGetFilteredGVKs(&ret, agr.Group, v, vrs, filter)
+		for v, ars := range agr.VersionedResources {
+			for _, ar := range ars {
+				ar := ar
+				ar.Group = agr.Group.Name
+				ar.Version = v
+
+				if !k.filterResource(&ar) {
+					continue
+				}
+				ret = append(ret, ar)
+			}
 		}
 	}
 	return ret, nil
 }
 
-func (k *K8sCluster) GetFilteredPreferredGVKs(filter func(ar *v1.APIResource) bool) ([]schema.GroupVersionKind, error) {
+func (k *K8sCluster) GetAllPreferredAPIResources() ([]v1.APIResource, error) {
 	agrs, err := k.doGetApiGroupResources()
 	if err != nil {
 		return nil, err
 	}
 
-	var ret []schema.GroupVersionKind
+	preferredVersions := map[string]string{}
+	grs := map[schema.GroupResource][]v1.APIResource{}
 	for _, agr := range agrs {
-		vrs, ok := agr.VersionedResources[agr.Group.PreferredVersion.Version]
-		if !ok {
-			continue
+		preferredVersions[agr.Group.Name] = agr.Group.PreferredVersion.Version
+		for v, ars := range agr.VersionedResources {
+			for _, ar := range ars {
+				ar := ar
+				ar.Group = agr.Group.Name
+				ar.Version = v
+
+				if !k.filterResource(&ar) {
+					continue
+				}
+
+				gr := schema.GroupResource{
+					Group:    agr.Group.Name,
+					Resource: ar.Name,
+				}
+
+				l := grs[gr]
+				l = append(l, ar)
+				grs[gr] = l
+			}
 		}
-		k.doGetFilteredGVKs(&ret, agr.Group, agr.Group.PreferredVersion.Version, vrs, filter)
+	}
+
+	var ret []v1.APIResource
+	for gkr, ars := range grs {
+		var preferredAR *v1.APIResource
+		if len(ars) > 1 {
+			err = nil
+		}
+		for _, ar := range ars {
+			ar := ar
+			if preferredVersions[gkr.Group] == ar.Version {
+				preferredAR = &ar
+				break
+			}
+			if preferredAR == nil || version.CompareKubeAwareVersionStrings(preferredAR.Version, ar.Version) < 0 {
+				preferredAR = &ar
+			}
+		}
+		ret = append(ret, *preferredAR)
+	}
+	return ret, nil
+}
+
+func (k *K8sCluster) GetFilteredPreferredAPIResources(filter func(ar *v1.APIResource) bool) ([]v1.APIResource, error) {
+	ars, err := k.GetAllPreferredAPIResources()
+	if err != nil {
+		return nil, err
+	}
+
+	var ret []v1.APIResource
+	for _, ar := range ars {
+		if filter == nil || filter(&ar) {
+			ret = append(ret, ar)
+		}
 	}
 	return ret, nil
 }

--- a/pkg/vars/vars_loader.go
+++ b/pkg/vars/vars_loader.go
@@ -474,19 +474,23 @@ func (v *VarsLoader) loadFromK8sObject(varsCtx *VarsCtx, varsSource types.VarsSo
 		gvk.Group = gv.Group
 		gvk.Version = gv.Version
 	} else {
-		gvks, err := v.k.GetFilteredPreferredGVKs(func(ar *metav1.APIResource) bool {
+		ars, err := v.k.GetFilteredPreferredAPIResources(func(ar *metav1.APIResource) bool {
 			return ar.Kind == varsSource.Kind
 		})
 		if err != nil {
 			return nil, err
 		}
-		if len(gvks) == 0 {
+		if len(ars) == 0 {
 			return nil, fmt.Errorf("no matching resource found for kind %s", varsSource.Kind)
 		}
-		if len(gvks) != 1 {
+		if len(ars) != 1 {
 			return nil, fmt.Errorf("more then one matching resources found for kind %s, consider also specifying apiVersion", varsSource.Kind)
 		}
-		gvk = gvks[0]
+		gvk = schema.GroupVersionKind{
+			Group:   ars[0].Group,
+			Version: ars[0].Version,
+			Kind:    ars[0].Kind,
+		}
 	}
 
 	var objs []*uo.UnstructuredObject


### PR DESCRIPTION
# Description

Sometimes individual resources inside a group do not have an APIResource with a version that matches the preferred version of the group. In that case, we must use the latest version instead.

Before this, such resources were completely ignored/skipped, leading to orphan detection to not work for these resources.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
