### PR TITLE
fix: Immediately patch lastPrepareError instead of doing it at the end of the reconciliation

### DIFF
--- a/pkg/controllers/kluctldeployment_controller_reconcile.go
+++ b/pkg/controllers/kluctldeployment_controller_reconcile.go
@@ -182,8 +182,6 @@ func (r *KluctlDeploymentReconciler) reconcileManualRequest(ctx context.Context,
 		return false, nil
 	}
 
-	obj.Status.LastPrepareError = ""
-
 	doError := func(resultId string, err error) (bool, error) {
 		err2 := r.patchFailPrepare(ctx, obj, err)
 		if err2 != nil {
@@ -204,6 +202,11 @@ func (r *KluctlDeploymentReconciler) reconcileManualRequest(ctx context.Context,
 	if err != nil {
 		return doError("", err)
 	}
+
+	err = r.patchStatus(ctx, client.ObjectKeyFromObject(obj), func(status *kluctlv1.KluctlDeploymentStatus) error {
+		status.LastPrepareError = ""
+		return nil
+	})
 
 	objectsHash, err := targetContext.DeploymentCollection.CalcObjectsHash()
 	if err != nil {


### PR DESCRIPTION
# Description

This should fix a few test flakes where the `lastPrepareError` is unexpectedly empty.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
