### PR TITLE
fix: update Azure Key Vault documentation link

### DIFF
--- a/docs/kluctl/templating/variable-sources.md
+++ b/docs/kluctl/templating/variable-sources.md
@@ -504,7 +504,7 @@ substitute PROJECT-NAME with your real project name in google. Service account i
 To run kluctl locally with gcpSecretManager enabled refer to [setting local development environment](https://cloud.google.com/docs/authentication/provide-credentials-adc#local-dev) article.
 
 ### azureKeyVault
-[Azure Key Vault](https://azure.microsoft.com/en-us/products/key-vault/) integration.
+[Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/general/overview) integration.
 Loads a variables YAML from an Azure Key Vault.
 
 Example


### PR DESCRIPTION
## What
Tiny docs tweak, no drama.

The Azure Key Vault product page can return 503 to lychee during `make markdown-link-check`, so CI gets flaky for a plain docs link. This points the link at the Microsoft Learn overview instead. Same topic, more stable URL.

## Repro
Before this change:

```text
make markdown-link-check
[docs/kluctl/templating/variable-sources.md]:
✗ [503] https://azure.microsoft.com/en-us/products/key-vault/
```

After this change:

```text
make markdown-link-check
406 Total, 401 OK, 0 Errors, 5 Excluded
```

No runtime code changed, just the docs link.