### PR TITLE
feat: Support running the webui under different path prefixes

### DIFF
--- a/cmd/kluctl/commands/cmd_webui_run.go
+++ b/cmd/kluctl/commands/cmd_webui_run.go
@@ -14,8 +14,9 @@ import (
 )
 
 type webuiRunCmd struct {
-	Host string `group:"misc" help:"Host to bind to. Pass an empty string to bind to all addresses. Defaults to 'localhost' when run locally and to all hosts when run in-cluster."`
-	Port int    `group:"misc" help:"Port to bind to." default:"8080"`
+	Host       string `group:"misc" help:"Host to bind to. Pass an empty string to bind to all addresses. Defaults to 'localhost' when run locally and to all hosts when run in-cluster."`
+	Port       int    `group:"misc" help:"Port to bind to." default:"8080"`
+	PathPrefix string `group:"misc" help:"Specify the prefix of the path to serve the webui on. This is required when using a reverse proxy, ingress or gateway that serves the webui on another path than /." default:"/"`
 
 	Kubeconfig  args.ExistingFileType `group:"misc" help:"Overrides the kubeconfig to use."`
 	Context     []string              `group:"misc" help:"List of kubernetes contexts to use."`
@@ -154,7 +155,7 @@ func (cmd *webuiRunCmd) Run(ctx context.Context) error {
 	collector := results.NewResultsCollector(ctx, stores)
 	collector.Start()
 
-	server, err := webui.NewCommandResultsServer(ctx, collector, configs, cmd.ControllerNamespace, inClusterConfig, inClusterClient, authConfig, cmd.OnlyApi)
+	server, err := webui.NewCommandResultsServer(ctx, collector, configs, cmd.ControllerNamespace, inClusterConfig, inClusterClient, authConfig, cmd.PathPrefix, cmd.OnlyApi)
 	if err != nil {
 		return err
 	}

--- a/docs/kluctl/commands/webui-run.md
+++ b/docs/kluctl/commands/webui-run.md
@@ -33,6 +33,9 @@ Misc arguments:
       --in-cluster-context string     The context to use fo in-cluster functionality.
       --kubeconfig existingfile       Overrides the kubeconfig to use.
       --only-api                      Only serve API without the actual UI.
+      --path-prefix string            Specify the prefix of the path to serve the webui on. This is required when
+                                      using a reverse proxy, ingress or gateway that serves the webui on another
+                                      path than /. (default "/")
       --port int                      Port to bind to. (default 8080)
 
 ```

--- a/docs/webui/installation.md
+++ b/docs/webui/installation.md
@@ -51,6 +51,23 @@ For an example of an OIDC provider configurations, see [Azure AD Integration](./
 
 ## Customization
 
+### Serving under a different path
+
+By default, the webui is served under the `/`path. To change the path, pass the `--prefix-path` argument to the webui:
+
+```yaml
+deployments:
+  - git:
+      url: https://github.com/kluctl/kluctl.git
+      subDir: install/webui
+      ref:
+        tag: v2.24.1
+    vars:
+      - values:
+          webui_args:
+            - --path-prefix=/my-custom-prefix
+```
+
 ### Overriding the version
 
 The image version of the Webui can be overriden with the `kluctl_version` arg:

--- a/pkg/webui/ui/src/components/Router.tsx
+++ b/pkg/webui/ui/src/components/Router.tsx
@@ -7,6 +7,7 @@ import { TargetsView } from "./target-view/TargetsView";
 import { CommandResultSummary } from "../models";
 import { buildTargetPath, ProjectSummary, TargetSummary } from "../project-summaries";
 import { Loading } from "./Loading";
+import { rootPath } from "../api";
 
 function ErrorPage() {
     const error = useRouteError() as any;
@@ -109,14 +110,14 @@ function RedirectToTarget(props: {}) {
     useEffect(() => {
         if (timedout) {
             console.log("timed out waiting for results/projects")
-            window.location.replace("/#/targets")
+            window.location.replace(rootPath + "/#/targets")
             return
         }
         if (!redirectPath) {
             return
         }
 
-        window.location.replace("/#" + redirectPath)
+        window.location.replace(rootPath + "/#" + redirectPath)
     }, [redirectPath, timedout]);
 
     return <Loading/>


### PR DESCRIPTION
# Description

This introduces `--path-prefix` to `kluctl webui run`.

Fixes #1078

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
