### PR TITLE
feat: Implement multidoc support for vars sources

### DIFF
--- a/docs/kluctl/templating/variable-sources.md
+++ b/docs/kluctl/templating/variable-sources.md
@@ -71,6 +71,13 @@ context.
 Only simple pathes are supported that do not contain wildcards or lists.
 
 For some variable sources, `targetPath` will become mandatory when the resulting variable is not a dictionary.
+It is also mandatory when `multidoc` is set to `true`.
+
+##### multidoc
+When set to `true`, the vars source's underlying yaml document is treated as a yaml multidoc and the resulting variable
+will be an array.
+
+Using `multidoc` also requires you to set `targetPath`.
 
 ## Variable source types
 Different types of vars entries are possible:

--- a/pkg/types/vars_source.go
+++ b/pkg/types/vars_source.go
@@ -1,12 +1,13 @@
 package types
 
 import (
+	"reflect"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/kluctl/kluctl/lib/git/types"
 	"github.com/kluctl/kluctl/lib/yaml"
 	"github.com/kluctl/kluctl/v2/pkg/utils/uo"
 	"k8s.io/apimachinery/pkg/runtime"
-	"reflect"
 )
 
 type VarsSourceGit struct {
@@ -127,6 +128,7 @@ type VarsSource struct {
 	IgnoreMissing *bool `json:"ignoreMissing,omitempty"`
 	NoOverride    *bool `json:"noOverride,omitempty"`
 	Sensitive     *bool `json:"sensitive,omitempty"`
+	Multidoc      *bool `json:"multidoc,omitempty"`
 
 	Values            *uo.UnstructuredObject              `json:"values,omitempty" isVarsSource:"true"`
 	File              *string                             `json:"file,omitempty" isVarsSource:"true"`

--- a/pkg/types/zz_generated.deepcopy.go
+++ b/pkg/types/zz_generated.deepcopy.go
@@ -788,6 +788,11 @@ func (in *VarsSource) DeepCopyInto(out *VarsSource) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Multidoc != nil {
+		in, out := &in.Multidoc, &out.Multidoc
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Values != nil {
 		in, out := &in.Values, &out.Values
 		*out = (*in).DeepCopy()

--- a/pkg/webui/ui/src/models.ts
+++ b/pkg/webui/ui/src/models.ts
@@ -478,6 +478,7 @@ export class VarsSource {
     ignoreMissing?: boolean;
     noOverride?: boolean;
     sensitive?: boolean;
+    multidoc?: boolean;
     values?: any;
     file?: string;
     git?: VarsSourceGit;
@@ -501,6 +502,7 @@ export class VarsSource {
         this.ignoreMissing = source["ignoreMissing"];
         this.noOverride = source["noOverride"];
         this.sensitive = source["sensitive"];
+        this.multidoc = source["multidoc"];
         this.values = source["values"];
         this.file = source["file"];
         this.git = this.convertValues(source["git"], VarsSourceGit);


### PR DESCRIPTION
# Description

This implements multidoc support for vars sources that are based on parsing yaml content (e.g. file, git, http, ...)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] This change requires a new example

