### PR TITLE
fix: Only use timeout restricted context for actual work, not the things around

### DIFF
--- a/cmd/kluctl/commands/cmd_delete.go
+++ b/cmd/kluctl/commands/cmd_delete.go
@@ -60,7 +60,7 @@ func (cmd *deleteCmd) Run(ctx context.Context) error {
 			return confirmDeletion(ctx, refs, cmd.DryRun, cmd.Yes)
 		})
 
-		err := outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, !cmd.DryRun || cmd.ForceWriteCommandResult)
+		err := outputCommandResult(ctx, cmdCtx, cmd.OutputFormatFlags, result, !cmd.DryRun || cmd.ForceWriteCommandResult)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_deploy.go
+++ b/cmd/kluctl/commands/cmd_deploy.go
@@ -67,13 +67,13 @@ func (cmd *deployCmd) Run(ctx context.Context) error {
 		discriminator:        cmd.Discriminator,
 	}
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
-		return cmd.runCmdDeploy(cmdCtx)
+		return cmd.runCmdDeploy(ctx, cmdCtx)
 	})
 }
 
-func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
-	status.Trace(cmdCtx.ctx, "enter runCmdDeploy")
-	defer status.Trace(cmdCtx.ctx, "leave runCmdDeploy")
+func (cmd *deployCmd) runCmdDeploy(ctx context.Context, cmdCtx *commandCtx) error {
+	status.Trace(ctx, "enter runCmdDeploy")
+	defer status.Trace(ctx, "leave runCmdDeploy")
 
 	cmd2 := commands.NewDeployCommand(cmdCtx.targetCtx)
 	cmd2.ForceApply = cmd.ForceApply
@@ -86,14 +86,14 @@ func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
 	cmd2.WaitPrune = !cmd.NoWait
 
 	cb := func(diffResult *result.CommandResult) error {
-		return cmd.diffResultCb(cmdCtx, diffResult)
+		return cmd.diffResultCb(ctx, cmdCtx, diffResult)
 	}
 	if cmd.Yes || cmd.DryRun {
 		cb = nil
 	}
 
 	result := cmd2.Run(cb)
-	err := outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, !cmd.DryRun || cmd.ForceWriteCommandResult)
+	err := outputCommandResult(ctx, cmdCtx, cmd.OutputFormatFlags, result, !cmd.DryRun || cmd.ForceWriteCommandResult)
 	if err != nil {
 		return err
 	}
@@ -103,11 +103,11 @@ func (cmd *deployCmd) runCmdDeploy(cmdCtx *commandCtx) error {
 	return nil
 }
 
-func (cmd *deployCmd) diffResultCb(ctx *commandCtx, diffResult *result.CommandResult) error {
+func (cmd *deployCmd) diffResultCb(ctx context.Context, cmdCtx *commandCtx, diffResult *result.CommandResult) error {
 	flags := cmd.OutputFormatFlags
 	flags.OutputFormat = nil // use default output format
 
-	err := outputCommandResult(ctx, flags, diffResult, false)
+	err := outputCommandResult(ctx, cmdCtx, flags, diffResult, false)
 	if err != nil {
 		return err
 	}
@@ -115,11 +115,11 @@ func (cmd *deployCmd) diffResultCb(ctx *commandCtx, diffResult *result.CommandRe
 		return nil
 	}
 	if len(diffResult.Errors) != 0 {
-		if !prompts.AskForConfirmation(ctx.ctx, "The diff resulted in errors, do you still want to proceed?") {
+		if !prompts.AskForConfirmation(ctx, "The diff resulted in errors, do you still want to proceed?") {
 			return fmt.Errorf("aborted")
 		}
 	} else {
-		if !prompts.AskForConfirmation(ctx.ctx, "The diff succeeded, do you want to proceed?") {
+		if !prompts.AskForConfirmation(ctx, "The diff succeeded, do you want to proceed?") {
 			return fmt.Errorf("aborted")
 		}
 	}

--- a/cmd/kluctl/commands/cmd_diff.go
+++ b/cmd/kluctl/commands/cmd_diff.go
@@ -57,7 +57,7 @@ func (cmd *diffCmd) Run(ctx context.Context) error {
 		cmd2.IgnoreAnnotations = cmd.IgnoreAnnotations
 		cmd2.IgnoreKluctlMetadata = cmd.IgnoreKluctlMetadata
 		result := cmd2.Run()
-		err := outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, false)
+		err := outputCommandResult(ctx, cmdCtx, cmd.OutputFormatFlags, result, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_poke_images.go
+++ b/cmd/kluctl/commands/cmd_poke_images.go
@@ -56,7 +56,7 @@ func (cmd *pokeImagesCmd) Run(ctx context.Context) error {
 		cmd2 := commands.NewPokeImagesCommand(cmdCtx.targetCtx)
 
 		result := cmd2.Run()
-		err := outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, !cmd.DryRun || cmd.ForceWriteCommandResult)
+		err := outputCommandResult(ctx, cmdCtx, cmd.OutputFormatFlags, result, !cmd.DryRun || cmd.ForceWriteCommandResult)
 		if err != nil {
 			return err
 		}

--- a/cmd/kluctl/commands/cmd_prune.go
+++ b/cmd/kluctl/commands/cmd_prune.go
@@ -52,16 +52,16 @@ func (cmd *pruneCmd) Run(ctx context.Context) error {
 		discriminator:        cmd.Discriminator,
 	}
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
-		return cmd.runCmdPrune(cmdCtx)
+		return cmd.runCmdPrune(ctx, cmdCtx)
 	})
 }
 
-func (cmd *pruneCmd) runCmdPrune(cmdCtx *commandCtx) error {
+func (cmd *pruneCmd) runCmdPrune(ctx context.Context, cmdCtx *commandCtx) error {
 	cmd2 := commands.NewPruneCommand(cmdCtx.targetCtx.Target.Discriminator, cmdCtx.targetCtx, true)
 	result := cmd2.Run(func(refs []k8s2.ObjectRef) error {
-		return confirmDeletion(cmdCtx.ctx, refs, cmd.DryRun, cmd.Yes)
+		return confirmDeletion(ctx, refs, cmd.DryRun, cmd.Yes)
 	})
-	err := outputCommandResult(cmdCtx, cmd.OutputFormatFlags, result, !cmd.DryRun || cmd.ForceWriteCommandResult)
+	err := outputCommandResult(ctx, cmdCtx, cmd.OutputFormatFlags, result, !cmd.DryRun || cmd.ForceWriteCommandResult)
 	if err != nil {
 		return err
 	}

--- a/cmd/kluctl/commands/cmd_render.go
+++ b/cmd/kluctl/commands/cmd_render.go
@@ -67,10 +67,10 @@ func (cmd *renderCmd) Run(ctx context.Context) error {
 			if isTmp {
 				defer os.RemoveAll(cmd.RenderOutputDir)
 			}
-			status.Flush(cmdCtx.ctx)
+			status.Flush(ctx)
 			return yaml.WriteYamlAllStream(getStdout(ctx), all)
 		} else {
-			status.Infof(cmdCtx.ctx, "Rendered into %s", cmdCtx.targetCtx.SharedContext.RenderDir)
+			status.Infof(ctx, "Rendered into %s", cmdCtx.targetCtx.SharedContext.RenderDir)
 		}
 		return nil
 	})

--- a/cmd/kluctl/commands/cmd_validate.go
+++ b/cmd/kluctl/commands/cmd_validate.go
@@ -47,23 +47,23 @@ func (cmd *validateCmd) Run(ctx context.Context) error {
 
 	return withProjectCommandContext(ctx, ptArgs, func(cmdCtx *commandCtx) error {
 		cmd2 := commands.NewValidateCommand("", cmdCtx.targetCtx)
-		return cmd.doValidate(cmdCtx, cmd2)
+		return cmd.doValidate(ctx, cmdCtx, cmd2)
 	})
 }
 
-func (cmd *validateCmd) doValidate(ctx *commandCtx, cmd2 *commands.ValidateCommand) error {
+func (cmd *validateCmd) doValidate(ctx context.Context, cmdCtx *commandCtx, cmd2 *commands.ValidateCommand) error {
 	startTime := time.Now()
 	for true {
-		result := cmd2.Run(ctx.ctx)
+		result := cmd2.Run(ctx)
 		failed := len(result.Errors) != 0 || (cmd.WarningsAsErrors && len(result.Warnings) != 0)
 
-		err := outputValidateResult(ctx, cmd.Output, result)
+		err := outputValidateResult(ctx, cmdCtx, cmd.Output, result)
 		if err != nil {
 			return err
 		}
 
 		if !failed {
-			status.Info(ctx.ctx, "Validation succeeded")
+			status.Info(ctx, "Validation succeeded")
 			return nil
 		}
 

--- a/cmd/kluctl/commands/command_result.go
+++ b/cmd/kluctl/commands/command_result.go
@@ -221,8 +221,8 @@ func outputHelper(ctx context.Context, output []string, cb func(format string) (
 	return nil
 }
 
-func outputCommandResult(ctx *commandCtx, flags args.OutputFormatFlags, cr *result.CommandResult, writeToResultStore bool) error {
-	cr.Id = ctx.resultId
+func outputCommandResult(ctx context.Context, cmdCtx *commandCtx, flags args.OutputFormatFlags, cr *result.CommandResult, writeToResultStore bool) error {
+	cr.Id = cmdCtx.resultId
 	cr.Command.Initiator = result.CommandInititiator_CommandLine
 
 	if !flags.NoObfuscate {
@@ -234,8 +234,8 @@ func outputCommandResult(ctx *commandCtx, flags args.OutputFormatFlags, cr *resu
 	}
 
 	var resultStoreErr error
-	if writeToResultStore && ctx.resultStore != nil {
-		s := status.Start(ctx.ctx, "Writing command result")
+	if writeToResultStore && cmdCtx.resultStore != nil {
+		s := status.Start(ctx, "Writing command result")
 		defer s.Failed()
 
 		didWarn := false
@@ -244,11 +244,11 @@ func outputCommandResult(ctx *commandCtx, flags args.OutputFormatFlags, cr *resu
 			cr.Warnings = append(cr.Warnings, result.DeploymentError{
 				Message: warning,
 			})
-			status.Warning(ctx.ctx, warning)
+			status.Warning(ctx, warning)
 			didWarn = true
 		}
 
-		resultStoreErr = ctx.resultStore.WriteCommandResult(cr)
+		resultStoreErr = cmdCtx.resultStore.WriteCommandResult(cr)
 		if resultStoreErr != nil {
 			s.FailedWithMessagef("Failed to write result to result store: %s", resultStoreErr.Error())
 		} else {
@@ -259,7 +259,7 @@ func outputCommandResult(ctx *commandCtx, flags args.OutputFormatFlags, cr *resu
 			}
 		}
 	}
-	err := outputCommandResult2(ctx.ctx, flags, cr)
+	err := outputCommandResult2(ctx, flags, cr)
 	if err == nil && resultStoreErr != nil {
 		return resultStoreErr
 	}
@@ -275,10 +275,10 @@ func outputCommandResult2(ctx context.Context, flags args.OutputFormatFlags, cr 
 	return err
 }
 
-func outputValidateResult(ctx *commandCtx, output []string, vr *result.ValidateResult) error {
-	vr.Id = ctx.resultId
+func outputValidateResult(ctx context.Context, cmdCtx *commandCtx, output []string, vr *result.ValidateResult) error {
+	vr.Id = cmdCtx.resultId
 
-	return outputValidateResult2(ctx.ctx, output, vr)
+	return outputValidateResult2(ctx, output, vr)
 }
 
 func outputValidateResult2(ctx context.Context, output []string, vr *result.ValidateResult) error {

--- a/cmd/kluctl/commands/utils.go
+++ b/cmd/kluctl/commands/utils.go
@@ -150,7 +150,6 @@ type projectTargetCommandArgs struct {
 }
 
 type commandCtx struct {
-	ctx       context.Context
 	targetCtx *target_context.TargetContext
 	images    *deployment.Images
 
@@ -255,7 +254,6 @@ func withProjectTargetCommandContext(ctx context.Context, args projectTargetComm
 		}
 	}
 	cmdCtx := &commandCtx{
-		ctx:         ctx,
 		targetCtx:   targetCtx,
 		images:      images,
 		resultId:    commandResultId,


### PR DESCRIPTION
# Description

For example, we should not have the timeout active when writing the command result, which must also be possible when the timeout hit while deploying.

This should fix many test flakes where a timeout returns failure of writing command results instead of the original timeout error.
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

