### PR TITLE
fix: Fix multiple crashes when there is no k8s client available

### DIFF
--- a/pkg/deployment/commands/result_utils.go
+++ b/pkg/deployment/commands/result_utils.go
@@ -41,7 +41,9 @@ func newCommandResult(targetCtx *target_context.TargetContext, startTime time.Ti
 		})
 	}
 
-	r.ClusterInfo = buildClusterInfo(targetCtx.SharedContext.K, &r.Warnings)
+	if targetCtx.SharedContext.K != nil {
+		r.ClusterInfo = buildClusterInfo(targetCtx.SharedContext.K, &r.Warnings)
+	}
 
 	r.TargetKey.TargetName = targetCtx.Target.Name
 	r.TargetKey.Discriminator = targetCtx.Target.Discriminator
@@ -64,11 +66,13 @@ func newValidateCommandResult(targetCtx *target_context.TargetContext, startTime
 		})
 	}
 
-	clusterInfo := buildClusterInfo(targetCtx.SharedContext.K, &r.Warnings)
-
 	r.TargetKey.TargetName = targetCtx.Target.Name
 	r.TargetKey.Discriminator = targetCtx.Target.Discriminator
-	r.TargetKey.ClusterId = clusterInfo.ClusterId
+
+	if targetCtx.SharedContext.K != nil {
+		clusterInfo := buildClusterInfo(targetCtx.SharedContext.K, &r.Warnings)
+		r.TargetKey.ClusterId = clusterInfo.ClusterId
+	}
 
 	return r
 }
@@ -86,8 +90,9 @@ func newDeleteCommandResult(k *k8s2.K8sCluster, startTime time.Time, inclusion *
 	r.Command.IncludeDeploymentDirs = inclusion.GetIncludes("deploymentItemDir")
 	r.Command.ExcludeDeploymentDirs = inclusion.GetExcludes("deploymentItemDir")
 
-	r.ClusterInfo = buildClusterInfo(k, &r.Warnings)
-
+	if k != nil {
+		r.ClusterInfo = buildClusterInfo(k, &r.Warnings)
+	}
 	return r
 }
 

--- a/pkg/deployment/utils/apply_utils.go
+++ b/pkg/deployment/utils/apply_utils.go
@@ -780,6 +780,11 @@ func (a *ApplyDeploymentsUtil) buildProgressName(d *deployment.DeploymentItem) *
 }
 
 func (a *ApplyDeploymentsUtil) ApplyDeployments(deployments []*deployment.DeploymentItem) {
+	if a.k == nil {
+		a.dew.AddError(k8s2.ObjectRef{}, fmt.Errorf("can not apply objects without a Kubernetes API client"))
+		return
+	}
+
 	var wg sync.WaitGroup
 	sem := semaphore.NewWeighted(8)
 

--- a/pkg/deployment/utils/delete_utils.go
+++ b/pkg/deployment/utils/delete_utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"github.com/kluctl/kluctl/v2/pkg/k8s"
 	k8s2 "github.com/kluctl/kluctl/v2/pkg/types/k8s"
 	"github.com/kluctl/kluctl/v2/pkg/utils"
@@ -161,6 +162,10 @@ func filterObjectsForDelete(k *k8s.K8sCluster, objects []*uo.UnstructuredObject,
 }
 
 func FindObjectsForDelete(k *k8s.K8sCluster, allClusterObjects []*uo.UnstructuredObject, inclusionHasTags bool, excludedObjects []k8s2.ObjectRef) ([]k8s2.ObjectRef, error) {
+	if k == nil {
+		return nil, fmt.Errorf("can not determine orphan objects without a Kubernetes API client")
+	}
+
 	excludedObjectsMap := make(map[k8s2.ObjectRef]bool)
 	for _, ref := range excludedObjects {
 		excludedObjectsMap[objectRefForExclusion(k, ref)] = true


### PR DESCRIPTION
# Description

Multiple potential crashes were discovered when working in offline mode. Some happen only when the offline-mode happens unexpectedly, e.g. when the kubeconfig is empty.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
