### PR TITLE
fix: Introduce RandomizeSuffix that respects max length of names

### DIFF
--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -371,14 +371,14 @@ func (a *ApplyUtil) ApplyObject(x *uo.UnstructuredObject, replaced bool, hook bo
 		// result
 		usesDummyName = true
 		x = x.Clone()
-		x.SetK8sName(fmt.Sprintf("%s-%s", ref.Name, utils.RandomString(8)))
+		x.SetK8sName(utils.RandomizeSuffix(ref.Name, 8, 63))
 	} else if a.o.DryRun && remoteNamespace == nil && ref.Namespace != "" {
 		if _, ok := a.allNamespaces.Load(ref.Namespace); ok {
 			// The namespace does not really exist, but would have been created if dryRun would be false.
 			// So let's pretend we deploy it to the default namespace with a dummy name
 			usesDummyName = true
 			x = x.Clone()
-			x.SetK8sName(fmt.Sprintf("%s-%s", ref.Name, utils.RandomString(8)))
+			x.SetK8sName(utils.RandomizeSuffix(ref.Name, 8, 63))
 			x.SetK8sNamespace("default")
 		}
 	}

--- a/pkg/utils/rand.go
+++ b/pkg/utils/rand.go
@@ -32,3 +32,11 @@ func RandomString(n int) string {
 	}
 	return string(b)
 }
+
+func RandomizeSuffix(s string, randLen int, maxLen int) string {
+	maxPrefixLen := maxLen - 1 - randLen
+	if len(s) > maxPrefixLen {
+		s = s[:maxPrefixLen]
+	}
+	return s + "-" + RandomString(randLen)
+}


### PR DESCRIPTION
# Description

This fixes two errors in diffs when Kluctl simulates applying objects to not yet existing namespaces.

See individual commits for details.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
