### PR TITLE
fix: apply RuntimeDefault seccompProfile in webui deployment

### DIFF
--- a/install/webui/webui/deployment.yaml
+++ b/install/webui/webui/deployment.yaml
@@ -63,5 +63,7 @@ spec:
             - ALL
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kluctl-webui
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION

# Description
This PR fixes the seccompProfile configuration for the webui deployment by setting it to `RuntimeDefault`.

### Testing
The fix was locally tested with a Talos Kubernetes cluster to ensure the warning mentioned in the related issue is resolved.

Fixes #1220

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
