### PR TITLE
Fix PrettyTable output of (most) characters where bytes != columns

### DIFF
--- a/pkg/utils/prettytable.go
+++ b/pkg/utils/prettytable.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kluctl/kluctl/lib/term"
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 type Row []string
@@ -30,8 +31,8 @@ func (t *PrettyTable) Render(limitWidths []int) string {
 		w := 0
 		for _, l := range t.rows {
 			for _, cl := range strings.Split(l[col], "\n") {
-				if len(cl) > w {
-					w = len(cl)
+				if utf8.RuneCountInString(cl) > w {
+					w = utf8.RuneCountInString(cl)
 				}
 			}
 		}
@@ -43,13 +44,13 @@ func (t *PrettyTable) Render(limitWidths []int) string {
 		return w
 	}
 	subStr := func(str string, s int, e int) string {
-		if s > len(str) {
-			s = len(str)
+		if s > utf8.RuneCountInString(str) {
+			s = utf8.RuneCountInString(str)
 		}
-		if e > len(str) {
-			e = len(str)
+		if e > utf8.RuneCountInString(str) {
+			e = utf8.RuneCountInString(str)
 		}
-		return str[s:e]
+		return string(([]rune(str))[s:e])
 	}
 
 	widths := make([]int, cols)
@@ -95,7 +96,7 @@ func (t *PrettyTable) Render(limitWidths []int) string {
 		for {
 			anyLess := false
 			for i := 0; i < cols; i++ {
-				if pos[i] < len(l[i]) {
+				if pos[i] < utf8.RuneCountInString(l[i]) {
 					anyLess = true
 				}
 			}
@@ -111,9 +112,9 @@ func (t *PrettyTable) Render(limitWidths []int) string {
 					x = x[:newLine]
 					pos[i] += 1
 				}
-				pos[i] += len(x)
+				pos[i] += utf8.RuneCountInString(x)
 				buf.WriteString(x)
-				buf.WriteString(strings.Repeat(" ", widths[i]-len(x)))
+				buf.WriteString(strings.Repeat(" ", widths[i]-utf8.RuneCountInString(x)))
 				if i != cols-1 {
 					buf.WriteString(" | ")
 				}

--- a/pkg/utils/prettytable.go
+++ b/pkg/utils/prettytable.go
@@ -15,7 +15,12 @@ type PrettyTable struct {
 }
 
 func (t *PrettyTable) AddRow(c ...string) {
-	t.rows = append(t.rows, c)
+	// expand tabs to 4 spaces, otherwise formatting breaks
+	formatted := make([]string, len(c))
+	for i, str := range c {
+		formatted[i] = strings.ReplaceAll(str, "\t", strings.Repeat(" ", 4))
+	}
+	t.rows = append(t.rows, formatted)
 }
 
 func (t *PrettyTable) SortRows(col int) {


### PR DESCRIPTION
# Description

- Make `prettytable.go` aware of multi-byte characters and print/format them correctly.
- Make `prettytable.go` forcibly expand tab characters to 4 spaces so that formatting works correctly. I chose 4 arbitrarily, but it's rather involved to get the terminal's tab width at runtime so a number needs to be chosen.

It would be nice to handle control characters properly in general, but to my knowledge there is no easy way to do that without specifying a bunch of cases. I believe tab is the only example of this issue that is likely to be relevant here.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Example

```go
var t utils.PrettyTable
t.AddRow("normal", "Hello, world!")
t.AddRow("too long", "\tD")
t.AddRow("too short", "€€€€€€€€€€")
fmt.Print(t.Render([]int{9, 13}))
```

Before: (exact alignment of "too long" row will depend on terminal)
```
+-----------+---------------+
| regular   | Hello, world! |
+-----------+---------------+
| too long  |       D            |
+-----------+---------------+
| too short | €€€€� |
|           | �€€€� |
|           | �€          |
+-----------+---------------+
```

After:
```
+-----------+---------------+
| regular   | Hello, world! |
+-----------+---------------+
| too long  |     D         |
+-----------+---------------+
| too short | €€€€€€€€€€    |
+-----------+---------------+
```

<!---
All Submissions:

* [ ] A corresponding issue exists
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->