### PR TITLE
fix: Don't try to find pre-pulled chart when skipPrePull is true

### DIFF
--- a/pkg/helm/chart.go
+++ b/pkg/helm/chart.go
@@ -112,6 +112,10 @@ func (c *Chart) GetLocalChartVersion() (string, error) {
 }
 
 func (c *Chart) BuildPulledChartDir(baseDir string, version string) (string, error) {
+	if baseDir == "" {
+		return "", fmt.Errorf("can't determine pulled chart dir. No base dir for charts found")
+	}
+
 	u, err := url.Parse(c.repo)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
# Description

This fixes an issue reported by @netthier in Slack. The controller tried to determined the pre-pulled path of a chart with pre-pulling disabled, which it should not do.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
