### PR TITLE
feat: show current version of helm chart if a new version is available

### DIFF
--- a/cmd/kluctl/commands/cmd_helm_update.go
+++ b/cmd/kluctl/commands/cmd_helm_update.go
@@ -175,7 +175,7 @@ func (cmd *helmUpdateCmd) Run(ctx context.Context) error {
 			continue
 		}
 
-		status.Infof(ctx, "%s: Chart %s has new version %s available", relDir, hr.Chart.GetChartName(), latestVersion)
+		status.Infof(ctx, "%s: Chart %s-%s has new version %s available", relDir, hr.Chart.GetChartName(), hr.Config.HelmChartConfig2.ChartVersion, latestVersion)
 
 		if !cmd.Upgrade {
 			continue

--- a/cmd/kluctl/commands/cmd_helm_update.go
+++ b/cmd/kluctl/commands/cmd_helm_update.go
@@ -175,7 +175,7 @@ func (cmd *helmUpdateCmd) Run(ctx context.Context) error {
 			continue
 		}
 
-		status.Infof(ctx, "%s: Chart %s-%s has new version %s available", relDir, hr.Chart.GetChartName(), hr.Config.HelmChartConfig2.ChartVersion, latestVersion)
+		status.Infof(ctx, "%s: Chart %s (old version %s) has new version %s available", relDir, hr.Chart.GetChartName(), hr.Config.HelmChartConfig2.ChartVersion, latestVersion)
 
 		if !cmd.Upgrade {
 			continue

--- a/e2e/helm_test.go
+++ b/e2e/helm_test.go
@@ -638,7 +638,7 @@ func testHelmUpdate(t *testing.T, oci bool, upgrade bool, commit bool) {
 
 	_, stderr := p.KluctlMust(t, args...)
 	assert.Contains(t, stderr, "helm1: Chart test-chart1 (old version 0.1.0) has new version 0.2.0 available")
-	assert.Contains(t, stderr, "helm2: Chart test-chart2-0.1.0 has new version 0.3.0 available")
+	assert.Contains(t, stderr, "helm2: Chart test-chart2 (old version 0.1.0) has new version 0.3.0 available")
 	assert.Contains(t, stderr, "helm3: Skipped update to version 0.2.0")
 
 	if upgrade {
@@ -749,9 +749,9 @@ func testHelmUpdateConstraints(t *testing.T, oci bool) {
 	args := []string{"helm-update", "--upgrade"}
 
 	_, stderr := p.KluctlMust(t, args...)
-	assert.Contains(t, stderr, "helm1: Chart test-chart1-0.1.0 has new version 0.1.1 available")
-	assert.Contains(t, stderr, "helm2: Chart test-chart1-0.1.0 has new version 0.2.0 available")
-	assert.Contains(t, stderr, "helm3: Chart test-chart1-0.1.0 has new version 1.2.1 available")
+	assert.Contains(t, stderr, "helm1: Chart test-chart1 (old version 0.1.0) has new version 0.1.1 available")
+	assert.Contains(t, stderr, "helm2: Chart test-chart1 (old version 0.1.0) has new version 0.2.0 available")
+	assert.Contains(t, stderr, "helm3: Chart test-chart1 (old version 0.1.0) has new version 1.2.1 available")
 
 	c1 := p.GetYaml("helm1/helm-chart.yaml")
 	c2 := p.GetYaml("helm2/helm-chart.yaml")

--- a/e2e/helm_test.go
+++ b/e2e/helm_test.go
@@ -637,7 +637,7 @@ func testHelmUpdate(t *testing.T, oci bool, upgrade bool, commit bool) {
 	}
 
 	_, stderr := p.KluctlMust(t, args...)
-	assert.Contains(t, stderr, "helm1: Chart test-chart1-0.1.0 has new version 0.2.0 available")
+	assert.Contains(t, stderr, "helm1: Chart test-chart1 (old version 0.1.0) has new version 0.2.0 available")
 	assert.Contains(t, stderr, "helm2: Chart test-chart2-0.1.0 has new version 0.3.0 available")
 	assert.Contains(t, stderr, "helm3: Skipped update to version 0.2.0")
 

--- a/e2e/helm_test.go
+++ b/e2e/helm_test.go
@@ -637,8 +637,8 @@ func testHelmUpdate(t *testing.T, oci bool, upgrade bool, commit bool) {
 	}
 
 	_, stderr := p.KluctlMust(t, args...)
-	assert.Contains(t, stderr, "helm1: Chart test-chart1 has new version 0.2.0 available")
-	assert.Contains(t, stderr, "helm2: Chart test-chart2 has new version 0.3.0 available")
+	assert.Contains(t, stderr, "helm1: Chart test-chart1-0.1.0 has new version 0.2.0 available")
+	assert.Contains(t, stderr, "helm2: Chart test-chart2-0.1.0 has new version 0.3.0 available")
 	assert.Contains(t, stderr, "helm3: Skipped update to version 0.2.0")
 
 	if upgrade {
@@ -749,9 +749,9 @@ func testHelmUpdateConstraints(t *testing.T, oci bool) {
 	args := []string{"helm-update", "--upgrade"}
 
 	_, stderr := p.KluctlMust(t, args...)
-	assert.Contains(t, stderr, "helm1: Chart test-chart1 has new version 0.1.1 available")
-	assert.Contains(t, stderr, "helm2: Chart test-chart1 has new version 0.2.0 available")
-	assert.Contains(t, stderr, "helm3: Chart test-chart1 has new version 1.2.1 available")
+	assert.Contains(t, stderr, "helm1: Chart test-chart1-0.1.0 has new version 0.1.1 available")
+	assert.Contains(t, stderr, "helm2: Chart test-chart1-0.1.0 has new version 0.2.0 available")
+	assert.Contains(t, stderr, "helm3: Chart test-chart1-0.1.0 has new version 1.2.1 available")
 
 	c1 := p.GetYaml("helm1/helm-chart.yaml")
 	c2 := p.GetYaml("helm2/helm-chart.yaml")


### PR DESCRIPTION
# Description
This pull request enhances the functionality of the `kluctl helm-update` command to provide users with more information. Now, in addition to searching for updates of the Helm chart, the command will also display the current version of the Helm chart if a newer version is available. This improvement aims to offer greater visibility into the version status of Helm charts.

<img width="610" alt="image" src="https://github.com/kluctl/kluctl/assets/43266827/a9df45c1-d437-4b15-90d3-3fc8a88a4a43">


Implements (#415)

## Type of change

Please delete options that are not relevant.
- [ x] New feature (non-breaking change which adds functionality)

