### PR TITLE
fix: Don't crash on oci push when git repo has no remote

### DIFF
--- a/cmd/kluctl/commands/cmd_oci_push.go
+++ b/cmd/kluctl/commands/cmd_oci_push.go
@@ -98,9 +98,11 @@ func (cmd *ociPushCmd) Run(ctx context.Context) error {
 	}
 
 	meta := client.Metadata{
-		Source:      gitInfo.Url.String(),
 		Revision:    gitInfo.Commit,
 		Annotations: annotations,
+	}
+	if gitInfo.Url != nil {
+		meta.Source = gitInfo.Url.String()
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, cmd.Timeout)


### PR DESCRIPTION
# Description

Fixes #1022 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
