### PR TITLE
fix: Fix pre-pulled Helm charts in kluctl libraries

### DIFF
--- a/cmd/kluctl/commands/cmd_helm_pull.go
+++ b/cmd/kluctl/commands/cmd_helm_pull.go
@@ -33,7 +33,7 @@ func (cmd *helmPullCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	if !yaml.Exists(filepath.Join(projectDir, ".kluctl.yaml")) {
+	if !yaml.Exists(filepath.Join(projectDir, ".kluctl.yaml")) && !yaml.Exists(filepath.Join(projectDir, ".kluctl-library.yaml")) {
 		return fmt.Errorf("helm-pull can only be used on the root of a Kluctl project that must have a .kluctl.yaml file")
 	}
 

--- a/cmd/kluctl/commands/cmd_helm_update.go
+++ b/cmd/kluctl/commands/cmd_helm_update.go
@@ -41,7 +41,7 @@ func (cmd *helmUpdateCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	if !yaml.Exists(filepath.Join(projectDir, ".kluctl.yaml")) {
+	if !yaml.Exists(filepath.Join(projectDir, ".kluctl.yaml")) && !yaml.Exists(filepath.Join(projectDir, ".kluctl-library.yaml")) {
 		return fmt.Errorf("helm-update can only be used on the root of a Kluctl project that must have a .kluctl.yaml file")
 	}
 

--- a/e2e/gitops_helm_test.go
+++ b/e2e/gitops_helm_test.go
@@ -102,7 +102,7 @@ func (suite *GitOpsHelmSuite) testHelmPull(tc helmTestCase, prePull bool) {
 		})
 	}
 
-	key := suite.createKluctlDeployment2(p, "test", map[string]any{
+	key := suite.createKluctlDeployment2(p, "", map[string]any{
 		"namespace": p.TestSlug(),
 	}, func(kd *kluctlv1.KluctlDeployment) {
 		kd.Spec.Source = kluctlv1.ProjectSource{

--- a/e2e/gitops_helm_test.go
+++ b/e2e/gitops_helm_test.go
@@ -22,7 +22,7 @@ func TestGitOpsHelm(t *testing.T) {
 func (suite *GitOpsHelmSuite) testHelmPull(tc helmTestCase, prePull bool) {
 	g := NewWithT(suite.T())
 
-	p, repo, err := prepareHelmTestCase(suite.T(), suite.k, tc, prePull, false)
+	p, repo, err := prepareHelmTestCase(suite.T(), suite.k, tc, prePull, false, noLibrary)
 	if err != nil {
 		if tc.expectedPrepareError == "" {
 			assert.Fail(suite.T(), "did not expect error")

--- a/e2e/helm_test.go
+++ b/e2e/helm_test.go
@@ -360,7 +360,6 @@ func prepareHelmTestCase(t *testing.T, k *test_utils.EnvTestCluster, tc helmTest
 
 	extraArgs := buildHelmTestExtraArgs(t, tc, repo)
 
-	p.UpdateTarget("test", nil)
 	p.AddHelmDeployment("helm1", repo.URL.String(), "test-chart1", "0.1.0", "test-helm1", p.TestSlug(), nil)
 
 	if tc.testAuth {
@@ -416,7 +415,7 @@ func testHelmPull(t *testing.T, tc helmTestCase, prePull bool, credsViaEnv bool)
 		return
 	}
 
-	args := []string{"deploy", "--yes", "-t", "test"}
+	args := []string{"deploy", "--yes"}
 	if credsViaEnv {
 		buildHelmTestEnvVars(t, tc, p, repo)
 	} else {
@@ -487,12 +486,11 @@ func testHelmManualUpgrade(t *testing.T, oci bool) {
 	}
 	repo.Start(t)
 
-	p.UpdateTarget("test", nil)
 	p.AddHelmDeployment("helm1", repo.URL.String(), "test-chart1", "0.1.0", "test-helm1", p.TestSlug(), nil)
 
 	p.KluctlMust(t, "helm-pull")
 	assert.FileExists(t, getChartFile(t, p, repo.URL.String(), "test-chart1", "0.1.0"))
-	p.KluctlMust(t, "deploy", "--yes", "-t", "test")
+	p.KluctlMust(t, "deploy", "--yes")
 	cm := assertConfigMapExists(t, k, p.TestSlug(), "test-helm1-test-chart1")
 	v, _, _ := cm.GetNestedString("data", "version")
 	assert.Equal(t, "0.1.0", v)
@@ -505,7 +503,7 @@ func testHelmManualUpgrade(t *testing.T, oci bool) {
 	p.KluctlMust(t, "helm-pull")
 	assert.NoFileExists(t, getChartFile(t, p, repo.URL.String(), "test-chart1", "0.1.0"))
 	assert.FileExists(t, getChartFile(t, p, repo.URL.String(), "test-chart1", "0.2.0"))
-	p.KluctlMust(t, "deploy", "--yes", "-t", "test")
+	p.KluctlMust(t, "deploy", "--yes")
 	cm = assertConfigMapExists(t, k, p.TestSlug(), "test-helm1-test-chart1")
 	v, _, _ = cm.GetNestedString("data", "version")
 	assert.Equal(t, "0.2.0", v)
@@ -539,7 +537,6 @@ func testHelmUpdate(t *testing.T, oci bool, upgrade bool, commit bool) {
 	}
 	repo.Start(t)
 
-	p.UpdateTarget("test", nil)
 	p.AddHelmDeployment("helm1", repo.URL.String(), "test-chart1", "0.1.0", "test-helm1", p.TestSlug(), nil)
 	p.AddHelmDeployment("helm2", repo.URL.String(), "test-chart2", "0.1.0", "test-helm2", p.TestSlug(), nil)
 	p.AddHelmDeployment("helm3", repo.URL.String(), "test-chart1", "0.1.0", "test-helm3", p.TestSlug(), nil)
@@ -660,7 +657,6 @@ func testHelmUpdateConstraints(t *testing.T, oci bool) {
 	}
 	repo.Start(t)
 
-	p.UpdateTarget("test", nil)
 	p.AddHelmDeployment("helm1", repo.URL.String(), "test-chart1", "0.1.0", "test-helm1", p.TestSlug(), nil)
 	p.AddHelmDeployment("helm2", repo.URL.String(), "test-chart1", "0.1.0", "test-helm2", p.TestSlug(), nil)
 	p.AddHelmDeployment("helm3", repo.URL.String(), "test-chart1", "0.1.0", "test-helm3", p.TestSlug(), nil)
@@ -741,13 +737,12 @@ func TestHelmValues(t *testing.T) {
 		},
 	}
 
-	p.UpdateTarget("test", nil)
 	p.AddHelmDeployment("helm1", repo.URL.String(), "test-chart1", "0.1.0", "test-helm1", p.TestSlug(), values1)
 	p.AddHelmDeployment("helm2", repo.URL.String(), "test-chart2", "0.1.0", "test-helm2", p.TestSlug(), values2)
 	p.AddHelmDeployment("helm3", repo.URL.String(), "test-chart1", "0.1.0", "test-helm3", p.TestSlug(), values3)
 
 	p.KluctlMust(t, "helm-pull")
-	p.KluctlMust(t, "deploy", "--yes", "-t", "test", "-aa=a", "-ab=b")
+	p.KluctlMust(t, "deploy", "--yes", "-aa=a", "-ab=b")
 
 	cm1 := assertConfigMapExists(t, k, p.TestSlug(), "test-helm1-test-chart1")
 	cm2 := assertConfigMapExists(t, k, p.TestSlug(), "test-helm2-test-chart2")
@@ -792,14 +787,13 @@ func TestHelmTemplateChartYaml(t *testing.T) {
 	}
 	repo.Start(t)
 
-	p.UpdateTarget("test", nil)
 	p.AddHelmDeployment("helm1", repo.URL.String(), "test-chart1", "0.1.0", "test-helm-{{ args.a }}", p.TestSlug(), nil)
 	p.AddHelmDeployment("helm2", repo.URL.String(), "test-chart2", "0.1.0", "test-helm-{{ args.b }}", p.TestSlug(), nil)
 	p.AddHelmDeployment("helm3", repo.URL.String(), "test-chart1", "0.1.0", "test-helm-ns", p.TestSlug()+"-{{ args.a }}", nil)
 	p.AddHelmDeployment("helm4", repo.URL.String(), "test-chart1", "0.1.0", "test-helm-ns", p.TestSlug()+"-{{ args.b }}", nil)
 
 	p.KluctlMust(t, "helm-pull")
-	p.KluctlMust(t, "deploy", "--yes", "-t", "test", "-aa=a", "-ab=b")
+	p.KluctlMust(t, "deploy", "--yes", "-aa=a", "-ab=b")
 
 	assertConfigMapExists(t, k, p.TestSlug(), "test-helm-a-test-chart1")
 	assertConfigMapExists(t, k, p.TestSlug(), "test-helm-b-test-chart2")
@@ -823,14 +817,13 @@ func TestHelmRenderOfflineKubernetes(t *testing.T) {
 	}
 	repo.Start(t)
 
-	p.UpdateTarget("test", nil)
 	p.AddHelmDeployment("helm1", repo.URL.String(), "test-chart1", "0.1.0", "test-helm1", p.TestSlug(), nil)
 	p.UpdateYaml("helm1/helm-chart.yaml", func(o *uo.UnstructuredObject) error {
 		_ = o.SetNestedField(true, "helmChart", "skipPrePull")
 		return nil
 	}, "")
 
-	stdout, _ := p.KluctlMust(t, "render", "--print-all", "--offline-kubernetes", "-t", "test")
+	stdout, _ := p.KluctlMust(t, "render", "--print-all", "--offline-kubernetes")
 	cm1 := uo.FromStringMust(stdout)
 
 	assert.Equal(t, map[string]any{
@@ -840,7 +833,7 @@ func TestHelmRenderOfflineKubernetes(t *testing.T) {
 		"kubeVersion": "v1.20.0",
 	}, cm1.Object["data"])
 
-	stdout, _ = p.KluctlMust(t, "render", "--print-all", "--offline-kubernetes", "--kubernetes-version", "1.22.1", "-t", "test")
+	stdout, _ = p.KluctlMust(t, "render", "--print-all", "--offline-kubernetes", "--kubernetes-version", "1.22.1")
 	cm1 = uo.FromStringMust(stdout)
 
 	assert.Equal(t, map[string]any{
@@ -860,14 +853,13 @@ func TestHelmLocalChart(t *testing.T) {
 
 	createNamespace(t, k, p.TestSlug())
 
-	p.UpdateTarget("test", nil)
 	p.AddHelmDeployment("helm1", "../test-chart1", "", "", "test-helm-1", p.TestSlug(), nil)
 	p.AddHelmDeployment("helm2", "test-chart2", "", "", "test-helm-2", p.TestSlug(), nil)
 
 	test_utils.CreateHelmDir(t, "test-chart1", "0.1.0", filepath.Join(p.LocalProjectDir(), "test-chart1"))
 	test_utils.CreateHelmDir(t, "test-chart2", "0.1.0", filepath.Join(p.LocalProjectDir(), "helm2/test-chart2"))
 
-	p.KluctlMust(t, "deploy", "--yes", "-t", "test")
+	p.KluctlMust(t, "deploy", "--yes")
 	assertConfigMapExists(t, k, p.TestSlug(), "test-helm-1-test-chart1")
 	assertConfigMapExists(t, k, p.TestSlug(), "test-helm-2-test-chart2")
 
@@ -894,7 +886,6 @@ func TestHelmSkipPrePull(t *testing.T) {
 	}
 	repo.Start(t)
 
-	p.UpdateTarget("test", nil)
 	p.AddHelmDeployment("helm1", repo.URL.String(), "test-chart1", "0.1.0", "test-helm1", p.TestSlug(), nil)
 	p.AddHelmDeployment("helm2", repo.URL.String(), "test-chart1", "0.1.1", "test-helm2", p.TestSlug(), nil)
 
@@ -1029,22 +1020,46 @@ func TestHelmLookup(t *testing.T) {
 		"lookupName":      lookupCm.Name,
 	}
 
-	p.UpdateTarget("test", nil)
 	p.AddHelmDeployment("helm1", repo.URL.String(), "test-chart1", "0.1.0", "test-helm1", p.TestSlug(), values1)
 
 	p.KluctlMust(t, "helm-pull")
-	p.KluctlMust(t, "deploy", "--yes", "-t", "test")
+	p.KluctlMust(t, "deploy", "--yes")
 
 	cm1 := assertConfigMapExists(t, k, p.TestSlug(), "test-helm1-test-chart1")
 	assertNestedFieldEquals(t, cm1, "lookupValue", "data", "lookup")
 
-	s, _ := p.KluctlMust(t, "render", "-t", "test", "--print-all")
+	s, _ := p.KluctlMust(t, "render", "--print-all")
 	y, err := uo.FromString(s)
 	assert.NoError(t, err)
 	assertNestedFieldEquals(t, y, "lookupValue", "data", "lookup")
 
-	s, _ = p.KluctlMust(t, "render", "-t", "test", "--print-all", "--offline-kubernetes")
+	s, _ = p.KluctlMust(t, "render", "--print-all", "--offline-kubernetes")
 	y, err = uo.FromString(s)
 	assert.NoError(t, err)
 	assertNestedFieldEquals(t, y, "lookupReturnedNil", "data", "lookup")
+}
+
+func TestHelmWithTarget(t *testing.T) {
+	t.Parallel()
+
+	k := defaultCluster1
+
+	p := test_project.NewTestProject(t)
+	p.UpdateTarget("test", nil)
+
+	createNamespace(t, k, p.TestSlug())
+
+	repo := &test_utils.TestHelmRepo{
+		Charts: []test_utils.RepoChart{
+			{ChartName: "test-chart1", Version: "0.1.0"},
+		},
+	}
+	repo.Start(t)
+
+	p.AddHelmDeployment("helm1", repo.URL.String(), "test-chart1", "0.1.0", "test-helm1", p.TestSlug(), nil)
+
+	p.KluctlMust(t, "helm-pull")
+	p.KluctlMust(t, "deploy", "--yes", "-t", "test")
+
+	assertConfigMapExists(t, k, p.TestSlug(), "test-helm1-test-chart1")
 }

--- a/e2e/test-utils/test_git_server.go
+++ b/e2e/test-utils/test_git_server.go
@@ -277,6 +277,7 @@ func (p *TestGitServer) UpdateYaml(repo string, pth string, update func(o map[st
 	fullPath := filepath.Join(p.LocalWorkDir(repo), pth)
 
 	var o map[string]any
+	isNew := false
 	if _, err := os.Stat(fullPath); err == nil {
 		b, err := os.ReadFile(fullPath)
 		if err != nil {
@@ -288,6 +289,7 @@ func (p *TestGitServer) UpdateYaml(repo string, pth string, update func(o map[st
 		}
 	} else {
 		o = map[string]any{}
+		isNew = true
 	}
 
 	var orig map[string]any
@@ -300,7 +302,7 @@ func (p *TestGitServer) UpdateYaml(repo string, pth string, update func(o map[st
 	if err != nil {
 		p.t.Fatal(err)
 	}
-	if reflect.DeepEqual(o, orig) {
+	if !isNew && reflect.DeepEqual(o, orig) {
 		return
 	}
 	p.CommitYaml(repo, pth, message, o)

--- a/e2e/test_project/project.go
+++ b/e2e/test_project/project.go
@@ -88,7 +88,9 @@ func NewTestProject(t *testing.T, opts ...TestProjectOption) *TestProject {
 	if p.gitServer == nil {
 		p.gitServer = git2.NewTestGitServer(t)
 	}
-	p.gitServer.GitInit(p.gitRepoName)
+	if !utils.IsDirectory(p.gitServer.LocalWorkDir(p.gitRepoName)) {
+		p.gitServer.GitInit(p.gitRepoName)
+	}
 
 	if !p.bare {
 		p.UpdateKluctlYaml(func(o *uo.UnstructuredObject) error {


### PR DESCRIPTION
# Description

This contains multiple fixes in regard to pre-pulling inside kluctl libraries. See individual commits.

Fixes #1036

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
