### PR TITLE
fix: Don't swallow errors when accepting websockets

### DIFF
--- a/pkg/webui/utils.go
+++ b/pkg/webui/utils.go
@@ -20,7 +20,7 @@ func acceptWebsocket(ctx *gin.Context) (*websocket.Conn, error) {
 
 	conn, err := websocket.Accept(ctx.Writer, ctx.Request, acceptOptions)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
 	return conn, err


### PR DESCRIPTION
# Description

A user reported panics in the webui logs when deployed to the cluster. This should fix the panics caused by swallowing Go errors and thus causing nil pointer references.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
