### PR TITLE
ci: Switch to macos-13 in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,7 +167,7 @@ jobs:
             run_e2e_non_gitops: false
             run_e2e_gitops: true
             name: ubuntu-gitops
-          - os: macos-12
+          - os: macos-13
             run_unit_tests: true
             # only run e2e tests on branches
             run_e2e_non_gitops: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
# Description

macos-12 is not supported anymore. See https://github.com/actions/runner-images/issues/10721

