### PR TITLE
fix: Don't crash in uo.GetNestedStringMapCopy in case of null strings

### DIFF
--- a/pkg/utils/uo/nested_fields.go
+++ b/pkg/utils/uo/nested_fields.go
@@ -250,11 +250,13 @@ func (uo *UnstructuredObject) GetNestedStringMapCopy(keys ...interface{}) (map[s
 	}
 	ret := make(map[string]string)
 	for k, v := range m {
-		s, ok := v.(string)
-		if !ok {
+		if v == nil {
+			ret[k] = ""
+		} else if s, ok := v.(string); ok {
+			ret[k] = s
+		} else {
 			return nil, false, fmt.Errorf("value at %s.%s is not a string", KeyPath(keys).ToJsonPath(), k)
 		}
-		ret[k] = s
 	}
 
 	return ret, true, nil


### PR DESCRIPTION
# Description

A user reported a crash in `GetK8sLabels()` that happened due to `null` label values. This PR fixes this.  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
