### PR TITLE
fix: Store deployment name/namespace for results in annotations instead of labels

### DIFF
--- a/pkg/results/result-store-secrets.go
+++ b/pkg/results/result-store-secrets.go
@@ -202,8 +202,8 @@ func (s *ResultStoreSecrets) WriteCommandResult(cr *result.CommandResult) error 
 		secret.Annotations["kluctl.io/result-project-subdir"] = cr.ProjectKey.SubDir
 	}
 	if cr.KluctlDeployment != nil {
-		secret.Labels["kluctl.io/result-deployment-name"] = cr.KluctlDeployment.Name
-		secret.Labels["kluctl.io/result-deployment-namespace"] = cr.KluctlDeployment.Namespace
+		secret.Annotations["kluctl.io/result-deployment-name"] = cr.KluctlDeployment.Name
+		secret.Annotations["kluctl.io/result-deployment-namespace"] = cr.KluctlDeployment.Namespace
 	}
 
 	err = s.client.Patch(s.ctx, &secret, client.Apply, client.FieldOwner("kluctl-results"))
@@ -291,8 +291,8 @@ func (s *ResultStoreSecrets) WriteValidateResult(vr *result.ValidateResult) erro
 		secret.Annotations["kluctl.io/result-project-subdir"] = vr.ProjectKey.SubDir
 	}
 	if vr.KluctlDeployment != nil {
-		secret.Labels["kluctl.io/result-deployment-name"] = vr.KluctlDeployment.Name
-		secret.Labels["kluctl.io/result-deployment-namespace"] = vr.KluctlDeployment.Namespace
+		secret.Annotations["kluctl.io/result-deployment-name"] = vr.KluctlDeployment.Name
+		secret.Annotations["kluctl.io/result-deployment-namespace"] = vr.KluctlDeployment.Namespace
 	}
 
 	err = s.client.Patch(s.ctx, &secret, client.Apply, client.FieldOwner("kluctl-results"))


### PR DESCRIPTION
# Description

Turns out label values have stricter limits in length then resource names, meaning that we can't use labels to store the deployment names. Using annotations instead of labels solves this.

These labels were luckily never used anywhere and their only meaning was for informational purposes when manually looking into the result objects. 

Fixes #1290

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
