### PR TITLE
fix: honor ignoreMissing when a clusterSecret/clusterConfigMap key is absent

### DIFF
--- a/pkg/vars/vars_loader.go
+++ b/pkg/vars/vars_loader.go
@@ -161,6 +161,19 @@ func (v *VarsLoader) LoadVars(ctx context.Context, varsCtx *VarsCtx, sourceIn *t
 		return err
 	}
 
+	// loadFromK8sConfigMapOrSecret returns an empty object when ignoreMissing
+	// skipped a missing object or a missing key. That empty result contributes
+	// no values, so skip the merge: wrapping it into targetPath would otherwise
+	// overwrite a default provided by an earlier vars source with {}. A present
+	// key always parses to a non-empty result or errors, so an empty result
+	// from these sources unambiguously means "skipped".
+	skipMerge := false
+	if ignoreMissing && (source.ClusterConfigMap != nil || source.ClusterSecret != nil) {
+		if o, ok := newValue.(*uo.UnstructuredObject); ok && o.IsZero() {
+			skipMerge = true
+		}
+	}
+
 	if sourceIn.Sensitive != nil {
 		// override the default
 		sensitive = *sourceIn.Sensitive
@@ -193,6 +206,10 @@ func (v *VarsLoader) LoadVars(ctx context.Context, varsCtx *VarsCtx, sourceIn *t
 
 	sourceIn.RenderedSensitive = sensitive
 	sourceIn.RenderedVars = newVars.Clone()
+
+	if skipMerge {
+		return nil
+	}
 
 	if source.NoOverride == nil || !*source.NoOverride {
 		varsCtx.Vars.Merge(newVars)
@@ -419,6 +436,9 @@ func (v *VarsLoader) loadFromK8sConfigMapOrSecret(varsCtx *VarsCtx, varsSource t
 		return nil, err
 	}
 	if !found {
+		if ignoreMissing {
+			return uo.New(), nil
+		}
 		return nil, fmt.Errorf("key %s not found in %s on cluster", varsSource.Key, ref.String())
 	}
 

--- a/pkg/vars/vars_loader_test.go
+++ b/pkg/vars/vars_loader_test.go
@@ -450,6 +450,47 @@ func (s *VarsLoaderTestSuite) TestClusterConfigMap() {
 		err := vl.LoadVars(context.TODO(), vc, &types.VarsSource{
 			IgnoreMissing: &b,
 			ClusterConfigMap: &types.VarsSourceClusterConfigMapOrSecret{
+				Name:      "cm",
+				Namespace: s.namespace(),
+				Key:       "vars1",
+			},
+		}, nil, "")
+		assert.NoError(s.T(), err)
+
+		_, found, _ := vc.Vars.GetNestedField("test1", "test2")
+		assert.False(s.T(), found)
+	})
+
+	s.testVarsLoader(func(vl *VarsLoader, vc *VarsCtx, aws *aws.FakeAwsClientFactory, gcp *gcp.FakeClientFactory) {
+		// A default provided by an earlier vars source must survive a missing
+		// key on an ignoreMissing source that uses targetPath (the documented
+		// defaults workaround).
+		err := vl.LoadVars(context.TODO(), vc, &types.VarsSource{
+			Values: uo.FromStringMust(`{"deep": {"nested": {"path": 7}}}`),
+		}, nil, "")
+		assert.NoError(s.T(), err)
+
+		b := true
+		err = vl.LoadVars(context.TODO(), vc, &types.VarsSource{
+			IgnoreMissing: &b,
+			ClusterConfigMap: &types.VarsSourceClusterConfigMapOrSecret{
+				Name:      "cm",
+				Namespace: s.namespace(),
+				Key:       "vars1",
+			},
+			TargetPath: "deep.nested.path",
+		}, nil, "")
+		assert.NoError(s.T(), err)
+
+		v, _, _ := vc.Vars.GetNestedInt("deep", "nested", "path")
+		assert.Equal(s.T(), int64(7), v)
+	})
+
+	s.testVarsLoader(func(vl *VarsLoader, vc *VarsCtx, aws *aws.FakeAwsClientFactory, gcp *gcp.FakeClientFactory) {
+		b := true
+		err := vl.LoadVars(context.TODO(), vc, &types.VarsSource{
+			IgnoreMissing: &b,
+			ClusterConfigMap: &types.VarsSourceClusterConfigMapOrSecret{
 				Name:      "cm-missing",
 				Namespace: s.namespace(),
 				Key:       "vars",
@@ -548,6 +589,22 @@ func (s *VarsLoaderTestSuite) TestClusterSecret() {
 			},
 		}, nil, "")
 		assert.EqualError(s.T(), err, fmt.Sprintf("key vars1 not found in %s/Secret/s on cluster", s.namespace()))
+	})
+
+	s.testVarsLoader(func(vl *VarsLoader, vc *VarsCtx, aws *aws.FakeAwsClientFactory, gcp *gcp.FakeClientFactory) {
+		b := true
+		err := vl.LoadVars(context.TODO(), vc, &types.VarsSource{
+			IgnoreMissing: &b,
+			ClusterSecret: &types.VarsSourceClusterConfigMapOrSecret{
+				Name:      "s",
+				Namespace: s.namespace(),
+				Key:       "vars1",
+			},
+		}, nil, "")
+		assert.NoError(s.T(), err)
+
+		_, found, _ := vc.Vars.GetNestedField("test1", "test2")
+		assert.False(s.T(), found)
 	})
 
 	s.testVarsLoader(func(vl *VarsLoader, vc *VarsCtx, aws *aws.FakeAwsClientFactory, gcp *gcp.FakeClientFactory) {


### PR DESCRIPTION
# Description

A `clusterSecret` or `clusterConfigMap` vars source fails at load time when the referenced object exists but the requested `key` is not yet present in its `data`. The load aborts with `key <K> not found in <ns>/<Kind>/<name> on cluster` before any deployment happens, which breaks bootstrapping a new key in the same deploy and forces a manual two-step workaround.

`ignoreMissing: true` already short-circuits a missing object, but the key lookup ignored it and errored unconditionally. This change extends the existing `ignoreMissing` handling so it also covers a missing key, matching the graceful-empty behavior already used for the missing-object paths in the same loader.

While wiring this up, I found that returning an empty object for a skipped source clobbers a default supplied by an earlier `values` source when `targetPath` is used (`{"deep": {"path": 7}}` became `{"deep": {"path": {}}}`). That is exactly the defaults pattern codablock suggested in the issue, so the empty result is now skipped before the targetPath merge for ClusterConfigMap/ClusterSecret sources only, leaving the file/git empty-document behavior untouched.

## Why this matters

This is the resolution the reporter asked for in [#1436](https://github.com/kluctl/kluctl/issues/1436): a `clusterSecret`/`clusterConfigMap` key that does not exist yet should degrade gracefully under `ignoreMissing` instead of failing the whole load. The maintainer's suggested `ignoreMissing: true` workaround did not actually cover the missing-key case in the current code, and the companion `values`-source default workaround silently produced the wrong vars because the empty result overwrote the default. Both are addressed here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added regression coverage in `pkg/vars/vars_loader_test.go`:

- `TestClusterConfigMap` / `TestClusterSecret`: object present, requested key absent, `IgnoreMissing: true` now loads with no error and contributes no vars.
- A default from an earlier `values` source at a `targetPath` survives a missing-key `ignoreMissing` source (the documented defaults workaround).
- The existing `IgnoreMissing` unset/false case still errors with `key <K> not found in <ns>/<Kind>/<name> on cluster`, and the missing-object `ignoreMissing` paths (including `RenderedSensitive`) are unchanged.

Verified with `go test ./pkg/vars/...` against envtest assets; the full `pkg/vars` suite passes.

Fixes #1436
