### PR TITLE
fix: Fall back to "git status" when wt.Status() of go-git fails

### DIFF
--- a/lib/git/utils.go
+++ b/lib/git/utils.go
@@ -57,6 +57,12 @@ func GetWorktreeStatus(ctx context.Context, path string) (git.Status, error) {
 	}
 	gitStatus, err := wt.Status()
 	if err != nil {
+		// there is no good reason for this to fail, except some form of incompatibility between go-git and upstream git.
+		// in that case, try to run "git status"
+		gitStatus2, err2 := getWorktreeStatusByExec(ctx, path)
+		if err2 == nil {
+			return gitStatus2, nil
+		}
 		return nil, err
 	}
 
@@ -73,25 +79,45 @@ func GetWorktreeStatus(ctx context.Context, path string) (git.Status, error) {
 
 	status.Trace(ctx, "Running git status --porcelain to verify CRLF issues are not what cause the dirty status")
 
+	gitStatus2, err := getWorktreeStatusByExec(ctx, path)
+	if err != nil {
+		// fall back to initial status
+		return gitStatus, nil
+	}
+	return gitStatus2, nil
+}
+
+func getWorktreeStatusByExec(ctx context.Context, path string) (git.Status, error) {
 	commandPath, err := exec.LookPath("git")
 	if err != nil {
 		status.Tracef(ctx, "Failed to lookup git binary: %v", err)
 		return nil, err
 	}
 
-	out := bytes.NewBuffer(nil)
+	stdout := bytes.NewBuffer(nil)
+	stderr := bytes.NewBuffer(nil)
 
-	cmd := &exec.Cmd{Path: commandPath, Dir: path, Env: os.Environ(), Args: []string{"git", "status", "--porcelain"}, Stdout: out, Stderr: out}
+	cmd := &exec.Cmd{
+		Path:   commandPath,
+		Dir:    path,
+		Env:    os.Environ(),
+		Args:   []string{"git", "status", "--porcelain"},
+		Stdout: stdout,
+		Stderr: stderr,
+	}
 	err = cmd.Run()
+	if stderr.Len() != 0 {
+		status.Warning(ctx, strings.TrimSpace(stderr.String()))
+	}
 	if err != nil {
-		status.Tracef(ctx, "Failed to run git status --porcelain: err=%v, out=%s", err, out.String())
-		return gitStatus, nil
+		status.Tracef(ctx, "Failed to run git status --porcelain: err=%v, out=%s", err, stdout.String())
+		return nil, err
 	}
 
-	parsedStatus, err := parsePorcelainStatus(out.String())
+	parsedStatus, err := parsePorcelainStatus(stdout.String())
 	if err != nil {
 		status.Tracef(ctx, "Failed to parse output of git status --porcelain: %v", err)
-		return gitStatus, err
+		return nil, err
 	}
 
 	return parsedStatus, nil


### PR DESCRIPTION
# Description

go-git's Status() might fail for different reasons when upstream "git status" would actually succeed. This PR makes us fall back to "git status" when needed.

Fixes #1402

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
