### PR TITLE
chore: Reduce required go version to 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kluctl/kluctl/v2
 
-go 1.22.4
+go 1.22.0
 
 replace github.com/kluctl/kluctl/lib => ./lib
 

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/kluctl/kluctl/lib
 
-go 1.22.4
+go 1.22.0
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d


### PR DESCRIPTION
# Description

No need to have 1.22.4 as minimum go version. This caused builds on some systems to fail.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
