### PR TITLE
ci: Ignore gnu.org link in link checking

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -99,6 +99,7 @@ headers = []
 exclude = [
     '^https://kubernetes\.io/docs/reference/generated/kubernetes-api/v1\.18/',
     '.*#getvarfieldpath-default', # lychee seems to not understand this one
+    'https://www.gnu.org/software/bash/', # this times out very often, no idea why
 ]
 
 # Exclude these filesystem paths from getting checked.


### PR DESCRIPTION
# Description

This should fix many flaky CI runs.