### PR TITLE
fix: Generate and render no-name target in loadTargets, same as other targets

### DIFF
--- a/e2e/discriminator_test.go
+++ b/e2e/discriminator_test.go
@@ -61,7 +61,7 @@ func TestDiscriminatorArgWithoutTarget(t *testing.T) {
 	cm = assertConfigMapExists(t, k, p.TestSlug(), "cm2")
 	assertNestedFieldEquals(t, cm, "test-discriminator", "metadata", "labels", "kluctl.io/discriminator")
 
-	p.KluctlMust(t, "deploy", "--yes", "--discriminator", "test-discriminator-{{ args.a }}", "-a", "a=x")
+	p.KluctlMust(t, "deploy", "--yes", "--discriminator", "test-discriminator-x")
 	cm = assertConfigMapExists(t, k, p.TestSlug(), "cm1")
 	assertNestedFieldEquals(t, cm, "test-discriminator-x", "metadata", "labels", "kluctl.io/discriminator")
 
@@ -98,7 +98,7 @@ func TestDiscriminatorArgWithTarget(t *testing.T) {
 	cm = assertConfigMapExists(t, k, p.TestSlug(), "cm2")
 	assertNestedFieldEquals(t, cm, "test-discriminator", "metadata", "labels", "kluctl.io/discriminator")
 
-	p.KluctlMust(t, "deploy", "--yes", "-t", "test", "--discriminator", "test-discriminator-{{ target.name }}-{{ args.a }}", "-a", "a=x")
+	p.KluctlMust(t, "deploy", "--yes", "-t", "test", "--discriminator", "test-discriminator-test-x", "-a", "a=x")
 	cm = assertConfigMapExists(t, k, p.TestSlug(), "cm1")
 	assertNestedFieldEquals(t, cm, "test-discriminator-test-x", "metadata", "labels", "kluctl.io/discriminator")
 

--- a/pkg/kluctl_project/project.go
+++ b/pkg/kluctl_project/project.go
@@ -15,6 +15,8 @@ type LoadedKluctlProject struct {
 	Config  types2.KluctlProject
 	Targets []*types2.Target
 
+	NoNameTarget *types2.Target
+
 	J2    *jinja2.Jinja2
 	GitRP *repocache.GitRepoCache
 	OciRP *repocache.OciRepoCache

--- a/pkg/kluctl_project/targets.go
+++ b/pkg/kluctl_project/targets.go
@@ -15,6 +15,19 @@ func (c *LoadedKluctlProject) loadTargets(ctx context.Context) error {
 	targetNames := make(map[string]bool)
 	c.Targets = nil
 
+	if len(c.Config.Targets) == 0 {
+		target, err := c.buildTarget(&types.Target{})
+		if err != nil {
+			return err
+		}
+		err = c.renderTarget(target)
+		if err != nil {
+			return err
+		}
+		c.NoNameTarget = target
+		return nil
+	}
+
 	for i, configTarget := range c.Config.Targets {
 		if configTarget.Name == "" {
 			status.Errorf(ctx, "Target at index %d has no name", i)
@@ -27,7 +40,7 @@ func (c *LoadedKluctlProject) loadTargets(ctx context.Context) error {
 			continue
 		}
 
-		err = c.RenderTarget(target)
+		err = c.renderTarget(target)
 		if err != nil {
 			status.Warningf(ctx, "Failed to load target %s: %v", target.Name, err)
 			continue
@@ -46,7 +59,7 @@ func (c *LoadedKluctlProject) loadTargets(ctx context.Context) error {
 	return nil
 }
 
-func (c *LoadedKluctlProject) RenderTarget(target *types.Target) error {
+func (c *LoadedKluctlProject) renderTarget(target *types.Target) error {
 	// Try rendering the target multiple times, until all values can be rendered successfully. This allows the target
 	// to reference itself in complex ways. We'll also try loading the cluster vars in each iteration.
 


### PR DESCRIPTION
# Description

This fixes many potential issues with defaulting and rendering of templated config. For example, the default aws config was not copied into the no-name target.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
