### PR TITLE
chore: Update go-jinja2 to latest main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/jinzhu/copier v0.4.0
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/kluctl/go-embed-python v0.0.0-3.11.9-20240415-1
-	github.com/kluctl/go-jinja2 v0.0.0-20240619083358-c137395943eb
+	github.com/kluctl/go-jinja2 v0.0.0-20240708212116-03ee7eefba4f
 	github.com/kluctl/kluctl/lib v0.0.0-20240708100510-73c5efc22b9a
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,8 @@ github.com/klauspost/cpuid/v2 v2.2.8 h1:+StwCXwm9PdpiEkPyzBXIy+M9KUb4ODm0Zarf1kS
 github.com/klauspost/cpuid/v2 v2.2.8/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 github.com/kluctl/go-embed-python v0.0.0-3.11.9-20240415-1 h1:WIKCwheVCfZsDmhtfVyaG5BZPxshHY/+cv5kLlmfq5Y=
 github.com/kluctl/go-embed-python v0.0.0-3.11.9-20240415-1/go.mod h1:9kqX8IjRCNh4ppXxlKGtLN+QFuvsdSsNGKsTLgdSNRw=
-github.com/kluctl/go-jinja2 v0.0.0-20240619083358-c137395943eb h1:ibPMOncAbKZqREllxULOLtC+7i4vfCK7hZvZbuER0iM=
-github.com/kluctl/go-jinja2 v0.0.0-20240619083358-c137395943eb/go.mod h1:O6CJS5+wwnQE4OorQi/fV3eGFye5ian11tjHIYLJzIY=
+github.com/kluctl/go-jinja2 v0.0.0-20240708212116-03ee7eefba4f h1:DXcOryOSs9LG2xd7LlllWOL8fPA8i4OTXJzHOPtz6hA=
+github.com/kluctl/go-jinja2 v0.0.0-20240708212116-03ee7eefba4f/go.mod h1:O6CJS5+wwnQE4OorQi/fV3eGFye5ian11tjHIYLJzIY=
 github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgShxwh4x8M=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=


### PR DESCRIPTION
# Description

This updates all internal Python dependencies.


