### PR TITLE
feat: add recursive resource discovery for path items

### DIFF
--- a/docs/kluctl/deployments/deployment-yml.md
+++ b/docs/kluctl/deployments/deployment-yml.md
@@ -52,6 +52,18 @@ deployments:
 - path: path/to/manifests
 ```
 
+If the manifests are stored in a nested directory structure (for example, when using the [Rendered Manifests Pattern](https://akuity.io/blog/the-rendered-manifests-pattern)), you can configure Kluctl to recursively walk and discover manifests by setting `recursive: true`.
+
+Note that `recursive: true` is mutually exclusive with having a `kustomization.yaml` or `kustomization.yml` in the root directory of the deployment item. If a root kustomization file is present, setting `recursive: true` will result in a validation error.
+
+Example:
+```yaml
+deployments:
+- path: path/to/manifests
+  recursive: true
+```
+
+
 ### Kustomize deployments
 
 When the deployment item directory specified via `path` contains a `kustomization.yaml`, Kluctl will use this file

--- a/e2e/deployment_items_test.go
+++ b/e2e/deployment_items_test.go
@@ -84,6 +84,124 @@ func TestGeneratedKustomize(t *testing.T) {
 	assertConfigMapNotExists(t, k, p.TestSlug(), "cm3")
 }
 
+func TestGeneratedKustomizeRecursive(t *testing.T) {
+	t.Parallel()
+
+	k := defaultCluster1
+
+	p := test_project.NewTestProject(t)
+
+	createNamespace(t, k, p.TestSlug())
+
+	p.UpdateTarget("test", nil)
+
+	p.UpdateDeploymentYaml("", func(o *uo.UnstructuredObject) error {
+		_ = o.SetNestedField([]any{
+			map[string]any{
+				"path":      "generated-kustomize",
+				"recursive": true,
+			},
+		}, "deployments")
+		return nil
+	})
+	p.UpdateYaml("generated-kustomize/sub1/cm1.yaml", func(o *uo.UnstructuredObject) error {
+		*o = *createConfigMapObject(nil, resourceOpts{
+			name:      "cm1",
+			namespace: p.TestSlug(),
+		})
+		return nil
+	}, "")
+	p.UpdateYaml("generated-kustomize/sub2/sub3/cm2.yaml", func(o *uo.UnstructuredObject) error {
+		*o = *createConfigMapObject(nil, resourceOpts{
+			name:      "cm2",
+			namespace: p.TestSlug(),
+		})
+		return nil
+	}, "")
+	p.UpdateYaml("generated-kustomize/sub1/cm3._yaml", func(o *uo.UnstructuredObject) error {
+		*o = *createConfigMapObject(nil, resourceOpts{
+			name:      "cm3",
+			namespace: p.TestSlug(),
+		})
+		return nil
+	}, "")
+
+	p.KluctlMust(t, "deploy", "--yes", "-t", "test")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm1")
+	assertConfigMapExists(t, k, p.TestSlug(), "cm2")
+	assertConfigMapNotExists(t, k, p.TestSlug(), "cm3")
+}
+
+func TestGeneratedKustomizeRecursiveConflict(t *testing.T) {
+	t.Parallel()
+
+	p := test_project.NewTestProject(t)
+
+	p.UpdateTarget("test", nil)
+
+	p.UpdateDeploymentYaml("", func(o *uo.UnstructuredObject) error {
+		_ = o.SetNestedField([]any{
+			map[string]any{
+				"path":      "generated-kustomize",
+				"recursive": true,
+			},
+		}, "deployments")
+		return nil
+	})
+	p.UpdateYaml("generated-kustomize/kustomization.yaml", func(o *uo.UnstructuredObject) error {
+		*o = *uo.FromMap(map[string]any{
+			"resources": []any{"cm1.yaml"},
+		})
+		return nil
+	}, "")
+	p.UpdateYaml("generated-kustomize/cm1.yaml", func(o *uo.UnstructuredObject) error {
+		*o = *createConfigMapObject(nil, resourceOpts{
+			name:      "cm1",
+			namespace: p.TestSlug(),
+		})
+		return nil
+	}, "")
+
+	_, _, err := p.Kluctl(t, "deploy", "--yes", "-t", "test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "recursive: true cannot be used when a kustomization.yaml/yml already exists")
+}
+
+func TestGeneratedKustomizeRecursiveNestedConflict(t *testing.T) {
+	t.Parallel()
+
+	p := test_project.NewTestProject(t)
+
+	p.UpdateTarget("test", nil)
+
+	p.UpdateDeploymentYaml("", func(o *uo.UnstructuredObject) error {
+		_ = o.SetNestedField([]any{
+			map[string]any{
+				"path":      "generated-kustomize",
+				"recursive": true,
+			},
+		}, "deployments")
+		return nil
+	})
+	p.UpdateYaml("generated-kustomize/sub/kustomization.yaml", func(o *uo.UnstructuredObject) error {
+		*o = *uo.FromMap(map[string]any{
+			"resources": []any{"cm1.yaml"},
+		})
+		return nil
+	}, "")
+	p.UpdateYaml("generated-kustomize/sub/cm1.yaml", func(o *uo.UnstructuredObject) error {
+		*o = *createConfigMapObject(nil, resourceOpts{
+			name:      "cm1",
+			namespace: p.TestSlug(),
+		})
+		return nil
+	}, "")
+
+	_, _, err := p.Kluctl(t, "deploy", "--yes", "-t", "test")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "recursive: true cannot be used when a nested kustomization.yaml/yml already exists")
+}
+
 func TestOnlyRender(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/deployment/deployment_item.go
+++ b/pkg/deployment/deployment_item.go
@@ -298,34 +298,71 @@ func (di *DeploymentItem) generateKustomizationYaml(subDir string) (*uo.Unstruct
 		return nil, nil
 	}
 
-	des, err := os.ReadDir(filepath.Join(di.RenderedDir, subDir))
-	if err != nil {
-		return nil, err
+	var files []string
+
+	baseDir := filepath.Join(di.RenderedDir, subDir)
+	if di.Config != nil && di.Config.Recursive {
+		err := filepath.WalkDir(baseDir, func(p string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if p == baseDir {
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			relPath, err := filepath.Rel(baseDir, p)
+			if err != nil {
+				return err
+			}
+			baseName := filepath.Base(p)
+			if baseName == "kustomization.yaml" || baseName == "kustomization.yml" {
+				return fmt.Errorf("recursive: true cannot be used when a nested kustomization.yaml/yml already exists in %s", relPath)
+			}
+			files = append(files, relPath)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		des, err := os.ReadDir(baseDir)
+		if err != nil {
+			return nil, err
+		}
+		for _, de := range des {
+			if de.IsDir() {
+				continue
+			}
+			files = append(files, de.Name())
+		}
 	}
 
-	list := make([]any, 0, len(des))
+	list := make([]any, 0, len(files))
 	m := map[string]bool{}
 
-	for _, de := range des {
-		if de.IsDir() {
-			continue
-		}
-
-		lname := strings.ToLower(de.Name())
+	for _, file := range files {
+		lname := strings.ToLower(file)
 		resourcePath := ""
 
-		if di.isHelmValuesYaml(de.Name()) {
+		baseName := filepath.Base(file)
+		if di.isHelmValuesYaml(baseName) {
 			continue
-		} else if di.isHelmChartYaml(de.Name()) {
-			hr, err := di.newHelmRelease(subDir)
+		} else if di.isHelmChartYaml(baseName) {
+			helmSubDir := filepath.Clean(filepath.Join(subDir, filepath.Dir(file)))
+			if helmSubDir == "." {
+				helmSubDir = ""
+			}
+			hr, err := di.newHelmRelease(helmSubDir)
 			if err != nil {
 				return nil, err
 			}
-			if !utils.IsFile(filepath.Join(di.RenderedDir, subDir, hr.GetOutputPath())) {
-				resourcePath = hr.GetOutputPath()
+			if !utils.IsFile(filepath.Join(di.RenderedDir, helmSubDir, hr.GetOutputPath())) {
+				resourcePath = filepath.Join(filepath.Dir(file), hr.GetOutputPath())
 			}
 		} else if strings.HasSuffix(lname, ".yml") || strings.HasSuffix(lname, ".yaml") {
-			resourcePath = de.Name()
+			resourcePath = file
 		}
 
 		if resourcePath != "" {
@@ -353,6 +390,11 @@ func (di *DeploymentItem) prepareKustomizationYaml() (*uo.UnstructuredObject, er
 	ky, err := di.readKustomizationYaml("")
 	if err != nil {
 		return nil, err
+	}
+	if ky != nil {
+		if di.Config != nil && di.Config.Recursive {
+			return nil, fmt.Errorf("recursive: true cannot be used when a kustomization.yaml/yml already exists in %s", di.RelToSourceItemDir)
+		}
 	}
 	if ky == nil {
 		ky, err = di.generateKustomizationYaml("")

--- a/pkg/types/deployment.go
+++ b/pkg/types/deployment.go
@@ -14,9 +14,10 @@ type DeploymentItemConfig struct {
 	Oci           *OciProject              `json:"oci,omitempty"`
 	DeleteObjects []DeleteObjectItemConfig `json:"deleteObjects,omitempty"`
 
-	Tags    []string `json:"tags,omitempty"`
-	Barrier bool     `json:"barrier,omitempty"`
-	Message *string  `json:"message,omitempty"`
+	Tags      []string `json:"tags,omitempty"`
+	Barrier   bool     `json:"barrier,omitempty"`
+	Message   *string  `json:"message,omitempty"`
+	Recursive bool     `json:"recursive,omitempty"`
 
 	WaitReadiness        bool                            `json:"waitReadiness,omitempty"`
 	WaitReadinessObjects []WaitReadinessObjectItemConfig `json:"waitReadinessObjects,omitempty"`
@@ -57,6 +58,9 @@ func ValidateDeploymentItemConfig(sl validator.StructLevel) {
 	}
 	if cnt > 1 {
 		sl.ReportError(s, "self", "self", "only one of path, include, git and oci can be set at the same time", "")
+	}
+	if s.Recursive && s.Path == nil {
+		sl.ReportError(s, "recursive", "recursive", "recursive can only be set when path is set", "")
 	}
 	if s.Path == nil && s.WaitReadiness {
 		sl.ReportError(s, "waitReadiness", "WaitReadiness", "only kustomize deployments are allowed to have waitReadiness set", "")

--- a/pkg/webui/ui/src/models.ts
+++ b/pkg/webui/ui/src/models.ts
@@ -265,6 +265,7 @@ export class DeploymentItemConfig {
     tags?: string[];
     barrier?: boolean;
     message?: string;
+    recursive?: boolean;
     waitReadiness?: boolean;
     waitReadinessObjects?: WaitReadinessObjectItemConfig[];
     args?: any;
@@ -288,6 +289,7 @@ export class DeploymentItemConfig {
         this.tags = source["tags"];
         this.barrier = source["barrier"];
         this.message = source["message"];
+        this.recursive = source["recursive"];
         this.waitReadiness = source["waitReadiness"];
         this.waitReadinessObjects = this.convertValues(source["waitReadinessObjects"], WaitReadinessObjectItemConfig);
         this.args = source["args"];


### PR DESCRIPTION
Implements recursive resource discovery for path items with opt-in 'recursive: true'. Walks subdirectories, ignoring subdirectory contents if they have their own kustomization.yaml. Details in docs/kluctl/deployments/deployment-yml.md. Closes #1488.