### PR TITLE
fix: Also ignore batch.kubernetes.io/controller-uid labels in diffs

### DIFF
--- a/pkg/diff/normalize.go
+++ b/pkg/diff/normalize.go
@@ -109,9 +109,13 @@ func normalizeMetadata(o *uo.UnstructuredObject) {
 }
 
 func normalizeMisc(o *uo.UnstructuredObject) {
-	// These are random values found in Jobs
+	// See https://kubernetes.io/docs/reference/labels-annotations-taints/#controller-uid
 	_ = o.RemoveNestedField("spec", "template", "metadata", "labels", "controller-uid")
 	_ = o.RemoveNestedField("spec", "selector", "matchLabels", "controller-uid")
+
+	// See https://kubernetes.io/docs/reference/labels-annotations-taints/#batchkubernetesio-controller-uid
+	_ = o.RemoveNestedField("spec", "template", "metadata", "labels", "batch.kubernetes.io/controller-uid")
+	_ = o.RemoveNestedField("spec", "selector", "matchLabels", "batch.kubernetes.io/controller-uid")
 
 	_ = o.RemoveNestedField("status")
 }

--- a/pkg/diff/normalize_test.go
+++ b/pkg/diff/normalize_test.go
@@ -78,6 +78,8 @@ func TestNormalizeMisc(t *testing.T) {
 	testCases := []testCase{
 		{remote: buildObject(`{"spec": {"template": {"metadata": {"labels": {"controller-uid": "test", "good": "keep"}}}}, "selector": {"controller-uid": "test", "good": "keep"}}`), local: buildObject(), result: buildResultObject(`{"metadata":{"annotations":{},"labels":{}},"selector":{"controller-uid":"test","good":"keep"},"spec":{"template":{"metadata":{"labels":{"good":"keep"}}}}}`)},
 		{remote: buildObject(`{"status": {"test": "test"}}`), local: buildObject(), result: buildResultObject()},
+		{remote: buildObject(`{"spec": {"template": {"metadata": {"labels": {"batch.kubernetes.io/controller-uid": "test", "good": "keep"}}}}, "selector": {"batch.kubernetes.io/controller-uid": "test", "good": "keep"}}`), local: buildObject(), result: buildResultObject(`{"metadata":{"annotations":{},"labels":{}},"selector":{"batch.kubernetes.io/controller-uid":"test","good":"keep"},"spec":{"template":{"metadata":{"labels":{"good":"keep"}}}}}`)},
+		{remote: buildObject(`{"status": {"test": "test"}}`), local: buildObject(), result: buildResultObject()},
 	}
 	runTests(t, testCases)
 }


### PR DESCRIPTION
# Description

In addition to the already ignored but deprecated non-prefixed controller-uid labels.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
