### PR TITLE
feat(list-targets): add a flag which allows to filter the output to show only target names

### DIFF
--- a/cmd/kluctl/commands/cmd_list_targets.go
+++ b/cmd/kluctl/commands/cmd_list_targets.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/kluctl_project"
 	"github.com/kluctl/kluctl/v2/pkg/types"
@@ -10,6 +11,8 @@ import (
 type listTargetsCmd struct {
 	args.ProjectFlags
 	args.OutputFlags
+
+	OnlyNames bool `group:"list-targets" help:"If provided --only-names will only output "`
 }
 
 func (cmd *listTargetsCmd) Help() string {
@@ -19,8 +22,17 @@ func (cmd *listTargetsCmd) Help() string {
 func (cmd *listTargetsCmd) Run(ctx context.Context) error {
 	return withKluctlProjectFromArgs(ctx, nil, cmd.ProjectFlags, nil, nil, nil, false, true, false, func(ctx context.Context, p *kluctl_project.LoadedKluctlProject) error {
 		var result []*types.Target
+
 		for _, t := range p.Targets {
 			result = append(result, t)
+		}
+
+		if cmd.OnlyNames {
+			var targetNames []string
+			for _, target := range result {
+				targetNames = append(targetNames, target.Name)
+			}
+			return outputYamlResult(ctx, cmd.Output, targetNames, false)
 		}
 		return outputYamlResult(ctx, cmd.Output, result, false)
 	})

--- a/cmd/kluctl/commands/cmd_list_targets.go
+++ b/cmd/kluctl/commands/cmd_list_targets.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"strings"
 
 	"github.com/kluctl/kluctl/v2/cmd/kluctl/args"
 	"github.com/kluctl/kluctl/v2/pkg/kluctl_project"
@@ -32,7 +33,11 @@ func (cmd *listTargetsCmd) Run(ctx context.Context) error {
 			for _, target := range result {
 				targetNames = append(targetNames, target.Name)
 			}
-			return outputYamlResult(ctx, cmd.Output, targetNames, false)
+			targetNamesStr := strings.Join(targetNames, "\n")
+			if targetNamesStr != "" {
+				targetNamesStr += "\n"
+			}
+			return outputResult2(ctx, cmd.Output, targetNamesStr)
 		}
 		return outputYamlResult(ctx, cmd.Output, result, false)
 	})

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -294,9 +294,6 @@ func outputValidateResult2(ctx context.Context, output []string, vr *result.Vali
 func outputYamlResult(ctx context.Context, output []string, result interface{}, multiDoc bool) error {
 	status.Flush(ctx)
 
-	if len(output) == 0 {
-		output = []string{"-"}
-	}
 	var s string
 	if multiDoc {
 		l, ok := result.([]interface{})
@@ -315,13 +312,7 @@ func outputYamlResult(ctx context.Context, output []string, result interface{}, 
 		}
 		s = x
 	}
-	for _, path := range output {
-		err := outputResult(ctx, &path, s)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return outputResult2(ctx, output, s)
 }
 
 func outputResult(ctx context.Context, f *string, result string) error {
@@ -340,4 +331,17 @@ func outputResult(ctx context.Context, f *string, result string) error {
 	}
 	_, err := w.Write([]byte(result))
 	return err
+}
+
+func outputResult2(ctx context.Context, output []string, result string) error {
+	if len(output) == 0 {
+		output = []string{"-"}
+	}
+	for _, o := range output {
+		err := outputResult(ctx, &o, result)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
# Description

The kluctl command `list-targets`now has an additional flag `--only-names` to filter the output to just include the name of the defined targets.

Usage:
`kluctl list-targets --only-names`

Fixes https://github.com/kluctl/kluctl/issues/678

## Type of change

- [X] New feature (non-breaking change which adds functionality)


