### PR TITLE
docs: Remove helm-pull command description from documentation

### DIFF
--- a/docs/kluctl/deployments/helm.md
+++ b/docs/kluctl/deployments/helm.md
@@ -76,10 +76,6 @@ helmChart:
   output: helm-rendered.yaml # this is optional
 ```
 
-When running the `helm-pull` command, it will search for all `helm-chart.yaml` files in your project and then pull the
-chart from the specified repository with the specified version. The pull chart will then be located in the sub-directory
-`charts` below the same directory as the `helm-chart.yaml`
-
 The same filename that was specified in `output` must then be referred in a `kustomization.yaml` as a normal local
 resource. If `output` is omitted, the default value `helm-rendered.yaml` is used and must also be referenced in
 `kustomization.yaml`.


### PR DESCRIPTION
fix docs: Removed a repeated and partially wrong description of the `helm-pull` command output and its behavior.

# Description

This section partially duplicates and explanation of the `pre-pull` command.
But at the same time it gives a wrong description of where the pulled chart is stored.
The same, but correctly is described at the beginning of the chapter, so all of this paragraph is removed.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] This change requires a new example

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
