### PR TITLE
fix: Fix errors when validating objects without permissions to get the CRDs

### DIFF
--- a/e2e/test-utils/envtest_cluster.go
+++ b/e2e/test-utils/envtest_cluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
@@ -190,4 +191,20 @@ func (c *EnvTestCluster) List(gvr schema.GroupVersionResource, namespace string,
 		ret = append(ret, uo.FromUnstructured(&x))
 	}
 	return ret, nil
+}
+
+func (c *EnvTestCluster) Apply(o *uo.UnstructuredObject) error {
+	var x unstructured.Unstructured
+	err := o.ToStruct(&x)
+	if err != nil {
+		return err
+	}
+	return c.Client.Patch(context.Background(), &x, client.Apply, client.FieldOwner("envtestcluster"))
+}
+
+func (c *EnvTestCluster) MustApply(t *testing.T, o *uo.UnstructuredObject) {
+	err := c.Apply(o)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/e2e/test-utils/envtest_cluster.go
+++ b/e2e/test-utils/envtest_cluster.go
@@ -208,3 +208,19 @@ func (c *EnvTestCluster) MustApply(t *testing.T, o *uo.UnstructuredObject) {
 		t.Fatal(err)
 	}
 }
+
+func (c *EnvTestCluster) ApplyStatus(o *uo.UnstructuredObject) error {
+	var x unstructured.Unstructured
+	err := o.ToStruct(&x)
+	if err != nil {
+		return err
+	}
+	return c.Client.SubResource("status").Patch(context.Background(), &x, client.Apply, client.FieldOwner("envtestcluster"))
+}
+
+func (c *EnvTestCluster) MustApplyStatus(t *testing.T, o *uo.UnstructuredObject) {
+	err := c.ApplyStatus(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/e2e/test_resources/example-crds.yaml
+++ b/e2e/test_resources/example-crds.yaml
@@ -38,3 +38,48 @@ spec:
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
       - ct
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: crontabstatuses.stable.example.com
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: stable.example.com
+  # list of versions supported by this CustomResourceDefinition
+  versions:
+    - name: v1
+      # Each version can be enabled/disabled by Served flag.
+      served: true
+      # One and only one version must be marked as the storage version.
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                cronSpec:
+                  type: string
+                image:
+                  type: string
+                replicas:
+                  type: integer
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+  # either Namespaced or Cluster
+  scope: Namespaced
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: crontabstatuses
+    # singular name to be used as an alias on the CLI and for display
+    singular: crontabstatuse
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: CronTabStatus
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+      - cts

--- a/e2e/test_resources/resources.go
+++ b/e2e/test_resources/resources.go
@@ -65,7 +65,7 @@ func waitReadiness(k *test_utils.EnvTestCluster, x *uo.UnstructuredObject) {
 		if err != nil {
 			panic(err)
 		}
-		vr := validation.ValidateObject(nil, uo.FromUnstructured(u), true, true)
+		vr := validation.ValidateObject(context.TODO(), nil, uo.FromUnstructured(u), true, true)
 		if vr.Ready {
 			break
 		} else {

--- a/e2e/validate_test.go
+++ b/e2e/validate_test.go
@@ -197,6 +197,7 @@ func TestValidateWithoutPermissions(t *testing.T) {
 	assert.NoError(t, err)
 
 	rbac := buildSingleNamespaceRbac(username, p.TestSlug(), nil, []schema.GroupResource{
+		{Group: "", Resource: "configmaps"},
 		{Group: "stable.example.com", Resource: "crontabs"},
 		{Group: "stable.example.com", Resource: "crontabstatuses"},
 	})
@@ -224,6 +225,14 @@ func TestValidateWithoutPermissions(t *testing.T) {
 		{Name: "crontab.yaml", Content: cronTab},
 		{Name: "crontab2.yaml", Content: cronTab2},
 	}, nil)
+	// a configmap should always be considered ready thanks to the scheme based check
+	addConfigMapDeployment(p, "cm", nil, resourceOpts{
+		name:      "cm",
+		namespace: p.TestSlug(),
+		annotations: map[string]string{
+			"kluctl.io/wait-readiness": "true",
+		},
+	})
 
 	// this should succeed but emit a warning about the wait not knowing if a status is expected
 	stdout, _, err := p.Kluctl(t, "deploy", "--yes")
@@ -257,6 +266,7 @@ func TestValidateWithoutPermissions(t *testing.T) {
 
 	// status requirement detection via sub-resource GET
 	testSuccess(nil, []schema.GroupResource{
+		{Group: "", Resource: "configmaps"},
 		{Group: "stable.example.com", Resource: "crontabs"},
 		{Group: "stable.example.com", Resource: "crontabs/status"},
 		{Group: "stable.example.com", Resource: "crontabstatuses"},
@@ -266,6 +276,7 @@ func TestValidateWithoutPermissions(t *testing.T) {
 	testSuccess([]schema.GroupResource{
 		{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
 	}, []schema.GroupResource{
+		{Group: "", Resource: "configmaps"},
 		{Group: "stable.example.com", Resource: "crontabs"},
 		{Group: "stable.example.com", Resource: "crontabstatuses"},
 	})
@@ -273,6 +284,7 @@ func TestValidateWithoutPermissions(t *testing.T) {
 	testSuccess([]schema.GroupResource{
 		{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
 	}, []schema.GroupResource{
+		{Group: "", Resource: "configmaps"},
 		{Group: "stable.example.com", Resource: "crontabs"},
 		{Group: "stable.example.com", Resource: "crontabs/status"},
 		{Group: "stable.example.com", Resource: "crontabstatuses"},

--- a/e2e/validate_test.go
+++ b/e2e/validate_test.go
@@ -5,13 +5,17 @@ import (
 	"fmt"
 	test_utils "github.com/kluctl/kluctl/v2/e2e/test-utils"
 	"github.com/kluctl/kluctl/v2/e2e/test_project"
+	"github.com/kluctl/kluctl/v2/e2e/test_resources"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"github.com/kluctl/kluctl/v2/pkg/yaml"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"testing"
+	"time"
 )
 
 func buildDeployment(name string, namespace string, ready bool, annotations map[string]string) *uo.UnstructuredObject {
@@ -175,4 +179,103 @@ func TestValidateSkipRollbackHooks(t *testing.T) {
 	assertObjectNotExists(t, k, appsv1.SchemeGroupVersion.WithResource("deployments"), p.TestSlug(), "d1")
 
 	assertValidate(t, p, true)
+}
+
+func TestValidateWithoutPermissions(t *testing.T) {
+	t.Parallel()
+
+	// need our own cluster due to CRDs being involved
+	k := createTestCluster(t, "cluster1")
+	test_resources.ApplyYaml(t, "example-crds.yaml", k)
+
+	p := test_project.NewTestProject(t)
+
+	createNamespace(t, k, p.TestSlug())
+
+	username := p.TestSlug()
+	au, err := k.AddUser(envtest.User{Name: username}, nil)
+	assert.NoError(t, err)
+
+	rbac := buildSingleNamespaceRbac(username, p.TestSlug(), nil, []schema.GroupResource{
+		{Group: "stable.example.com", Resource: "crontabs"},
+		{Group: "stable.example.com", Resource: "crontabstatuses"},
+	})
+	for _, x := range rbac {
+		k.MustApply(t, x)
+	}
+
+	kc, err := au.KubeConfig()
+	assert.NoError(t, err)
+
+	p.AddExtraArgs("--kubeconfig", getKubeconfigTmpFile(t, kc))
+
+	cronTab := uo.New()
+	cronTab.SetK8sGVK(schema.GroupVersionKind{Group: "stable.example.com", Version: "v1", Kind: "CronTab"})
+	cronTab.SetK8sNamespace(p.TestSlug())
+	cronTab.SetK8sName("crontab")
+	_ = cronTab.SetNestedField(map[string]any{
+		"cronSpec": "x",
+	}, "spec")
+	cronTab.SetK8sAnnotation("kluctl.io/wait-readiness", "true")
+	cronTab2 := cronTab.Clone()
+	cronTab2.SetK8sGVK(schema.GroupVersionKind{Group: "stable.example.com", Version: "v1", Kind: "CronTabStatus"})
+
+	p.AddKustomizeDeployment("x", []test_project.KustomizeResource{
+		{Name: "crontab.yaml", Content: cronTab},
+		{Name: "crontab2.yaml", Content: cronTab2},
+	}, nil)
+
+	// this should succeed but emit a warning about the wait not knowing if a status is expected
+	stdout, _, err := p.Kluctl(t, "deploy", "--yes")
+	assert.NoError(t, err)
+	assert.Contains(t, stdout, "CronTab/crontab: unable to determine if a status is expected")
+	assert.Contains(t, stdout, "CronTabStatus/crontab: unable to determine if a status is expected")
+
+	testSuccess := func(globalRbacResources []schema.GroupResource, rbacResources []schema.GroupResource) {
+		rbac = buildSingleNamespaceRbac(username, p.TestSlug(), globalRbacResources, rbacResources)
+		for _, x := range rbac {
+			k.MustApply(t, x)
+		}
+
+		// need to reset status
+		err = k.Client.Delete(context.TODO(), cronTab2.ToUnstructured())
+		assert.NoError(t, err)
+
+		// this should succeed without any warning
+		go func() {
+			// set the status sub-resource after a few seconds so that the wait finishes
+			time.Sleep(3 * time.Second)
+			x := cronTab2.Clone()
+			_ = x.SetNestedField("test", "status", "x")
+			k.MustApplyStatus(t, x)
+		}()
+		stdout, _, err = p.Kluctl(t, "deploy", "--yes", "--timeout=10s")
+		assert.NoError(t, err)
+		assert.NotContains(t, stdout, "CronTab/crontab: unable to determine if a status is expected")
+		assert.NotContains(t, stdout, "CronTabStatus/crontab: unable to determine if a status is expected")
+	}
+
+	// status requirement detection via sub-resource GET
+	testSuccess(nil, []schema.GroupResource{
+		{Group: "stable.example.com", Resource: "crontabs"},
+		{Group: "stable.example.com", Resource: "crontabs/status"},
+		{Group: "stable.example.com", Resource: "crontabstatuses"},
+		{Group: "stable.example.com", Resource: "crontabstatuses/status"},
+	})
+	// status requirement detection via CRDs
+	testSuccess([]schema.GroupResource{
+		{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
+	}, []schema.GroupResource{
+		{Group: "stable.example.com", Resource: "crontabs"},
+		{Group: "stable.example.com", Resource: "crontabstatuses"},
+	})
+	// both
+	testSuccess([]schema.GroupResource{
+		{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"},
+	}, []schema.GroupResource{
+		{Group: "stable.example.com", Resource: "crontabs"},
+		{Group: "stable.example.com", Resource: "crontabs/status"},
+		{Group: "stable.example.com", Resource: "crontabstatuses"},
+		{Group: "stable.example.com", Resource: "crontabstatuses/status"},
+	})
 }

--- a/pkg/deployment/commands/validate.go
+++ b/pkg/deployment/commands/validate.go
@@ -91,7 +91,7 @@ func (cmd *ValidateCommand) Run(ctx context.Context) *result.ValidateResult {
 			ret.Errors = append(ret.Errors, result.DeploymentError{Ref: ref, Message: "object not found"})
 			continue
 		}
-		r := validation.ValidateObject(cmd.targetCtx.SharedContext.K, remoteObject, true, false)
+		r := validation.ValidateObject(ctx, cmd.targetCtx.SharedContext.K, remoteObject, true, false)
 		if !r.Ready {
 			ret.Ready = false
 		}

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -520,6 +520,12 @@ func (a *ApplyUtil) WaitReadiness(ref k8s2.ObjectRef, timeout time.Duration) boo
 				if didLog {
 					a.sctx.InfoFallbackf("Finished waiting for %s (%ds elapsed)", ref.String(), elapsed)
 				}
+				for _, e := range v.Errors {
+					a.HandleError(ref, errors2.New(e.Message))
+				}
+				for _, e := range v.Warnings {
+					a.HandleWarning(ref, errors2.New(e.Message))
+				}
 				return true
 			}
 			if len(v.Errors) != 0 {
@@ -527,7 +533,10 @@ func (a *ApplyUtil) WaitReadiness(ref k8s2.ObjectRef, timeout time.Duration) boo
 					status.Warningf(a.ctx, "Cancelled waiting for %s due to errors (%ds elapsed)", ref.String(), elapsed)
 				}
 				for _, e := range v.Errors {
-					a.HandleError(ref, fmt.Errorf(e.Message))
+					a.HandleError(ref, errors2.New(e.Message))
+				}
+				for _, e := range v.Warnings {
+					a.HandleWarning(ref, errors2.New(e.Message))
 				}
 				return false
 			}

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -515,7 +515,7 @@ func (a *ApplyUtil) WaitReadiness(ref k8s2.ObjectRef, timeout time.Duration) boo
 		} else {
 			seen = true
 
-			v := validation.ValidateObject(a.k, o, false, false)
+			v := validation.ValidateObject(a.ctx, a.k, o, false, false)
 			if v.Ready {
 				if didLog {
 					a.sctx.InfoFallbackf("Finished waiting for %s (%ds elapsed)", ref.String(), elapsed)


### PR DESCRIPTION
# Description

This makes the permission errors seen in situations like in #1011 to be warning instead. This PR also adds a fallback that tries to get the required information by trying a sub-resource GET on the status.

Fixes #1011

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
