### PR TITLE
fix: Use a temporary copy of the oauth2 config while refreshing tokens

### DIFF
--- a/pkg/webui/auth.go
+++ b/pkg/webui/auth.go
@@ -108,7 +108,7 @@ func newAuthHandler(ctx context.Context, serverClient client.Client, controllerN
 		ret.viewerPassword = x
 	}
 
-	err = ret.setupOidcProvider(ctx, authConfig)
+	err = ret.setupOidcProvider(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/webui/auth_oidc.go
+++ b/pkg/webui/auth_oidc.go
@@ -157,7 +157,11 @@ func (s *authHandler) oidcCallbackHandler(c *gin.Context) {
 }
 
 func (s *authHandler) oidcRefresh(c *gin.Context, session sessions.Session, tokenInfo *oidcTokenInfo) error {
-	ts := s.oauth2Config.TokenSource(c, &oauth2.Token{
+	// We must use a copy of the config to avoid poisoning the authStyleCache
+	// See https://github.com/golang/oauth2/issues/718
+	cfgCopy := *s.oauth2Config
+
+	ts := cfgCopy.TokenSource(c, &oauth2.Token{
 		RefreshToken: tokenInfo.RefreshToken,
 	})
 	newToken, err := ts.Token()

--- a/pkg/webui/auth_oidc.go
+++ b/pkg/webui/auth_oidc.go
@@ -22,17 +22,17 @@ type oidcTokenInfo struct {
 	User         *User
 }
 
-func (s *authHandler) setupOidcProvider(ctx context.Context, authConfig AuthConfig) error {
-	if authConfig.OidcIssuerUrl == "" {
+func (s *authHandler) setupOidcProvider(ctx context.Context) error {
+	if s.authConfig.OidcIssuerUrl == "" {
 		return nil
 	}
 
-	clientSecret, err := s.getSecret(authConfig.OidcClientSecretName, authConfig.OidcClientSecretKey, false)
+	clientSecret, err := s.getSecret(s.authConfig.OidcClientSecretName, s.authConfig.OidcClientSecretKey, false)
 	if err != nil {
 		return err
 	}
 
-	provider, err := oidc.NewProvider(ctx, authConfig.OidcIssuerUrl)
+	provider, err := oidc.NewProvider(ctx, s.authConfig.OidcIssuerUrl)
 	if err != nil {
 		return err
 	}
@@ -44,10 +44,10 @@ func (s *authHandler) setupOidcProvider(ctx context.Context, authConfig AuthConf
 	}
 
 	s.oauth2Config = &oauth2.Config{
-		ClientID:     authConfig.OidcClientId,
+		ClientID:     s.authConfig.OidcClientId,
 		ClientSecret: clientSecret,
-		RedirectURL:  authConfig.OidcRedirectUrl,
-		Scopes:       authConfig.OidcScopes,
+		RedirectURL:  s.authConfig.OidcRedirectUrl,
+		Scopes:       s.authConfig.OidcScopes,
 		Endpoint:     provider.Endpoint(),
 	}
 


### PR DESCRIPTION
# Description

This is a workaround for https://github.com/golang/oauth2/issues/718

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
