### PR TITLE
fix: Return error instead of nil when command result can't be found

### DIFF
--- a/pkg/results/result-store-secrets.go
+++ b/pkg/results/result-store-secrets.go
@@ -631,7 +631,7 @@ func (s *ResultStoreSecrets) GetCommandResult(options GetCommandResultOptions) (
 		return nil, err
 	}
 	if len(l.Items) == 0 {
-		return nil, nil
+		return nil, fmt.Errorf("command result with id %s not found", options.Id)
 	}
 
 	secret := l.Items[0]


### PR DESCRIPTION
# Description

This avoids crashing afterwards and instead shows an error.

Fixes #1289

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
