### PR TITLE
feat(metrics): add start_time as label to the last object status 

### DIFF
--- a/pkg/controllers/metrics/kluctldeployment_controller.go
+++ b/pkg/controllers/metrics/kluctldeployment_controller.go
@@ -36,7 +36,7 @@ var (
 		Subsystem: KluctlDeploymentControllerSubsystem,
 		Name:      LastObjectStatusKey,
 		Help:      "Last object status of a single deployment.",
-	}, []string{"namespace", "name"})
+	}, []string{"namespace", "name", "start_time"})
 
 	pruneEnabled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: KluctlDeploymentControllerSubsystem,
@@ -86,8 +86,8 @@ func NewKluctlDryRunEnabled(namespace string, name string) prometheus.Gauge {
 	return dryRunEnabled.WithLabelValues(namespace, name)
 }
 
-func NewKluctlLastObjectStatus(namespace string, name string) prometheus.Gauge {
-	return lastObjectStatus.WithLabelValues(namespace, name)
+func NewKluctlLastObjectStatus(namespace string, name string, startTime string) prometheus.Gauge {
+	return lastObjectStatus.WithLabelValues(namespace, name, startTime)
 }
 
 func NewKluctlPruneEnabled(namespace string, name string) prometheus.Gauge {


### PR DESCRIPTION
# Description

We'd like to be able to track the time when changes started to happen on a cluster whenever we release a specific deployment.
We already have the state if the last deployment was successful or not and for this I've added the start_time metric from the LastDeployResult or set to the current time when the result is not available.

Fixes #1294 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
